### PR TITLE
bump min version of SRP package to 2020.1b8

### DIFF
--- a/com.unity.render-pipelines.core/package.json
+++ b/com.unity.render-pipelines.core/package.json
@@ -3,7 +3,7 @@
   "description": "SRP Core makes it easier to create or customize a Scriptable Render Pipeline (SRP). SRP Core contains reusable code, including boilerplate code for working with platform-specific graphics APIs, utility functions for common rendering operations, and  shader libraries. The code in SRP Core is use by the High Definition Render Pipeline (HDRP) and Universal Render Pipeline (URP). If you are creating a custom SRP from scratch or customizing a prebuilt SRP, using SRP Core will save you time.",
   "version": "9.0.0-preview.27",
   "unity": "2020.1",
-  "unityRelease": "0b6",
+  "unityRelease": "0b8",
   "displayName": "Core RP Library",
   "dependencies": {
     "com.unity.ugui": "1.0.0"

--- a/com.unity.render-pipelines.high-definition-config/package.json
+++ b/com.unity.render-pipelines.high-definition-config/package.json
@@ -3,7 +3,7 @@
   "description": "Configuration files for the High Definition Render Pipeline.",
   "version": "9.0.0-preview.29",
   "unity": "2020.1",
-  "unityRelease": "0b6",
+  "unityRelease": "0b8",
   "displayName": "High Definition RP Config",
   "dependencies": {
     "com.unity.render-pipelines.core": "9.0.0-preview.27"

--- a/com.unity.render-pipelines.high-definition/package.json
+++ b/com.unity.render-pipelines.high-definition/package.json
@@ -3,7 +3,7 @@
   "description": "The High Definition Render Pipeline (HDRP) is a high-fidelity Scriptable Render Pipeline built by Unity to target modern (Compute Shader compatible) platforms. HDRP utilizes Physically-Based Lighting techniques, linear lighting, HDR lighting, and a configurable hybrid Tile/Cluster deferred/Forward lighting architecture and gives you the tools you need to create games, technical demos, animations, and more to a high graphical standard.",
   "version": "9.0.0-preview.27",
   "unity": "2020.1",
-  "unityRelease": "0b6",
+  "unityRelease": "0b8",
   "displayName": "High Definition RP",
   "dependencies": {
     "com.unity.render-pipelines.core": "9.0.0-preview.27",

--- a/com.unity.render-pipelines.lightweight/package.json
+++ b/com.unity.render-pipelines.lightweight/package.json
@@ -3,7 +3,7 @@
   "description": "The Lightweight Render Pipeline (LWRP) is a prebuilt Scriptable Render Pipeline, made by Unity. The technology offers graphics that are scalable to mobile platforms, and you can also use it for higher-end consoles and PCs. You’re able to achieve quick rendering at a high quality without needing compute shader technology. LWRP uses simplified, physically based Lighting and Materials. The LWRP uses single-pass forward rendering. Use this pipeline to get optimized real-time performance on several platforms.",
   "version": "9.0.0-preview.28",
   "unity": "2020.1",
-  "unityRelease": "0b6",
+  "unityRelease": "0b8",
   "displayName": "Lightweight RP",
   "dependencies": {
     "com.unity.render-pipelines.universal": "9.0.0-preview.28",

--- a/com.unity.render-pipelines.universal/package.json
+++ b/com.unity.render-pipelines.universal/package.json
@@ -3,7 +3,7 @@
   "description": "The Universal Render Pipeline (URP) is a prebuilt Scriptable Render Pipeline, made by Unity. URP provides artist-friendly workflows that let you quickly and easily create optimized graphics across a range of platforms, from mobile to high-end consoles and PCs.",
   "version": "9.0.0-preview.28",
   "unity": "2020.1",
-  "unityRelease": "0b6",
+  "unityRelease": "0b8",
   "displayName": "Universal RP",
   "dependencies": {
     "com.unity.render-pipelines.core": "9.0.0-preview.27",

--- a/com.unity.shadergraph/package.json
+++ b/com.unity.shadergraph/package.json
@@ -3,7 +3,7 @@
   "description": "The Shader Graph package adds a visual Shader editing tool to Unity. You can use this tool to create Shaders in a visual way instead of writing code. Specific render pipelines can implement specific graph features. Currently, both the High Definition Rendering Pipeline and the Universal Rendering Pipeline support Shader Graph.",
   "version": "9.0.0-preview.28",
   "unity": "2020.1",
-  "unityRelease": "0b6",
+  "unityRelease": "0b8",
   "displayName": "Shader Graph",
   "dependencies": {
     "com.unity.render-pipelines.core": "9.0.0-preview.27",

--- a/com.unity.visualeffectgraph/package.json
+++ b/com.unity.visualeffectgraph/package.json
@@ -3,7 +3,7 @@
   "displayName": "Visual Effect Graph",
   "version": "9.0.0-preview.27",
   "unity": "2020.1",
-  "unityRelease": "0b6",
+  "unityRelease": "0b8",
   "description": "The Visual Effect Graph is a node based visual effect editor. It allows you to author next generation visual effects that Unity simulates directly on the GPU.",
   "keywords": [
     "vfx",


### PR DESCRIPTION
 # Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
bump min version of SRP package to 2020.1b8
This is required by this PR: https://github.com/Unity-Technologies/Graphics/pull/122

to avoid this error:
D:\code\Graphics\com.unity.render-pipelines.high-definition\Runtime\RenderPipeline\HDRenderPipeline.cs(713,19): error CS0117: 'SupportedRenderingFeatures' does not contain a definition for 'overridesShadowmask'

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/902-Graphics

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
