### PR TITLE
Fix NaN cause when a 0-length normal is generated and then normalized. 

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -585,6 +585,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix error when removing DecalProjector from component contextual menu (case 1243960)
 - Fixed issue with post process when running in RGBA16 and an object with additive blending is in the scene.
 - Fixed corrupted values on LayeredLit when using Vertex Color multiply mode to multiply and MSAA is activated. 
+- Fixed a cause of NaN when a normal of 0-length is generated (usually via shadergraph). 
 
 ### Changed
 - Improve MIP selection for decals on Transparents

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl
@@ -32,8 +32,8 @@ void GetNormalWS(FragInputs input, float3 normalTS, out float3 normalWS, float3 
     normalTS.xy *= flipSign;
 #endif // _DOUBLESIDED_ON
 
-    // We need to normalize as we use mikkt tangent space and this is expected (tangent space is not normalize)
-    normalWS = normalize(TransformTangentToWorld(normalTS, input.tangentToWorld));
+    // We need to normalize as we use mikkt tangent space and this is expected (tangent space is not normalized)
+    normalWS = SafeNormalize(TransformTangentToWorld(normalTS, input.tangentToWorld));
 
 #endif // SURFACE_GRADIENT
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalBlendNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalBlendNode.cs
@@ -58,7 +58,7 @@ namespace UnityEditor.ShaderGraph
 
             return @"
 {
-    Out = normalize($precision3(A.rg + B.rg, A.b * B.b));
+    Out = SafeNormalize($precision3(A.rg + B.rg, A.b * B.b));
 }
 ";
         }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromHeightNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromHeightNode.cs
@@ -99,7 +99,7 @@ namespace UnityEditor.ShaderGraph
                         s.AppendLine("$precision dHdx = ddx(In);");
                         s.AppendLine("$precision dHdy = ddy(In);");
                         s.AppendLine("$precision3 surfGrad = surface * (dHdx*crossY + dHdy*crossX);");
-                        s.AppendLine("Out = normalize(TangentMatrix[2].xyz - (Strength * surfGrad));");
+                        s.AppendLine("Out = SafeNormalize(TangentMatrix[2].xyz - (Strength * surfGrad));");
 
                         if(outputSpace == OutputSpace.Tangent)
                             s.AppendLine("Out = TransformWorldToTangent(Out, TangentMatrix);");


### PR DESCRIPTION
The bug that it fixes is this: https://fogbugz.unity3d.com/f/cases/1243282/ 

The problem derives when shadergraph can generate a 0-length normal (for several manipulation that are possible, this is not impossible). This leads to a normalization that causes a div by 0, hence NaN ensue in lighting calculations. 


I will backport when approved as I think there is a conflict that doesn't allow a simple cherry pick. 

For QA: 
Note that to repro you need to add a camera additional data to the camera and move around a bit when in play mode. Before this fix a small flash will happen. 
Ping me and I can point to you where is a good spot to see the issue. 