### PR TITLE
Updated hdrp agents

### DIFF
--- a/.yamato/config/hdrp.metafile
+++ b/.yamato/config/hdrp.metafile
@@ -23,15 +23,16 @@ platforms:
       type: Unity::VM
       image: graphics-foundation/win10-dxr:latest
       flavor: b1.xlarge
-      model: rtx2080
     agent_standalone:
       type: Unity::VM::GPU
-      image: sdet/gamecode_win10:stable
-      flavor: b1.large
+      image: graphics-foundation/win10-dxr:latest
+      flavor: b1.xlarge
+      model: rtx2080
     agent_standalone_build:
       type: Unity::VM
-      image: sdet/gamecode_win10:stable
+      image: graphics-foundation/win10-dxr:latest
       flavor: b1.xlarge
+      model: rtx2080
     components:
       - editor
       - il2cpp

--- a/.yamato/hdrp-win-dx11.yml
+++ b/.yamato/hdrp-win-dx11.yml
@@ -51,7 +51,6 @@ HDRP_Win_DX11_editmode_trunk:
         type: Unity::VM
         image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
-        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -70,8 +69,9 @@ HDRP_Win_DX11_Standalone_trunk:
     name: HDRP on Win_DX11_Standalone on version trunk
     agent:
         type: Unity::VM::GPU
-        image: sdet/gamecode_win10:stable
-        flavor: b1.large
+        image: graphics-foundation/win10-dxr:latest
+        flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -93,8 +93,9 @@ Build_HDRP_Win_DX11_Player_trunk:
     name: Build HDRP on Win_DX11_Player on version trunk
     agent:
         type: Unity::VM
-        image: sdet/gamecode_win10:stable
+        image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -160,7 +161,6 @@ HDRP_Win_DX11_editmode_fast-trunk:
         type: Unity::VM
         image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
-        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -179,8 +179,9 @@ HDRP_Win_DX11_Standalone_fast-trunk:
     name: HDRP on Win_DX11_Standalone on version fast-trunk
     agent:
         type: Unity::VM::GPU
-        image: sdet/gamecode_win10:stable
-        flavor: b1.large
+        image: graphics-foundation/win10-dxr:latest
+        flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -202,8 +203,9 @@ Build_HDRP_Win_DX11_Player_fast-trunk:
     name: Build HDRP on Win_DX11_Player on version fast-trunk
     agent:
         type: Unity::VM
-        image: sdet/gamecode_win10:stable
+        image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -271,7 +273,6 @@ HDRP_Win_DX11_editmode_CUSTOM-REVISION:
         type: Unity::VM
         image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
-        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
         CUSTOM_REVISION: custom_revision_not_set
@@ -291,8 +292,9 @@ HDRP_Win_DX11_Standalone_CUSTOM-REVISION:
     name: HDRP on Win_DX11_Standalone on version CUSTOM-REVISION
     agent:
         type: Unity::VM::GPU
-        image: sdet/gamecode_win10:stable
-        flavor: b1.large
+        image: graphics-foundation/win10-dxr:latest
+        flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
         CUSTOM_REVISION: custom_revision_not_set
@@ -315,8 +317,9 @@ Build_HDRP_Win_DX11_Player_CUSTOM-REVISION:
     name: Build HDRP on Win_DX11_Player on version CUSTOM-REVISION
     agent:
         type: Unity::VM
-        image: sdet/gamecode_win10:stable
+        image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
         CUSTOM_REVISION: custom_revision_not_set

--- a/.yamato/hdrp-win-dx12.yml
+++ b/.yamato/hdrp-win-dx12.yml
@@ -51,7 +51,6 @@ HDRP_Win_DX12_editmode_trunk:
         type: Unity::VM
         image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
-        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -70,8 +69,9 @@ HDRP_Win_DX12_Standalone_trunk:
     name: HDRP on Win_DX12_Standalone on version trunk
     agent:
         type: Unity::VM::GPU
-        image: sdet/gamecode_win10:stable
-        flavor: b1.large
+        image: graphics-foundation/win10-dxr:latest
+        flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -93,8 +93,9 @@ Build_HDRP_Win_DX12_Player_trunk:
     name: Build HDRP on Win_DX12_Player on version trunk
     agent:
         type: Unity::VM
-        image: sdet/gamecode_win10:stable
+        image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -160,7 +161,6 @@ HDRP_Win_DX12_editmode_fast-trunk:
         type: Unity::VM
         image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
-        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -179,8 +179,9 @@ HDRP_Win_DX12_Standalone_fast-trunk:
     name: HDRP on Win_DX12_Standalone on version fast-trunk
     agent:
         type: Unity::VM::GPU
