### PR TITLE
regenerate contextual entries 

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where `Keywords` on the Blackboard would not duplicate with the same `Default` value.
 - Shader Graph now requests preview shader compilation asynchronously. [1209047](https://issuetracker.unity3d.com/issues/shader-graph-unresponsive-editor-when-using-large-graphs)
 - Fixed an issue where Shader Graph would not compile master previews after an assembly reload.
+- Fixed a bug where searcher entries would not repopulate correctly after an undo was perfromed (https://fogbugz.unity3d.com/f/cases/1241018/)
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Drawing/EdgeConnectorListener.cs
+++ b/com.unity.shadergraph/Editor/Drawing/EdgeConnectorListener.cs
@@ -22,9 +22,11 @@ namespace UnityEditor.ShaderGraph.Drawing
         {
             var draggedPort = (edge.output != null ? edge.output.edgeConnector.edgeDragHelper.draggedPort : null) ?? (edge.input != null ? edge.input.edgeConnector.edgeDragHelper.draggedPort : null);
             m_SearchWindowProvider.connectedPort = (ShaderPort)draggedPort;
+            m_SearchWindowProvider.regenerateEntries = true;//need to be sure the entires are relevant to the edge we are dragging
             SearcherWindow.Show(m_editorWindow, (m_SearchWindowProvider as SearcherProvider).LoadSearchWindow(), 
                 item => (m_SearchWindowProvider as SearcherProvider).OnSearcherSelectEntry(item, position),
                 position, null);
+            m_SearchWindowProvider.regenerateEntries = true;//entries no longer necessarily relevant, need to regenerate
         }
 
         public void OnDrop(GraphView graphView, Edge edge)


### PR DESCRIPTION

### **Please read**
**PR workflow guidelines**
* SRP ABV will start automatically on Yamato when you open your PR
* Changes to docs and md files will **not** trigger ABV jobs 
* Consider making use of **draft PRs** if you are not 100% sure that your PR is ready for review
* ABV will restart if you add a new commit to a branch with an open PR (hence why you should consider using draft PRs)
* Adding [skip ci] (case insensitive) to the title of PRs will stop any jobs being trigger automatically - you will need to open Yamato and find your branch to run ABV
* You can also add [skip ci] to commit messages to prevent CI from running on that push
* Add [cancel old ci] to your commit message if you've made changes you want to test and no longer need the previous jobs

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
bugfix for https://fogbugz.unity3d.com/f/cases/1241018/
---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/902-Graphics

---
### Comments to reviewers
Notes for the reviewers you have assigned.
