### PR TITLE
backport of hotfix for regression introduced by bugfix for issues wit…

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -159,7 +159,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             return compatibleAnchors;
         }
 
-        internal void ResetSelectedBlockNodes()
+        internal bool ResetSelectedBlockNodes()
         {
             var selectedBlocknodes = selection.FindAll(e => e is MaterialNodeView && ((MaterialNodeView)e).node is BlockNode).Cast<MaterialNodeView>().ToArray();
             foreach (var mNode in selectedBlocknodes)
@@ -174,16 +174,18 @@ namespace UnityEditor.ShaderGraph.Drawing
                 // solution is to call its DragLeave until its interface can be improved.
                 context.DragLeave(null, null, null, null);
             }
+            return selectedBlocknodes.Length > 0;
         }
 
         public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
         {
             Vector2 mousePosition = evt.mousePosition;
 
-            // If a block node is floating, the context menu may not build correctly.     
-            if (!(evt.target is MaterialNodeView && ((MaterialNodeView)evt.target).node is BlockNode))
+            // If the target wasn't a block node, but there is one selected (and reset) by the time we reach this point,
+            // it means a block node was in an invalid configuration and that it may be unsafe to build the context menu.
+            bool targetIsBlockNode = evt.target is MaterialNodeView && ((MaterialNodeView)evt.target).node is BlockNode;
+            if (ResetSelectedBlockNodes() && !targetIsBlockNode)
             {
-                // GraphEditorView will call ResetSelectedBlockNodes via MouseUpEvent to ensure block nodes are reset
                 return;
             }
 


### PR DESCRIPTION
### Purpose of this PR
Fix for regression caused by #1931. This in itself is also a backport of #2008.

The original fix provides some protections from generating context menus while a block node is floating. These protections were applied across a larger case than originally intended. Context Menus across many objects were failing to build as a result.


### Testing status

Manually testing, ensure that context menus build properly across MaterialGraphView objects.
