### PR TITLE
[7.x.x][Shader Graph] Fix Custom Function node object selector

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [7.5.0] - 2020-06-08
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed
+Fixed a bug where the object selector for Custom Function Nodes did not update correctly. [1176129](https://issuetracker.unity3d.com/product/unity/issues/guid/1176129/)
 
 ## [7.4.1] - 2020-06-03
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -283,10 +283,6 @@ namespace UnityEditor.ShaderGraph
 
         public override void ValidateNode()
         {
-            if (!this.GetOutputSlots<MaterialSlot>().Any())
-            {
-                owner.AddValidationError(tempId, k_MissingOutputSlot, ShaderCompilerMessageSeverity.Warning);
-            }
             if(sourceType == HlslSourceType.File)
             {
                 if(!string.IsNullOrEmpty(functionSource))
@@ -299,8 +295,16 @@ namespace UnityEditor.ShaderGraph
                         {
                             owner.AddValidationError(tempId, k_InvalidFileType, ShaderCompilerMessageSeverity.Error);
                         }
+                        else
+                        {
+                            owner.ClearErrorsForNode(this);
+                        }
                     }
                 }
+            }
+            if (!this.GetOutputSlots<MaterialSlot>().Any())
+            {
+                owner.AddValidationError(tempId, k_MissingOutputSlot, ShaderCompilerMessageSeverity.Warning);
             }
             ValidateSlotName();
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/HlslFunctionView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/HlslFunctionView.cs
@@ -77,7 +77,6 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     node.owner.owner.RegisterCompleteObjectUndo("Change Function Source");
                     node.functionSource = guidString;
-                    Draw(node);
                     node.ValidateNode();
                     node.Dirty(ModificationScope.Graph);
                 }


### PR DESCRIPTION
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Backport #977 
fixes [1176129](https://issuetracker.unity3d.com/product/unity/issues/guid/1176129/) where the object selector for custom function file nodes would not update after first selection. 

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: 
tests repeated for backport
- Created a custom function node and selected multiple objects in a row, confirming the selections are updating correctly. 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/902-Graphics

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
