### PR TITLE
Fix issue causing asset dependencies to be ignored

### DIFF
--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -22,7 +22,7 @@ namespace UnityEditor.ShaderGraph
     // This ifdef can be removed once V2 is the only option.
     [ScriptedImporter(101, Extension, 3)]
 #else
-    [ScriptedImporter(33, Extension, 3)]
+    [ScriptedImporter(34, Extension, 3)]
 #endif
 
     class ShaderGraphImporter : ScriptedImporter
@@ -173,7 +173,7 @@ Shader ""Hidden/GraphErrorShader2""
                 var generator = new Generator(graph, graph.outputNode, GenerationMode.ForReals, shaderName);
                 shaderString = generator.generatedShader;
                 configuredTextures = generator.configuredTextures;
-                sourceAssetDependencyPaths = generator.assetDependencyPaths;
+                sourceAssetDependencyPaths.AddRange(generator.assetDependencyPaths);
 
                 if (graph.messageManager.AnyError())
                 {

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -20,7 +20,7 @@ namespace UnityEditor.ShaderGraph
     // sure that all shader graphs get re-imported. Re-importing is required,
     // because the shader graph codegen is different for V2.
     // This ifdef can be removed once V2 is the only option.
-    [ScriptedImporter(101, Extension, 3)]
+    [ScriptedImporter(102, Extension, 3)]
 #else
     [ScriptedImporter(34, Extension, 3)]
 #endif


### PR DESCRIPTION
# Purpose of this PR

Import dependencies from the `Generator` class were being ignored due to re-assignment of list without `out`. I changed it to `AddRange` on the input list. Also bumped the importer version so that all Shader Graphs get re-imported and then have the dependencies setup correctly.

The issue was introduced in this PR: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/4940

# Testing status
## Manual Tests
- Reproduced issue locally
- Verified fix locally

To reproduce the issue, you can make any change to `com.unity.render-pipelines.universal/Editor/ShaderGraph/Targets/UniversalTarget.cs` and notice that without the fix it does not cause a re-import of Shader Graphs, even though it registers itself as a source dependency.

You can also modify put a `Debug.Log` in here to see what ends up getting declared, and notice that without the fix it does not declare anything.
https://github.com/Unity-Technologies/Graphics/blob/master/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs#L168