### PR TITLE
[ShaderGraph] [bugfix 1283425] Handle invalid SubGraph assets during recursion check

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed issues with ShaderGraph detection and handling of deleted graph files
 - Fixed an issue where the ShaderGraph was corrupting the translation cache
 - Fixed an issue where ShaderGraph would not prompt the user to save unsaved changes after an assembly reload
+- Fixed an issue where failing SubGraphs would block saving graph files using them (recursion check would throw exceptions) [1283425]
 
 ## [10.0.0] - 2019-06-10
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
@@ -139,7 +139,15 @@ namespace UnityEditor.ShaderGraph
             {
                 foreach (var sgNode in subGraphNodes)
                 {
-                    if ((sgNode.asset.assetGuid == overwriteGUID) || sgNode.asset.descendents.Contains(overwriteGUID))
+                    var asset = sgNode?.asset;
+                    if (asset == null)
+                    {
+                        // cannot read the asset; might be recursive but we can't tell... should we return "maybe"?
+                        // I think to be minimally intrusive to the user we can assume "No" in this case,
+                        // even though this may miss recursions in extraordinary cases.
+                        // it's more important to allow the user to save their files than to catch 100% of recursions
+                    }
+                    else if ((asset.assetGuid == overwriteGUID) || asset.descendents.Contains(overwriteGUID))
                     {
                         if (context != null)
                         {

--- a/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
@@ -146,6 +146,7 @@ namespace UnityEditor.ShaderGraph
                         // I think to be minimally intrusive to the user we can assume "No" in this case,
                         // even though this may miss recursions in extraordinary cases.
                         // it's more important to allow the user to save their files than to catch 100% of recursions
+                        continue;
                     }
                     else if ((asset.assetGuid == overwriteGUID) || asset.descendents.Contains(overwriteGUID))
                     {


### PR DESCRIPTION
### Purpose of this PR
Fix for regression https://fogbugz.unity3d.com/f/cases/1283425/

Handle null SubGraphAsset instead of throwing null access exception.

We assume any subgraphs we can't access do not contain recursions; erring on the side of letting the user save their files.

---
### Testing status
Describe what manual/automated tests were performed for this PR

Tested on my local repro, not entirely sure how the repro occurred, but could repro it locally 100%.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
