### PR TITLE
Made property row labels flexible

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GraphDataPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GraphDataPropertyDrawer.cs
@@ -96,6 +96,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
                 // Create foldout
                 var foldout = new Foldout() { text = targetName, value = foldoutActive, name = "foldout" };
                 element.Add(foldout);
+                foldout.AddToClassList("MainFoldout");
                 foldout.RegisterValueChangedCallback(evt =>
                 {
                     // Update foldout value and rebuild

--- a/com.unity.shadergraph/Editor/Generation/Contexts/TargetPropertyGUIContext.cs
+++ b/com.unity.shadergraph/Editor/Generation/Contexts/TargetPropertyGUIContext.cs
@@ -61,9 +61,9 @@ namespace UnityEditor.ShaderGraph
             this.hierarchy.Add(propertyRow);
         }
 
-        void ApplyPadding(VisualElement element, int indentLevel)
+        void ApplyPadding(PropertyRow row, int indentLevel)
         {
-            element.style.paddingLeft = (globalIndentLevel + indentLevel) * kIndentWidthInPixel;
+            row.Q(className: "unity-label").style.marginLeft = (globalIndentLevel + indentLevel) * kIndentWidthInPixel;
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Generation/Contexts/TargetPropertyGUIContext.cs
+++ b/com.unity.shadergraph/Editor/Generation/Contexts/TargetPropertyGUIContext.cs
@@ -10,6 +10,8 @@ namespace UnityEditor.ShaderGraph
     [GenerationAPI]
     internal class TargetPropertyGUIContext : VisualElement
     {
+        const int kIndentWidthInPixel = 20;
+
         public TargetPropertyGUIContext()
         {
             
@@ -43,29 +45,23 @@ namespace UnityEditor.ShaderGraph
                 notifyValueChanged.RegisterValueChangedCallback(evt);
             }
 
-            string labelText = "";
-            for (var i = 0; i < indentLevel; i++)
-            {
-                labelText += "    ";
-            }
-            labelText += label;
 
-            var propertyRow = new PropertyRow(new Label(labelText));
+            var propertyRow = new PropertyRow(new Label(label));
+            ApplyPadding(propertyRow, indentLevel);
             propertyRow.Add(field);
             this.hierarchy.Add(propertyRow);
         }
 
         public void AddLabel(string label, int indentLevel)
         {
-            string labelText = "";
-            for (var i = 0; i < indentLevel; i++)
-            {
-                labelText += "    ";
-            }
-            labelText += label;
-
-            var propertyRow = new PropertyRow(new Label(labelText));
+            var propertyRow = new PropertyRow(new Label(label));
+            ApplyPadding(propertyRow, indentLevel);
             this.hierarchy.Add(propertyRow);
+        }
+
+        void ApplyPadding(VisualElement element, int indentLevel)
+        {
+            element.style.paddingLeft = indentLevel * kIndentWidthInPixel;
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Generation/Contexts/TargetPropertyGUIContext.cs
+++ b/com.unity.shadergraph/Editor/Generation/Contexts/TargetPropertyGUIContext.cs
@@ -10,7 +10,9 @@ namespace UnityEditor.ShaderGraph
     [GenerationAPI]
     internal class TargetPropertyGUIContext : VisualElement
     {
-        const int kIndentWidthInPixel = 20;
+        const int kIndentWidthInPixel = 15;
+
+        public int globalIndentLevel {get; set;} = 0;
 
         public TargetPropertyGUIContext()
         {
@@ -61,7 +63,7 @@ namespace UnityEditor.ShaderGraph
 
         void ApplyPadding(VisualElement element, int indentLevel)
         {
-            element.style.paddingLeft = indentLevel * kIndentWidthInPixel;
+            element.style.paddingLeft = (globalIndentLevel + indentLevel) * kIndentWidthInPixel;
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Resources/Styles/InspectorView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/InspectorView.uss
@@ -1,8 +1,3 @@
-.unity-label {
-    padding: 5px 2px 2px;
-    margin: 2px 4px;
-}
-
 .InspectorView {
     position:absolute;
     justify-content: flex-start;
@@ -64,4 +59,10 @@
 #subTitleLabel {
     font-size: 11px;
     color: #606060;
+}
+
+.MainFoldout {
+    background-color: #383838;
+    border-color: #1F1F1F;
+    border-top-width: 1px;
 }

--- a/com.unity.shadergraph/Editor/Resources/Styles/PropertyRow.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/PropertyRow.uss
@@ -19,6 +19,8 @@ PropertyRow > #container{
 }
 
 PropertyRow > #container > #label {
+    flex-grow: 5;
+    min-width: 92px;
     width: 92px;
     font-size: 12px;
     margin-right: 4px;


### PR DESCRIPTION
# Purpose of this PR
- Flexible label width in inspector
- fixed indentlevel with padding instead of spaces (now word wrap works) 
- reduced the padding between labels to match the builtin inspector
- added a globalIndentLevel to help to control the indent level in blocks
- added a new style for target foldout making them stand out a bit more (like headers of the builtin inspector)

### Old layout:
![image](https://user-images.githubusercontent.com/6877923/82903268-0273a980-9f61-11ea-93a0-7b205f2b92e5.png)

### New layout:
![image](https://user-images.githubusercontent.com/6877923/82903062-af99f200-9f60-11ea-9f60-62967da5a4ec.png)
![PropertyRowPadding](https://user-images.githubusercontent.com/6877923/82884948-c3cff600-9f44-11ea-8f89-2636962da0dd.gif)
