### PR TITLE
[Shader Graph] Remove Dangling Namespaces 

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Data.Util;
 using UnityEditor.Graphing;
 using UnityEngine;              // Vector3,4
 using UnityEditor.ShaderGraph;

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated the functions in the `Normal From Height` node to avoid NaN outputs.
 - Changed the Voronoi Node algorithm to increase the useful range of the input values and to always use float values internally to avoid clipping.
 - Changed the `Reference Suffix` of Keyword Enum entries so that you cannot edit them, which ensures that material keywords compile properly. 
+- Moved all code to be under Unity specific namespaces.
 
 ### Fixed
 - Edges no longer produce errors when you save a Shader Graph.

--- a/com.unity.shadergraph/Editor/Data/Interfaces/IInspectable.cs
+++ b/com.unity.shadergraph/Editor/Data/Interfaces/IInspectable.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using Drawing.Inspector;
 using UnityEngine.UIElements;
 

--- a/com.unity.shadergraph/Editor/Data/Interfaces/IInspectable.cs
+++ b/com.unity.shadergraph/Editor/Data/Interfaces/IInspectable.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Drawing.Inspector;
 using UnityEngine.UIElements;
 
 namespace UnityEditor.ShaderGraph.Drawing

--- a/com.unity.shadergraph/Editor/Data/Interfaces/IPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Data/Interfaces/IPropertyDrawer.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEngine.UIElements;
 
