### PR TITLE
disable density blending for more than 4 layers

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Version Updated
 The version number for this package has increased due to a version update of a related graphics package.
 
-### Changed
-- Changed TerrainLit blending to disable density blend when more than four Terrain Layers are in use.
+### Fixed
+- Fixed TerrainLit blending to disable density blend when more than four Terrain Layers are in use. [case 1283124](https://issuetracker.unity3d.com/issues/terrain-lit-opacity-as-density-option-causes-alphad-areas-on-the-5th-layer-or-greater-to-appear-with-artifacts)
 
 ## [10.2.0] - 2020-10-19
 

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Version Updated
 The version number for this package has increased due to a version update of a related graphics package.
 
+### Changed
+- Changed TerrainLit blending to disable density blend when more than four Terrain Layers are in use.
+
 ## [10.2.0] - 2020-10-19
 
 ### Changed

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -133,11 +133,14 @@ void SplatmapMix(float4 uvMainAndLM, float4 uvSplat01, float4 uvSplat23, inout h
     defaultSmoothness *= half4(_Smoothness0, _Smoothness1, _Smoothness2, _Smoothness3);
 
 #ifndef _TERRAIN_BLEND_HEIGHT
-    // 20.0 is the number of steps in inputAlphaMask (Density mask. We decided 20 empirically)
-    half4 opacityAsDensity = saturate((half4(diffAlbedo[0].a, diffAlbedo[1].a, diffAlbedo[2].a, diffAlbedo[3].a) - (half4(1.0, 1.0, 1.0, 1.0) - splatControl)) * 20.0);
-    opacityAsDensity += 0.001h * splatControl;      // if all weights are zero, default to what the blend mask says
-    half4 useOpacityAsDensityParam = { _DiffuseRemapScale0.w, _DiffuseRemapScale1.w, _DiffuseRemapScale2.w, _DiffuseRemapScale3.w }; // 1 is off
-    splatControl = lerp(opacityAsDensity, splatControl, useOpacityAsDensityParam);
+    if(_NumLayersCount <= 4) // disable if > 4 layers due to normalization breaking with multi-pass
+    {
+        // 20.0 is the number of steps in inputAlphaMask (Density mask. We decided 20 empirically)
+        half4 opacityAsDensity = saturate((half4(diffAlbedo[0].a, diffAlbedo[1].a, diffAlbedo[2].a, diffAlbedo[3].a) - (half4(1.0, 1.0, 1.0, 1.0) - splatControl)) * 20.0);
+        opacityAsDensity += 0.001h * splatControl;      // if all weights are zero, default to what the blend mask says
+        half4 useOpacityAsDensityParam = { _DiffuseRemapScale0.w, _DiffuseRemapScale1.w, _DiffuseRemapScale2.w, _DiffuseRemapScale3.w }; // 1 is off
+        splatControl = lerp(opacityAsDensity, splatControl, useOpacityAsDensityParam);
+    }
 #endif
 
     // Now that splatControl has changed, we can compute the final weight and normalize


### PR DESCRIPTION
# **Please read;**
## **PR Workflow for the Graphics repository:**
* **All PRs must be opened as draft initially**
* Reviewers can be added while the PR is still in draft
* The PR can be marked as “Ready for Review” once the reviewers have confirmed that **no more changes are needed**
* Tests will start automatically after the PR is marked as “Ready for Review”
* **Do not use [skip ci]** - this can break some of our tooling
* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Disables density blending for more than 4 Terrain Layers. Fixes incorrect blending due to multi-pass normalization. Height blending is handled the same way.

Fixes [Case 1283124](https://fogbugz.unity3d.com/f/cases/1283124/)

---
### Testing status
- Manually paint with 4 layers and more than 4 layers
- Run graphics test locally. Specifically 038_TerrainBlend

---
### Comments to reviewers
Notes for the reviewers you have assigned.
