### PR TITLE
Fix ShaderGraph compilation due to changed VT trunk API

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
+++ b/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
@@ -354,11 +354,11 @@ namespace UnityEditor.ShaderGraph.Drawing
                             {
                                 // Ensure we always request the mip sized 256x256
                                 int width, height;
-                                UnityEngine.Rendering.VirtualTexturing.System.GetTextureStackSize(mat, stackPropertyId, out width, out height);
+                                UnityEngine.Rendering.VirtualTexturing.Streaming.GetTextureStackSize(mat, stackPropertyId, out width, out height);
                                 int textureMip = (int)Math.Max(Mathf.Log(width, 2f), Mathf.Log(height, 2f));
                                 const int baseMip = 8;
                                 int mip = Math.Max(textureMip - baseMip, 0);
-                                UnityEngine.Rendering.VirtualTexturing.System.RequestRegion(mat, stackPropertyId, new Rect(0.0f, 0.0f, 1.0f, 1.0f), mip, UnityEngine.Rendering.VirtualTexturing.System.AllMips);
+                                UnityEngine.Rendering.VirtualTexturing.Streaming.RequestRegion(mat, stackPropertyId, new Rect(0.0f, 0.0f, 1.0f, 1.0f), mip, UnityEngine.Rendering.VirtualTexturing.System.AllMips);
                             }
                             catch (InvalidOperationException)
                             {


### PR DESCRIPTION
# Purpose of this PR

> There is a PR coming to trunk soon that will change some of the Virtual Texturing API.
This 2 line PR will fix ShaderGraph compilation to use the new API.

# Testing
> I've manually verified that with this fix and my upcoming changes to trunk, Shadergraph compiles again.