### PR TITLE
[ShaderGraph] Bump Searcher Version

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Error messages reported on Sub Graph output nodes for invalid previews now present clearer information, with documentation support.
 - Updated legacy COLOR output semantic to SV_Target in pixel shader for compatibility with DXC
 - Changed the `Reference Suffix` of Keyword Enum entries so that you cannot edit them, which ensures that material keywords compile properly. 
+- Updated the dependent version of `Searcher` to 4.1.0. 
 
 ### Fixed
 - Edges no longer produce errors when you save a Shader Graph.

--- a/com.unity.shadergraph/package.json
+++ b/com.unity.shadergraph/package.json
@@ -7,7 +7,7 @@
   "displayName": "Shader Graph",
   "dependencies": {
     "com.unity.render-pipelines.core": "9.0.0-preview.20",
-    "com.unity.searcher": "4.0.9"
+    "com.unity.searcher": "4.1.0"
   },
   "samples": [
     {


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Bumps the dependent version of the searcher package to 4.1 to enable bug fixes for Shader Graph. 

---
### Testing status

**Manual Tests**: What did you do?
Launched all projects to make sure everything compiles. 
Opened the shader graph window and confirmed that the search order for entries (leaf first) is fixed. 
Text entry is no longer offset from predictive text. 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/902-Graphics

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
