### PR TITLE
[ShaderGraph] [bugfix 1283782] Fix for previews when selecting "None" as your texture property texture

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where ShaderGraph would not prompt the user to save unsaved changes after an assembly reload
 - Fixed an issue with Position Node not automatically upgrading
 - Fixed an issue where failing SubGraphs would block saving graph files using them (recursion check would throw exceptions) [1283425]
+- Fixed an issue where choosing "None" as the default texture for a texture property would not correctly preview the correct default color [1283782]
 
 ## [10.0.0] - 2019-06-10
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Graphs/PreviewProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/PreviewProperty.cs
@@ -46,6 +46,7 @@ namespace UnityEditor.ShaderGraph
 
         ClassData m_ClassData;
         StructData m_StructData;
+        Texture2DShaderProperty.DefaultType m_texture2dDefaultType;
 
         public Color colorValue
         {
@@ -76,6 +77,22 @@ namespace UnityEditor.ShaderGraph
                 if (propType != PropertyType.Texture2D && propType != PropertyType.Texture2DArray && propType != PropertyType.Texture3D)
                     throw new ArgumentException(string.Format(k_SetErrorMessage, PropertyType.Texture2D, propType));
                 m_ClassData.textureValue = value;
+            }
+        }
+
+        public Texture2DShaderProperty.DefaultType texture2DDefaultType
+        {
+            get
+            {
+                if (propType != PropertyType.Texture2D)
+                    throw new ArgumentException(string.Format(k_GetErrorMessage, "Texture2DShaderProperty.DefaultType", propType));
+                return m_texture2dDefaultType;
+            }
+            set
+            {
+                if (propType != PropertyType.Texture2D)
+                    throw new ArgumentException(string.Format(k_GetErrorMessage, "Texture2DShaderProperty.DefaultType", propType));
+                m_texture2dDefaultType = value;
             }
         }
 
@@ -205,7 +222,21 @@ namespace UnityEditor.ShaderGraph
                     // and no way to delete the property either
                     // so instead we set the value to what we know the default will be
                     // (all textures in ShaderGraph default to white)
-                    mat.SetTexture(name, Texture2D.whiteTexture);
+                    switch (m_texture2dDefaultType)
+                    {
+                        case Texture2DShaderProperty.DefaultType.White:
+                            mat.SetTexture(name, Texture2D.whiteTexture);
+                            break;
+                        case Texture2DShaderProperty.DefaultType.Black:
+                            mat.SetTexture(name, Texture2D.blackTexture);
+                            break;
+                        case Texture2DShaderProperty.DefaultType.Grey:
+                            mat.SetTexture(name, Texture2D.grayTexture);
+                            break;
+                        case Texture2DShaderProperty.DefaultType.Bump:
+                            mat.SetTexture(name, Texture2D.normalTexture);
+                            break;
+                    }
                 }
                 else
                     mat.SetTexture(name, m_ClassData.textureValue);

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture2DInputMaterialSlot.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture2DInputMaterialSlot.cs
@@ -78,6 +78,7 @@ namespace UnityEditor.ShaderGraph
             {
                 name = name,
                 textureValue = texture,
+                texture2DDefaultType = defaultType
             };
             properties.Add(pp);
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture2DShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture2DShaderProperty.cs
@@ -69,7 +69,8 @@ namespace UnityEditor.ShaderGraph.Internal
             return new PreviewProperty(propertyType)
             {
                 name = referenceName,
-                textureValue = value.texture
+                textureValue = value.texture,
+                texture2DDefaultType = defaultType
             };
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/Texture2DAssetNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/Texture2DAssetNode.cs
@@ -58,7 +58,8 @@ namespace UnityEditor.ShaderGraph
             properties.Add(new PreviewProperty(PropertyType.Texture2D)
             {
                 name = GetVariableNameForSlot(OutputSlotId),
-                textureValue = texture
+                textureValue = texture,
+                texture2DDefaultType = Texture2DShaderProperty.DefaultType.White
             });
         }
 


### PR DESCRIPTION
### Purpose of this PR
Fix for https://fogbugz.unity3d.com/f/cases/1283782/

The core of the issue is that we cannot remove a Texture (or any property really) from a MaterialPropertyBlock, and we also cannot set the Texture to null (error).  So effectively we cannot go back to the unassigned Texture state that would allow us to automatically pick up the default texture values.

As a workaround, we now pass the defaults into the preview property for texture2Ds, so we can properly assign the texture in the MaterialPropertyBlock with the corresponding value.

Talking with Yao, it should be possible to actually make public RemoveProperty() functions on MaterialPropertyBlock, which would greatly simplify all of this, but that would be a feature in trunk, so not until 21.1 at the earliest.

---
### Testing status
Tested that all four default types show up properly in previews, and in the main preview, and match the color in scene.
![image](https://user-images.githubusercontent.com/28871759/95778144-55ce6600-0c7c-11eb-809c-cd16d9faf67d.png)

Tested that assigning default types works with undo/redo/assembly reload, and that the previews update correctly.
Tested that assigning and unassigning (set to none) textures still works properly, with undo/redo/assembly reload and preview update.

Tested that non-2D texture types (2DArray, 3D, cubemap) still work as expected.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
