### PR TITLE
Two bugs: DiffusionProfileInputSlot CopyValuesFrom was not clearing t…

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDBlockFields.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDBlockFields.cs
@@ -35,7 +35,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
             public static BlockFieldDescriptor Thickness = new BlockFieldDescriptor(SurfaceDescription.name, "Thickness", "SURFACEDESCRIPTION_THICKNESS", 
                 new FloatControl(1.0f), ShaderStage.Fragment);
             public static CustomSlotBlockFieldDescriptor DiffusionProfileHash = new CustomSlotBlockFieldDescriptor(SurfaceDescription.name, "DiffusionProfileHash", "Diffusion Profile", "SURFACEDESCRIPTION_DIFFUSIONPROFILEHASH", 
-                new DiffusionProfileInputMaterialSlot(0, "Diffusion Profile", "DiffusionProfileHash", ShaderStageCapability.Fragment));
+                () => { return new DiffusionProfileInputMaterialSlot(0, "Diffusion Profile", "DiffusionProfileHash", ShaderStageCapability.Fragment); });
             public static BlockFieldDescriptor IridescenceMask = new BlockFieldDescriptor(SurfaceDescription.name, "IridescenceMask", "Iridescence Mask", "SURFACEDESCRIPTION_IRIDESCENCEMASK", 
                 new FloatControl(0.0f), ShaderStage.Fragment);
             public static BlockFieldDescriptor IridescenceThickness = new BlockFieldDescriptor(SurfaceDescription.name, "IridescenceThickness", "Iridescence Thickness", "SURFACEDESCRIPTION_IRIDESCENCETHICKNESS", 
@@ -54,10 +54,10 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 new FloatControl(0.0f), ShaderStage.Fragment);
             public static BlockFieldDescriptor SpecularAAThreshold = new BlockFieldDescriptor(SurfaceDescription.name, "SpecularAAThreshold", "Specular AA Threshold", "SURFACEDESCRIPTION_SPECULARAATHRESHOLD", 
                 new FloatControl(0.0f), ShaderStage.Fragment);
-            public static CustomSlotBlockFieldDescriptor BakedGI = new CustomSlotBlockFieldDescriptor(SurfaceDescription.name, "BakedGI", "Baked GI", "SURFACEDESCRIPTION_BAKEDGI", 
-                new DefaultMaterialSlot(0, "Baked GI", "BakedGI", ShaderStageCapability.Fragment));
-            public static CustomSlotBlockFieldDescriptor BakedBackGI = new CustomSlotBlockFieldDescriptor(SurfaceDescription.name, "BakedBackGI", "Baked Back GI", "SURFACEDESCRIPTION_BAKEDBACKGI", 
-                new DefaultMaterialSlot(0, "Baked Back GI", "BakedBackGI", ShaderStageCapability.Fragment));
+            public static CustomSlotBlockFieldDescriptor BakedGI = new CustomSlotBlockFieldDescriptor(SurfaceDescription.name, "BakedGI", "Baked GI", "SURFACEDESCRIPTION_BAKEDGI",
+                () => { return new DefaultMaterialSlot(0, "Baked GI", "BakedGI", ShaderStageCapability.Fragment); });
+            public static CustomSlotBlockFieldDescriptor BakedBackGI = new CustomSlotBlockFieldDescriptor(SurfaceDescription.name, "BakedBackGI", "Baked Back GI", "SURFACEDESCRIPTION_BAKEDBACKGI",
+                () => { return new DefaultMaterialSlot(0, "Baked Back GI", "BakedBackGI", ShaderStageCapability.Fragment); });
             public static BlockFieldDescriptor DepthOffset = new BlockFieldDescriptor(SurfaceDescription.name, "DepthOffset", "Depth Offset", "SURFACEDESCRIPTION_DEPTHOFFSET", 
                 new FloatControl(0.0f), ShaderStage.Fragment);
             public static BlockFieldDescriptor RefractionIndex = new BlockFieldDescriptor(SurfaceDescription.name, "RefractionIndex", "Refraction Index", "SURFACEDESCRIPTION_REFRACTIONINDEX", 

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Slots/DiffusionProfileInputMaterialSlot.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Slots/DiffusionProfileInputMaterialSlot.cs
@@ -133,6 +133,7 @@ namespace UnityEditor.Rendering.HighDefinition
             if (slot != null)
             {
                 m_SerializedDiffusionProfile = slot.m_SerializedDiffusionProfile;
+                m_DiffusionProfileAsset = null;
             }
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/BlockNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/BlockNode.cs
@@ -60,16 +60,18 @@ namespace UnityEditor.ShaderGraph
             // TODO: This needs to be removed but is currently required by HDRP for DiffusionProfileInputMaterialSlot
             if(m_Descriptor is CustomSlotBlockFieldDescriptor customSlotDescriptor)
             {
-                AddSlot(customSlotDescriptor.slot);
+                var newSlot = customSlotDescriptor.createSlot();
+                AddSlot(newSlot);
                 RemoveSlotsNameNotMatching(new int[] {0});
                 return;
             }
 
-            AddSlot();
+            AddSlotFromControlType();
         }
 