-namespace Data.Interfaces
+namespace UnityEditor.ShaderGraph.Drawing
 {
     // Interface that should be implemented by any property drawer for the inspector view
     public interface IPropertyDrawer

--- a/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
@@ -12,7 +12,6 @@ using UnityEditorInternal;
 using Debug = UnityEngine.Debug;
 using System.Reflection;
 using System.Runtime.Remoting.Metadata.W3cXsd2001;
-using Data.Util;
 using UnityEditor.ProjectWindowCallback;
 using UnityEditor.ShaderGraph.Internal;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Data/Util/KeywordDependentCollection.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/KeywordDependentCollection.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Data.Util
+namespace UnityEditor.ShaderGraph.Internal
 {
     public static class KeywordDependentCollection
     {

--- a/com.unity.shadergraph/Editor/Data/Util/ShaderGraphRequirementsPerKeyword.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/ShaderGraphRequirementsPerKeyword.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor.ShaderGraph;
-using UnityEditor.ShaderGraph.Internal;
 
-namespace Data.Util
+namespace UnityEditor.ShaderGraph.Internal
 {
     sealed class ShaderGraphRequirementsPerKeyword: KeywordDependentCollection<
         ShaderGraphRequirements,

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardFieldView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardFieldView.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEditor.Graphing;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/InspectorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/InspectorView.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
- using Data.Interfaces;
  using UnityEditor.Experimental.GraphView;
  using UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers;
  using UnityEditor.ShaderGraph.Drawing.Views;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/BoolPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/BoolPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.Graphing.Util;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ColorPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ColorPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/CubemapPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/CubemapPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/DropdownPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/DropdownPropertyDrawer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/EnumPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/EnumPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.Graphing.Util;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/FloatPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/FloatPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEngine;
 using UnityEngine.UIElements;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GradientPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GradientPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GraphDataPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GraphDataPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.ShaderGraph.Internal;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/IntegerPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/IntegerPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/MatrixPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/MatrixPropertyDrawer.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Reflection;
 using UnityEditor.ShaderGraph.Drawing;
-using UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace Drawing.Inspector.PropertyDrawers
+namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
 {
     [SGPropertyDrawer(typeof(Matrix4x4))]
     class MatrixPropertyDrawer : IPropertyDrawer

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/MatrixPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/MatrixPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderGUIOverridePropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderGUIOverridePropertyDrawer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using Data.Interfaces;
 using UnityEditor;
 using UnityEditor.Graphing.Util;
 using UnityEditor.Rendering;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderInputPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderInputPropertyDrawer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using Drawing.Inspector.PropertyDrawers;
 using UnityEditor;
 using UnityEditor.Graphing;
 using UnityEditor.Graphing.Util;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderInputPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderInputPropertyDrawer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using Data.Interfaces;
 using Drawing.Inspector.PropertyDrawers;
 using UnityEditor;
 using UnityEditor.Graphing;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/TextPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/TextPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.Graphing.Util;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Texture2DArrayPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Texture2DArrayPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Texture2DPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Texture2DPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Texture3DPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Texture3DPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;
 using UnityEngine;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ToggleDataPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ToggleDataPropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor.Graphing.Util;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.ShaderGraph.Drawing.Controls;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Vector2PropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Vector2PropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Vector3PropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Vector3PropertyDrawer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Vector4PropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/Vector4PropertyDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Data.Interfaces;
 using UnityEditor;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEditor.UIElements;

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Drawing.Inspector;
 using UnityEngine;
 using UnityEditor.Graphing;
 using UnityEditor.Graphing.Util;

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -6,7 +6,6 @@ using UnityEditor.Graphing.Util;
 using UnityEngine;
 using UnityEditor.Graphing;
 using Object = UnityEngine.Object;
-using Data.Interfaces;
 using UnityEditor.Experimental.GraphView;
 using UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers;
 using UnityEditor.ShaderGraph.Internal;

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -7,7 +7,6 @@ using UnityEditor.Graphing;
 using UnityEditor.Graphing.Util;
 using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine.Rendering;
-using Data.Interfaces;
 using UnityEditor.Experimental.GraphView;
 using UnityEditor.Rendering;
 using UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers;

--- a/com.unity.shadergraph/Editor/Drawing/Views/PropertyNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/PropertyNodeView.cs
@@ -9,7 +9,6 @@ using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEditor.ShaderGraph.Internal;
 using UnityEngine;
 using UnityEngine.UIElements;
-using Data.Interfaces;
 using UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers;
 
 namespace UnityEditor.ShaderGraph

--- a/com.unity.shadergraph/Editor/Extensions/IConditionalExtensions.cs
+++ b/com.unity.shadergraph/Editor/Extensions/IConditionalExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using Data.Util;
 using UnityEditor.ShaderGraph.Internal;
 
 namespace UnityEditor.ShaderGraph

--- a/com.unity.shadergraph/Editor/Generation/Processors/ActiveFields.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/ActiveFields.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using UnityEditor.ShaderGraph;
 using UnityEditor.ShaderGraph.Internal;
 
-namespace Data.Util
+namespace UnityEditor.ShaderGraph.Internal
 {
     internal interface IActiveFields: KeywordDependentCollection.IInstance, KeywordDependentCollection.ISet<IActiveFields>
     {

--- a/com.unity.shadergraph/Editor/Generation/Processors/GenerationUtils.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/GenerationUtils.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph.Internal;
-using Data.Util;
 
 namespace UnityEditor.ShaderGraph
 {

--- a/com.unity.shadergraph/Editor/Generation/Processors/Generator.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/Generator.cs
@@ -5,7 +5,6 @@ using System.IO;
 using UnityEngine;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph.Internal;
-using Data.Util;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEngine.Rendering;
 

--- a/com.unity.shadergraph/Editor/Generation/Processors/ShaderSpliceUtil.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/ShaderSpliceUtil.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Data.Util;
 using UnityEditor.ShaderGraph.Internal;
 
 namespace UnityEditor.ShaderGraph

--- a/com.unity.shadergraph/Tests/Editor/IntegrationTests/NamespaceTests.cs
+++ b/com.unity.shadergraph/Tests/Editor/IntegrationTests/NamespaceTests.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEditor.Graphing;
+using UnityEditor.ShaderGraph.Internal;
+
+namespace UnityEditor.ShaderGraph.UnitTests
+{
+    [TestFixture]
+    internal class NamespaceTests
+    {
+
+        [Test]
+        public void NoDanglingNamespaces()
+        {
+            var myAssembly = Assembly.GetAssembly(typeof(AbstractMaterialNode));
+            HashSet<string> namespaces = new HashSet<string>();
+            foreach (var theType in myAssembly.GetTypes().Where(t => !string.IsNullOrEmpty(t.Namespace)))
+            {
+                namespaces.Add(theType.Namespace);
+            }
+            var invalidNames = new List<string>();
+            foreach (var name in namespaces)
+            {
+                if(name.Contains("ShaderGraph"))
+                    continue;
+                if (name.Contains("UnityEditor"))
+                    continue;
+                if(name.Contains("UnityEngine"))
+                    continue;
+
+                invalidNames.Add(name);
+            }
+            Assert.IsEmpty(invalidNames, "The following namespaces are invalid for the Shader Graph package:\n" + string.Join("\n", invalidNames));
+        }
+    }
+}

--- a/com.unity.shadergraph/Tests/Editor/IntegrationTests/NamespaceTests.cs.meta
+++ b/com.unity.shadergraph/Tests/Editor/IntegrationTests/NamespaceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4e7501d4d0d01c4f90cfb2c002de0b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Purpose of this PR

> Why is this PR needed, what hard problem is it solving/fixing?

Moves all code in Shader Graph package to be under Unity specific namespaces, fixing [1241826](https://issuetracker.unity3d.com/product/unity/issues/guid/1241826/) and removing the collision for users. 

# Testing status
## Manual Tests
> What have you tested?

Opened the Shader Graph and HDRP test projects and ran all tests locally, ensuring that all code is compiling correctly. 

## Automated Tests
> What did you setup? (Add a screenshot or the reference image of the test please)

Added a unit test to check that all namespaces in the Shader Graph package contain either `ShaderGraph`, `UnityEditor`, or `UnityEngine`. Will print the failing namespaces if it finds any. 

## Links
**Yamato**: (Select your branch) https://yamato.prd.cds.internal.unity3d.com/jobs/902-Graphics
> Any test projects or documents to go with this to help reviewers?

# Comments to reviewers
> Notes for the reviewers you have assigned.
Doesn't need thorough testing. Automated tests should catch anything beyond my local testing.