### PR TITLE
[10.x.x] ShaderGraph: Stop making transparent objects cast shadows

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -231,6 +231,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed profiler marker errors. [case 1240963](https://issuetracker.unity3d.com/issues/urp-errors-are-thrown-in-a-console-when-using-profiler-to-profile-editor)
 - Fixed issue that caused the pipeline to not create _CameraColorTexture if a custom render pass is injected. [case 1232761](https://issuetracker.unity3d.com/issues/urp-the-intermediate-color-texture-is-no-longer-created-when-there-is-at-least-one-renderer-feature)
 - Fixed target eye UI for XR rendering is missing from camera inspector. [case 1261612](https://issuetracker.unity3d.com/issues/xr-cameras-target-eye-property-is-missing-when-inspector-is-in-normal-mode)
+- Fixed an issue where transparent shaders made with ShaderGraph were casting shadows.
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide


### PR DESCRIPTION
# Purpose of this PR
In URP when you change the surface type to transparent, the Shader GUI calls this function to disable the ShaderCaster pass
`material.SetShaderPassEnabled("ShadowCaster", false);`

For shaders made with ShaderGraph there isn't anything preventing the transparent objects casting shadows. This PR removes the ShadowCaster pass by introducing two SubShaderDescriptor and selecting the appropriate ones when we process SubShaders

# Yamato
https://yamato.prd.cds.internal.unity3d.com/jobs/902-Graphics/tree/universal%252Fshadergraph%252Ftransparent-shadows

# Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)