-        void AddSlot()
+        void AddSlotFromControlType()
         {
+            // TODO: this should really just use callbacks like the CustomSlotBlockFieldDescriptor.. then we wouldn't need this switch to make a copy
             var stageCapability = m_Descriptor.shaderStage.GetShaderStageCapability();
             switch(descriptor.control)
             {

--- a/com.unity.shadergraph/Editor/Generation/Descriptors/BlockFieldDescriptor.cs
+++ b/com.unity.shadergraph/Editor/Generation/Descriptors/BlockFieldDescriptor.cs
@@ -1,4 +1,6 @@
-﻿namespace UnityEditor.ShaderGraph
+using System;
+
+namespace UnityEditor.ShaderGraph
 {
     internal class BlockFieldDescriptor : FieldDescriptor
     {
@@ -32,18 +34,18 @@
     // TODO: This needs to be removed but is currently required by HDRP for DiffusionProfileInputMaterialSlot
     internal class CustomSlotBlockFieldDescriptor : BlockFieldDescriptor
     {
-        public MaterialSlot slot { get; }
+        public Func<MaterialSlot> createSlot;
 
-        public CustomSlotBlockFieldDescriptor(string tag, string referenceName, string define, MaterialSlot slot)
+        public CustomSlotBlockFieldDescriptor(string tag, string referenceName, string define, Func<MaterialSlot> createSlot)
             : base (tag, referenceName, define, null, ShaderStage.Fragment)
         {
-            this.slot = slot;
+            this.createSlot = createSlot;
         }
 
-        public CustomSlotBlockFieldDescriptor(string tag, string referenceName, string displayName, string define, MaterialSlot slot)
+        public CustomSlotBlockFieldDescriptor(string tag, string referenceName, string displayName, string define, Func<MaterialSlot> createSlot)
             : base (tag, referenceName, displayName, define, null, ShaderStage.Fragment)
         {
-            this.slot = slot;
+            this.createSlot = createSlot;
         }
     }
 }

--- a/com.unity.shadergraph/Tests/Editor/UnitTests/BlockNodeTests.cs
+++ b/com.unity.shadergraph/Tests/Editor/UnitTests/BlockNodeTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEditor.Graphing;
@@ -13,7 +13,8 @@ namespace UnityEditor.ShaderGraph.UnitTests
         static BlockFieldDescriptor s_DescriptorB = new BlockFieldDescriptor("Test", "BlockB", string.Empty, new NormalControl(CoordinateSpace.World), ShaderStage.Fragment, true);
 
         static Vector3MaterialSlot s_MaterialSlot = new Vector3MaterialSlot(0, "Test", "BlockB", SlotType.Input, Vector3.one);
-        static CustomSlotBlockFieldDescriptor s_CustomSlotDescriptor = new CustomSlotBlockFieldDescriptor("Test", "CustomBlock", string.Empty, s_MaterialSlot);
+        static CustomSlotBlockFieldDescriptor s_CustomSlotDescriptor = new CustomSlotBlockFieldDescriptor("Test", "CustomBlock", string.Empty,
+            () => { return new Vector3MaterialSlot(0, "Test", "BlockB", SlotType.Input, Vector3.one); });
 
         [OneTimeSetUp]
         public void RunBeforeAnyTests()


### PR DESCRIPTION
…he asset reference

And:  default block node descriptors were having their default slots actually placed in the graph, instead of making a copy

**Guide** : https://github.com/Unity-Technologies/Graphics/blob/master/.github/pr-read.png.md

**Display Addon** : https://userstyles.org/styles/182991/unity-graphics-pr-readme

# Purpose of this PR

> Why is this PR needed, what hard problem is it solving/fixing?

# Testing status
## Manual Tests
> What have you tested?

## Automated Tests
> What did you setup? (Add a screenshot or the reference image of the test please)

## Links
**Yamato**: (Select your branch) https://yamato.prd.cds.internal.unity3d.com/jobs/902-Graphics
> Any test projects or documents to go with this to help reviewers?

# Comments to reviewers
> Notes for the reviewers you have assigned.