-        image: sdet/gamecode_win10:stable
-        flavor: b1.large
+        image: graphics-foundation/win10-dxr:latest
+        flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -202,8 +203,9 @@ Build_HDRP_Win_DX12_Player_fast-trunk:
     name: Build HDRP on Win_DX12_Player on version fast-trunk
     agent:
         type: Unity::VM
-        image: sdet/gamecode_win10:stable
+        image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -271,7 +273,6 @@ HDRP_Win_DX12_editmode_CUSTOM-REVISION:
         type: Unity::VM
         image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
-        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
         CUSTOM_REVISION: custom_revision_not_set
@@ -291,8 +292,9 @@ HDRP_Win_DX12_Standalone_CUSTOM-REVISION:
     name: HDRP on Win_DX12_Standalone on version CUSTOM-REVISION
     agent:
         type: Unity::VM::GPU
-        image: sdet/gamecode_win10:stable
-        flavor: b1.large
+        image: graphics-foundation/win10-dxr:latest
+        flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
         CUSTOM_REVISION: custom_revision_not_set
@@ -315,8 +317,9 @@ Build_HDRP_Win_DX12_Player_CUSTOM-REVISION:
     name: Build HDRP on Win_DX12_Player on version CUSTOM-REVISION
     agent:
         type: Unity::VM
-        image: sdet/gamecode_win10:stable
+        image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
         CUSTOM_REVISION: custom_revision_not_set

--- a/.yamato/hdrp-win-vulkan.yml
+++ b/.yamato/hdrp-win-vulkan.yml
@@ -51,7 +51,6 @@ HDRP_Win_Vulkan_editmode_trunk:
         type: Unity::VM
         image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
-        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -70,8 +69,9 @@ HDRP_Win_Vulkan_Standalone_trunk:
     name: HDRP on Win_Vulkan_Standalone on version trunk
     agent:
         type: Unity::VM::GPU
-        image: sdet/gamecode_win10:stable
-        flavor: b1.large
+        image: graphics-foundation/win10-dxr:latest
+        flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -93,8 +93,9 @@ Build_HDRP_Win_Vulkan_Player_trunk:
     name: Build HDRP on Win_Vulkan_Player on version trunk
     agent:
         type: Unity::VM
-        image: sdet/gamecode_win10:stable
+        image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -160,7 +161,6 @@ HDRP_Win_Vulkan_editmode_fast-trunk:
         type: Unity::VM
         image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
-        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -179,8 +179,9 @@ HDRP_Win_Vulkan_Standalone_fast-trunk:
     name: HDRP on Win_Vulkan_Standalone on version fast-trunk
     agent:
         type: Unity::VM::GPU
-        image: sdet/gamecode_win10:stable
-        flavor: b1.large
+        image: graphics-foundation/win10-dxr:latest
+        flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -202,8 +203,9 @@ Build_HDRP_Win_Vulkan_Player_fast-trunk:
     name: Build HDRP on Win_Vulkan_Player on version fast-trunk
     agent:
         type: Unity::VM
-        image: sdet/gamecode_win10:stable
+        image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
     dependencies:
@@ -271,7 +273,6 @@ HDRP_Win_Vulkan_editmode_CUSTOM-REVISION:
         type: Unity::VM
         image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
-        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
         CUSTOM_REVISION: custom_revision_not_set
@@ -291,8 +292,9 @@ HDRP_Win_Vulkan_Standalone_CUSTOM-REVISION:
     name: HDRP on Win_Vulkan_Standalone on version CUSTOM-REVISION
     agent:
         type: Unity::VM::GPU
-        image: sdet/gamecode_win10:stable
-        flavor: b1.large
+        image: graphics-foundation/win10-dxr:latest
+        flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
         CUSTOM_REVISION: custom_revision_not_set
@@ -315,8 +317,9 @@ Build_HDRP_Win_Vulkan_Player_CUSTOM-REVISION:
     name: Build HDRP on Win_Vulkan_Player on version CUSTOM-REVISION
     agent:
         type: Unity::VM
-        image: sdet/gamecode_win10:stable
+        image: graphics-foundation/win10-dxr:latest
         flavor: b1.xlarge
+        model: rtx2080
     variables:
         UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
         CUSTOM_REVISION: custom_revision_not_set


### PR DESCRIPTION
---
### Purpose of this PR
Updated HDRP images to match with what is on the non-refactored 9.x.x/release branch. Now Windows uses graphics-foundation/win10-dxr:latest with rtx2080 for playmode, playmode XR and editmode, instead of sdet/gamecode_win10:stable

---
### Testing status


**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/902-Graphics/tree/yamato%252Fhdrp-images

