### PR TITLE
[Backport 8.x.x] Fix NaN cause when a 0-length normal is generated and then normalized

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Version Updated
 The version number for this package has increased due to a version update of a related graphics package.
 
+### Fixed
+- Fixed a cause of NaN when a normal of 0-length is generated (usually via shadergraph).
+
 ## [8.1.0] - 2020-04-21
 
 ### Added

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl
@@ -32,8 +32,8 @@ void GetNormalWS(FragInputs input, float3 normalTS, out float3 normalWS, float3 
     normalTS.xy *= flipSign;
 #endif // _DOUBLESIDED_ON
 
-    // We need to normalize as we use mikkt tangent space and this is expected (tangent space is not normalize)
-    normalWS = normalize(TransformTangentToWorld(normalTS, input.tangentToWorld));
+    // We need to normalize as we use mikkt tangent space and this is expected (tangent space is not normalized)
+    normalWS = SafeNormalize(TransformTangentToWorld(normalTS, input.tangentToWorld));
 
 #endif // SURFACE_GRADIENT
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalBlendNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalBlendNode.cs
@@ -58,7 +58,7 @@ namespace UnityEditor.ShaderGraph
 
             return @"
 {
-    Out = normalize($precision3(A.rg + B.rg, A.b * B.b));
+    Out = SafeNormalize($precision3(A.rg + B.rg, A.b * B.b));
 }
 ";
         }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromHeightNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromHeightNode.cs
@@ -91,7 +91,7 @@ namespace UnityEditor.ShaderGraph
                         s.AppendLine("$precision3 inToNormal = ((((In + ddx(In)) - In) * crossY) + (((In + ddy(In)) - In) * crossX)) * sign(d);");
                         s.AppendLine("inToNormal.y *= -1.0;");
                         s.AppendNewLine();
-                        s.AppendLine("Out = normalize((d * TangentMatrix[2].xyz) - inToNormal);");
+                        s.AppendLine("Out = SafeNormalize((d * TangentMatrix[2].xyz) - inToNormal);");
 
                         if(outputSpace == OutputSpace.Tangent)
                             s.AppendLine("Out = TransformWorldToTangent(Out, TangentMatrix);");


### PR DESCRIPTION
Backport of #437

