### PR TITLE
Fix Shader Graph SRP Batcher issues

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
@@ -76,10 +76,9 @@ namespace UnityEditor.ShaderGraph.Internal
         // the more complex interface for complex properties (defaulted for simple properties)
         internal virtual void AppendPropertyBlockStrings(ShaderStringBuilder builder)
         {
-            var propertyBlockString = GetPropertyBlockString();
-            if (propertyBlockString != string.Empty)
+            if (isExposable)
             {
-                builder.AppendLine(propertyBlockString);
+                builder.AppendLine(GetPropertyBlockString());
             }
         }
 

--- a/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
@@ -54,7 +54,7 @@ namespace UnityEditor.ShaderGraph.Internal
             set => m_Hidden = value;
         }
 
-        internal string hideTagString => hidden ? "[HideInInspector]" : "";
+        internal string hideTagString => !generatePropertyBlock || hidden ? "[HideInInspector]" : "";
 
         // simple properties use a single reference name; this function covers that case
         // complex properties can override this function to produce multiple reference names

--- a/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
@@ -76,7 +76,11 @@ namespace UnityEditor.ShaderGraph.Internal
         // the more complex interface for complex properties (defaulted for simple properties)
         internal virtual void AppendPropertyBlockStrings(ShaderStringBuilder builder)
         {
-            builder.AppendLine(GetPropertyBlockString());
+            var propertyBlockString = GetPropertyBlockString();
+            if (propertyBlockString != string.Empty)
+            {
+                builder.AppendLine(propertyBlockString);
+            }
         }
 
         // the simple interface for simple properties

--- a/com.unity.shadergraph/Editor/Generation/Processors/GenerationUtils.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/GenerationUtils.cs
@@ -615,7 +615,7 @@ namespace UnityEditor.ShaderGraph
             sb.AppendLine("Properties");
             using (sb.BlockScope())
             {
-                foreach (var prop in propertyCollector.properties.Where(x => x.generatePropertyBlock))
+                foreach (var prop in propertyCollector.properties)
                 {
                     prop.AppendPropertyBlockStrings(sb);
                 }


### PR DESCRIPTION
# Purpose of this PR

This PR fixes [1224388](https://issuetracker.unity3d.com/product/unity/issues/guid/1224388/). Other than the issues it was causing for SRP Batcher compatibility, it also caused Shader Graphs to not work when using the Hybrid Renderer.

# Testing status
## Manual Tests
- Reproduce bug locally
- Verify fix locally using all property types as exposed and unexposed

## Automated Tests
Nothing. I don't think there's any API points we could use for automated testing of this.
