### PR TITLE
Bump min editor version to 20.1.0b15

### DIFF
--- a/com.unity.render-pipelines.core/package.json
+++ b/com.unity.render-pipelines.core/package.json
@@ -3,7 +3,7 @@
     "description": "SRP Core makes it easier to create or customize a Scriptable Render Pipeline (SRP). SRP Core contains reusable code, including boilerplate code for working with platform-specific graphics APIs, utility functions for common rendering operations, and  shader libraries. The code in SRP Core is use by the High Definition Render Pipeline (HDRP) and Universal Render Pipeline (URP). If you are creating a custom SRP from scratch or customizing a prebuilt SRP, using SRP Core will save you time.",
     "version": "8.2.0",
     "unity": "2020.1",
-    "unityRelease": "0b6",
+    "unityRelease": "0b15",
     "displayName": "Core RP Library",
 	"dependencies": {
 	"com.unity.ugui" : "1.0.0"

--- a/com.unity.render-pipelines.high-definition-config/package.json
+++ b/com.unity.render-pipelines.high-definition-config/package.json
@@ -3,7 +3,7 @@
     "description": "Configuration files for the High Definition Render Pipeline.",
     "version": "8.2.0",
     "unity": "2020.1",
-    "unityRelease": "0b6",
+    "unityRelease": "0b15",
     "displayName": "High Definition RP Config",
     "dependencies": {
         "com.unity.render-pipelines.core": "8.2.0"

--- a/com.unity.render-pipelines.high-definition/package.json
+++ b/com.unity.render-pipelines.high-definition/package.json
@@ -3,7 +3,7 @@
     "description": "The High Definition Render Pipeline (HDRP) is a high-fidelity Scriptable Render Pipeline built by Unity to target modern (Compute Shader compatible) platforms. HDRP utilizes Physically-Based Lighting techniques, linear lighting, HDR lighting, and a configurable hybrid Tile/Cluster deferred/Forward lighting architecture and gives you the tools you need to create games, technical demos, animations, and more to a high graphical standard.",
     "version": "8.2.0",
     "unity": "2020.1",
-    "unityRelease": "0b11",
+    "unityRelease": "0b15",
     "displayName": "High Definition RP",
     "dependencies": {
         "com.unity.render-pipelines.core": "8.2.0",

--- a/com.unity.render-pipelines.lightweight/package.json
+++ b/com.unity.render-pipelines.lightweight/package.json
@@ -3,7 +3,7 @@
     "description": "The Lightweight Render Pipeline (LWRP) is a prebuilt Scriptable Render Pipeline, made by Unity. The technology offers graphics that are scalable to mobile platforms, and you can also use it for higher-end consoles and PCs. You’re able to achieve quick rendering at a high quality without needing compute shader technology. LWRP uses simplified, physically based Lighting and Materials. The LWRP uses single-pass forward rendering. Use this pipeline to get optimized real-time performance on several platforms.",
     "version": "8.2.0",
     "unity": "2020.1",
-    "unityRelease": "0b6",
+    "unityRelease": "0b15",
     "displayName": "Lightweight RP",
     "dependencies": {
         "com.unity.render-pipelines.universal": "8.2.0",

--- a/com.unity.render-pipelines.universal/package.json
+++ b/com.unity.render-pipelines.universal/package.json
@@ -3,7 +3,7 @@
     "description": "The Universal Render Pipeline (URP) is a prebuilt Scriptable Render Pipeline, made by Unity. URP provides artist-friendly workflows that let you quickly and easily create optimized graphics across a range of platforms, from mobile to high-end consoles and PCs.",
     "version": "8.2.0",
     "unity": "2020.1",
-    "unityRelease": "0b6",
+    "unityRelease": "0b15",
     "displayName": "Universal RP",
     "dependencies": {
         "com.unity.render-pipelines.core": "8.2.0",

--- a/com.unity.shadergraph/package.json
+++ b/com.unity.shadergraph/package.json
@@ -3,7 +3,7 @@
     "description": "The Shader Graph package adds a visual Shader editing tool to Unity. You can use this tool to create Shaders in a visual way instead of writing code. Specific render pipelines can implement specific graph features. Currently, both the High Definition Rendering Pipeline and the Universal Rendering Pipeline support Shader Graph.",
     "version": "8.2.0",
     "unity": "2020.1",
-    "unityRelease": "0b6",
+    "unityRelease": "0b15",
     "displayName": "Shader Graph",
     "dependencies": {
         "com.unity.render-pipelines.core": "8.2.0",

--- a/com.unity.testing.hdrp/package.json
+++ b/com.unity.testing.hdrp/package.json
@@ -3,7 +3,7 @@
 	"displayName":"HDRP graphic tests common library",
 	"version": "1.0.0",
 	"unity": "2020.1",
-	"unityRelease": "0b6",
+	"unityRelease": "0b15",
 	"description": "Common assets library for HDRP test projects.",
 	"keywords": ["qa", "test", "testing", "tests", "graphics", "HDRP"],
 	"dependencies": {

--- a/com.unity.testing.visualeffectgraph/package.json
+++ b/com.unity.testing.visualeffectgraph/package.json
@@ -3,7 +3,7 @@
     "displayName": "Visual Effect Graphic Tests",
     "version": "8.2.0",
     "unity": "2020.1",
-    "unityRelease": "0a23",
+    "unityRelease": "0b15",
     "description": "This package contains common graphics tests from several scriptable renderpipeline",
     "dependencies": {
         "com.unity.visualeffectgraph": "8.2.0",

--- a/com.unity.visualeffectgraph/package.json
+++ b/com.unity.visualeffectgraph/package.json
@@ -3,7 +3,7 @@
     "displayName": "Visual Effect Graph",
     "version": "8.2.0",
     "unity": "2020.1",
-    "unityRelease": "0b6",
+    "unityRelease": "0b15",
     "description":"The Visual Effect Graph is a node based visual effect editor. It allows you to author next generation visual effects that Unity simulates directly on the GPU. The Visual Effect Graph is production-ready for the High Definition Render Pipeline and runs on all platforms supported by it. Full support for the Universal Render Pipeline and compatible mobile devices is still in development.",
     "keywords":[
         "vfx",


### PR DESCRIPTION
Why is this PR needed, what hard problem is it solving/fixing?
Bump min editor version of all packages to b15 due to breaking changes.
