### PR TITLE
Changed ShaderGraphImporter import order [skip ci]

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated the dependent version of `Searcher` to 4.2.0. 
 - Added support for `Linear Blend Skinning` Node to Universal Render Pipeline.
 - Moved all code to be under Unity specific namespaces.
+- Changed ShaderGraphImporter and ShaderSubgraphImporter so that graphs are imported before Models.
 
 ### Fixed
 - Edges no longer produce errors when you save a Shader Graph.

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -24,9 +24,9 @@ namespace UnityEditor.ShaderGraph
     // sure that all shader graphs get re-imported. Re-importing is required,
     // because the shader graph codegen is different for V2.
     // This ifdef can be removed once V2 is the only option.
-    [ScriptedImporter(102, Extension, 3)]
+    [ScriptedImporter(102, Extension, -902)]
 #else
-    [ScriptedImporter(34, Extension, 3)]
+    [ScriptedImporter(34, Extension, -902)]
 #endif
 
     class ShaderGraphImporter : ScriptedImporter

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
@@ -18,7 +18,7 @@ using UnityEditor.ShaderGraph.Serialization;
 namespace UnityEditor.ShaderGraph
 {
     [ExcludeFromPreset]
-    [ScriptedImporter(14, Extension)]
+    [ScriptedImporter(14, Extension, -905)]
     class ShaderSubGraphImporter : ScriptedImporter
     {
         public const string Extension = "shadersubgraph";


### PR DESCRIPTION
…before models.

### **Please read**
**PR workflow guidelines**
* SRP ABV will start automatically on Yamato when you open your PR
* Changes to docs and md files will **not** trigger ABV jobs 
* Consider making use of **draft PRs** if you are not 100% sure that your PR is ready for review
* ABV will restart if you add a new commit to a branch with an open PR (hence why you should consider using draft PRs)
* Adding [skip ci] (case insensitive) to the title of PRs will stop any jobs being trigger automatically - you will need to open Yamato and find your branch to run ABV
* You can also add [skip ci] to commit messages to prevent CI from running on that push
* Add [cancel old ci] to your commit message if you've made changes you want to test and no longer need the previous jobs

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR:

ScriptedImporters currently run at a base priority that is lower than models ( see kImportOrderLate of AssetImportOrder.h in Unity). This causes an issue with importers assigning shaders that are shadergraphs to materials when the import happens when Unity's starting, like after deleting the Library folder. The affected materials end up using the Legacy Standard shader instead. 

This changes the import orders so that ShaderGraphs are now imported just before models. 
As far as I can see, the only requirement is that graphs are imported after scripts and I did not notice any side effect but still, it's a risky change and should be thouroughly tested.

---
### Testing status

**Manual Tests**: 
Tested in sandbox, specifically with Graphs that reference cubemaps and textures. 
Tested with the Boat Attack project, no issue found.


- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/902-Graphics

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
