### PR TITLE
[8.x.x][Shader Graph]Fixes for 3 cases of undo not working

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed 
+- Fixed undo not being recorded properly for setting active master node, graph precision, and node defaults.
 
 ## [8.1.0] - 2020-04-21
 

--- a/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
@@ -1059,6 +1059,9 @@ namespace UnityEditor.ShaderGraph
             if (other == null)
                 throw new ArgumentException("Can only replace with another AbstractMaterialGraph", "other");
 
+            concretePrecision = other.concretePrecision;
+            m_ActiveOutputNodeGuid = other.m_ActiveOutputNodeGuid;
+
             using (var removedInputsPooledObject = ListPool<Guid>.GetDisposable())
             {
                 var removedInputGuids = removedInputsPooledObject.value;

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -164,10 +164,12 @@ namespace UnityEditor.ShaderGraph.Drawing
 
                     EditorGUI.BeginChangeCheck();
                     GUILayout.Label("Precision");
-                    graph.concretePrecision = (ConcretePrecision)EditorGUILayout.EnumPopup(graph.concretePrecision, GUILayout.Width(100f));
-                    GUILayout.Space(4);
+                    var precision = (ConcretePrecision)EditorGUILayout.EnumPopup(graph.concretePrecision, GUILayout.Width(100f));
                     if (EditorGUI.EndChangeCheck())
                     {
+                        m_Graph.owner.RegisterCompleteObjectUndo("Changed Graph Precision");
+                        graph.concretePrecision = precision;
+
                         var nodeList = m_GraphView.Query<MaterialNodeView>().ToList();
                         m_ColorManager.SetNodesDirty(nodeList);
                         graph.ValidateGraph();

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -335,6 +335,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void SetMasterAsActive(DropdownMenuAction action)
         {
+            node.owner.owner.RegisterCompleteObjectUndo("Change Active Master");
             node.owner.activeOutputNodeGuid = node.guid;
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/Slots/MultiFloatSlotControlView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/Slots/MultiFloatSlotControlView.cs
@@ -70,11 +70,12 @@ namespace UnityEditor.ShaderGraph.Drawing.Slots
                         m_Node.Dirty(ModificationScope.Node);
                     }
                 });
-            // Reset UndoGroup when done editing input field
+            // Reset UndoGroup when done editing input field & update title
             field.Q("unity-text-input").RegisterCallback<FocusOutEvent>(evt =>
-                {
-                    m_UndoGroup = -1;
-                });
+            {
+                m_Node.owner.owner.isDirty = true;
+                m_UndoGroup = -1;
+            });
             Add(field);
         }
     }


### PR DESCRIPTION
*Summary:*
Backport #259 
Fixes bugs related to lack of registering undos: 1 prio 3 bug and 3 other Undo related bugs (first two are basically the same bug):
- https://fogbugz.unity3d.com/f/cases/1184932/
- https://fogbugz.unity3d.com/f/cases/1215447/
- https://fogbugz.unity3d.com/f/cases/1215448/
- https://fogbugz.unity3d.com/f/cases/1213629/

[Internal link to previous PR](https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/6357)

*Manually Tested:*
Manual Tests were repeated for backport branch 
That none of the bug reproduces anymore
For the default-value-sub-node, all sorts of changes to confirm that the title asterisk only appears when necessary, such as something that results in the field returning to it was before type (0, safeaef => 0)

Technical Risk: 1/4
Halo Effect: 1/4