### PR TITLE
[VFX] Fix incorrect AlphaTreshold listing (7.x.x) 

### DIFF
--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -208,7 +208,7 @@ Shader ""Hidden/GraphErrorShader2""
             var graph = masterNode.owner;
 
             asset.lit = masterNode.lit.isOn;
-            asset.alphaClipping = target.alphaTest;
+            asset.alphaClipping = masterNode.alphaTest.isOn;
 
             var assetGuid = masterNode.owner.assetGuid;
             var assetPath = AssetDatabase.GUIDToAssetPath(assetGuid);
@@ -219,16 +219,6 @@ Shader ""Hidden/GraphErrorShader2""
 
             var nodes = new List<AbstractMaterialNode>();
             NodeUtils.DepthFirstCollectNodesFromNode(nodes, masterNode);
-
-            //Remove inactive blocks from generation
-            {
-                var tmpCtx = new TargetActiveBlockContext(new List<BlockFieldDescriptor>(), null);
-                target.GetActiveBlocks(ref tmpCtx);
-                ports.RemoveAll(materialSlot =>
-                {
-                    return !tmpCtx.activeBlocks.Any(o => materialSlot.RawDisplayName() == o.displayName);
-                });
-            }
 
             var bodySb = new ShaderStringBuilder(1);
             var registry = new FunctionRegistry(new ShaderStringBuilder(), true);
@@ -563,7 +553,7 @@ Shader ""Hidden/GraphErrorShader2""
             var outputMetadatas = new OutputMetadata[ports.Count];
             for (int portIndex = 0; portIndex < outputMetadatas.Length; portIndex++)
             {
-                outputMetadatas[portIndex] = new OutputMetadata(portIndex, ports[portIndex].shaderOutputName, originialPortIds[portIndex]);
+                outputMetadatas[portIndex] = new OutputMetadata(portIndex, ports[portIndex].shaderOutputName, ports[portIndex].id);
             }
 
             asset.SetOutputs(outputMetadatas);

--- a/com.unity.shadergraph/Editor/Internal/ShaderGraphVfxAsset.cs
+++ b/com.unity.shadergraph/Editor/Internal/ShaderGraphVfxAsset.cs
@@ -28,6 +28,9 @@ namespace UnityEditor.ShaderGraph.Internal
         public bool lit;
 
         [SerializeField]
+        public bool alphaClipping;
+
+        [SerializeField]
         internal GraphCompilationResult compilationResult;
 
         [SerializeField]

--- a/com.unity.visualeffectgraph/CHANGELOG.md
+++ b/com.unity.visualeffectgraph/CHANGELOG.md
@@ -150,6 +150,7 @@ The version number for this package has increased due to a version update of a r
 - Correct VFXSettings display in Shader Graph compatible outputs
 - No more NullReference on sub-outputs after domain reload
 - Fix typo in strip tangent computation
+- Handle correctly disabled alphaTreshold material slot in shaderGraph.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.visualeffectgraph/Editor/ShaderGraph/VFXShaderGraphParticleOutput.cs
+++ b/com.unity.visualeffectgraph/Editor/ShaderGraph/VFXShaderGraphParticleOutput.cs
@@ -126,7 +126,7 @@ namespace UnityEditor.VFX
                 }
                 else
                 {
-                    if (!shaderGraph.HasOutput(ShaderGraphVfxAsset.AlphaThresholdSlotId)) //alpha threshold isn't controlled by shadergraph
+                    if (!shaderGraph.alphaClipping) //alpha threshold isn't controlled by shadergraph
                         return true;
                 }
                 return false;
@@ -138,7 +138,7 @@ namespace UnityEditor.VFX
             get
             {
                 bool noShaderGraphAlphaThreshold = shaderGraph == null && useAlphaClipping;
-                bool ShaderGraphAlphaThreshold = shaderGraph != null && shaderGraph.HasOutput(ShaderGraphVfxAsset.AlphaThresholdSlotId);
+                bool ShaderGraphAlphaThreshold = shaderGraph != null && shaderGraph.alphaClipping;
                 return noShaderGraphAlphaThreshold || ShaderGraphAlphaThreshold;
             }
         }
@@ -540,7 +540,7 @@ namespace UnityEditor.VFX
                         callSG.builder.AppendLine(");");
 
                         var pixelPorts = currentRP.passInfos[kvPass.Key].pixelPorts;
-                        if (pixelPorts.Any(t => t == ShaderGraphVfxAsset.AlphaThresholdSlotId) && shaderGraph.HasOutput(ShaderGraphVfxAsset.AlphaThresholdSlotId))
+                        if (pixelPorts.Any(t => t == ShaderGraphVfxAsset.AlphaThresholdSlotId) && shaderGraph.alphaClipping)
                         {
                             callSG.builder.AppendLine(
 @"#if (USE_ALPHA_TEST || WRITE_MOTION_VECTOR_IN_FORWARD) && defined(VFX_VARYING_ALPHATHRESHOLD)


### PR DESCRIPTION
Backport of https://github.com/Unity-Technologies/Graphics/pull/1405

### Note
Fix build at https://github.com/Unity-Technologies/Graphics/pull/1705/commits/16c4d0393acdeea01309085881061c194d8f2188 because TargetActiveBlockContext is a concept which doesn't exist in 7.x.x

I'm still adding asset.alphaClipping = masterNode.alphaTest.isOn; to be able to do a consistent VFX Backport.