### PR TITLE
[11.x] Avoid the system 'AppendLine' during generation and serialization

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Version Updated
 The version number for this package has increased due to a version update of a related graphics package.
 
+## [10.3.0] - 2020-11-03
+
+### Added
+
+### Changed
+
+### Fixed
+- Fixed an issue where shaders could be generated with CR/LF ("\r\n") instead of just LF ("\n") line endings [1286430]
+
 ## [10.2.0] - 2020-10-19
 
 ### Added
@@ -89,7 +98,7 @@ The version number for this package has increased due to a version update of a r
 
 ## [10.0.0] - 2019-06-10
 ### Added
-- Added the Internal Inspector which allows the user to view data contained in selected nodes and properties in a new floating graph sub-window. Also added support for custom property drawers to let you visualize any data type you like and expose it to the inspector.  
+- Added the Internal Inspector which allows the user to view data contained in selected nodes and properties in a new floating graph sub-window. Also added support for custom property drawers to let you visualize any data type you like and expose it to the inspector.
 - Added samples for Procedural Patterns to the package.
 - You can now use the right-click context menu to delete Sticky Notes.
 - You can now save your graph as a new Asset.
@@ -103,7 +112,7 @@ The version number for this package has increased due to a version update of a r
 - If Unity Editor Analytics are enabled, Shader Graph collects anonymous data about which nodes you use in your graphs. This helps the Shader Graph team focus our efforts on the most common graph scenarios, and better understand the needs of our customers. We don't track edge data and cannot recreate your graphs in any form.
 - The Create Node Menu now has a tree view and support for fuzzy field searching.
 - When a Shader Graph or Sub Graph Asset associated with a open window has been deleted, Unity now displays a dialog that asks whether you would like to save the graph as a new Asset or close the window.
-- Added a drop-down menu to the PBR Master Node that lets you select the final coordinate space of normals delivered from the fragment function. 
+- Added a drop-down menu to the PBR Master Node that lets you select the final coordinate space of normals delivered from the fragment function.
 - Added support for users to drag and drop Blackboard Properties from one graph to another.
 - Breaking out GraphData validation into clearer steps.
 - Added AlphaToMask render state.
@@ -120,8 +129,8 @@ The version number for this package has increased due to a version update of a r
 - Updated legacy COLOR output semantic to SV_Target in pixel shader for compatibility with DXC.
 - Updated the functions in the `Normal From Height` node to avoid NaN outputs.
 - Changed the Voronoi Node algorithm to increase the useful range of the input values and to always use float values internally to avoid clipping.
-- Changed the `Reference Suffix` of Keyword Enum entries so that you cannot edit them, which ensures that material keywords compile properly. 
-- Updated the dependent version of `Searcher` to 4.2.0. 
+- Changed the `Reference Suffix` of Keyword Enum entries so that you cannot edit them, which ensures that material keywords compile properly.
+- Updated the dependent version of `Searcher` to 4.2.0.
 - Added support for `Linear Blend Skinning` Node to Universal Render Pipeline.
 - Moved all code to be under Unity specific namespaces.
 - Changed ShaderGraphImporter and ShaderSubgraphImporter so that graphs are imported before Models.
@@ -164,9 +173,9 @@ The version number for this package has increased due to a version update of a r
 - Fixed a bug where Shader Graph shaders were writing to `POSITION` instead of `SV_POSITION`, which caused PS4 builds to fail.
 - Fixed a bug where `Object to Tangent` transforms in the `Transform` node used the wrong matrix. [1162203](https://issuetracker.unity3d.com/issues/shadergraph-transform-node-from-object-to-tangent-space-uses-the-wrong-matrix)
 - Fixed an issue where boolean keywords in a Shader Graph caused HDRP Material features to fail. [1204827](https://issuetracker.unity3d.com/issues/hdrp-shadergraph-adding-a-boolean-keyword-to-an-hdrp-lit-shader-makes-material-features-not-work)
-- Fixed a bug where Object space normals scaled with Object Scale. 
+- Fixed a bug where Object space normals scaled with Object Scale.
 - Documentation links on nodes now point to the correct URLs and package versions.
-- Fixed an issue where Sub Graphs sometimes had duplicate names when you converted nodes into Sub Graphs. 
+- Fixed an issue where Sub Graphs sometimes had duplicate names when you converted nodes into Sub Graphs.
 - Fixed an issue where the number of ports on Keyword nodes didn't update when you added or removed Enum Keyword entries.
 - Fixed an issue where colors in graphs didn't update when you changed a Blackboard Property's precision while the Color Mode is set to Precision.
 - Fixed a bug where custom mesh in the Master Preview didn't work.
@@ -180,7 +189,7 @@ The version number for this package has increased due to a version update of a r
 - Fixed a bug where if a user had a Blackboard Property Reference start with a digit the generated shader would be broken.
 - Avoid unintended behavior by removing the ability to create presets from Shader Graph (and Sub Graph) assets. [1220914](https://issuetracker.unity3d.com/issues/shadergraph-preset-unable-to-open-editor-when-clicking-on-open-shader-editor-in-the-shadersubgraphimporter)
 - Fixed a bug where undo would make the Master Preview visible regardless of its toggle status.
-- Fixed a bug where any change to the PBR master node settings would lose connection to the normal slot. 
+- Fixed a bug where any change to the PBR master node settings would lose connection to the normal slot.
 - Fixed a bug where the user couldn't open up HDRP Master Node Shader Graphs without the Render Pipeline set to HDRP.
 - Fixed a bug where adding a HDRP Master Node to a Shader Graph would softlock the Shader Graph.
 - Fixed a bug where shaders fail to compile due to `#pragma target` generation when your system locale uses commas instead of periods.
@@ -196,15 +205,15 @@ The version number for this package has increased due to a version update of a r
 - Optimized loading a large Shader Graph. [1209047](https://issuetracker.unity3d.com/issues/shader-graph-unresponsive-editor-when-using-large-graphs)
 - Fixed NaN issue in triplanar SG node when blend goes to 0.
 - Fixed a recurring bug where node inputs would get misaligned from their ports. [1224480]
-- Fixed an issue where Blackboard properties would not duplicate with `Precision` or `Hybrid Instancing` options. 
-- Fixed an issue where `Texture` properties on the Blackboard would not duplicate with the same `Mode` settings. 
+- Fixed an issue where Blackboard properties would not duplicate with `Precision` or `Hybrid Instancing` options.
+- Fixed an issue where `Texture` properties on the Blackboard would not duplicate with the same `Mode` settings.
 - Fixed an issue where `Keywords` on the Blackboard would not duplicate with the same `Default` value.
 - Shader Graph now requests preview shader compilation asynchronously. [1209047](https://issuetracker.unity3d.com/issues/shader-graph-unresponsive-editor-when-using-large-graphs)
 - Fixed an issue where Shader Graph would not compile master previews after an assembly reload.
 - Fixed issue where `Linear Blend Skinning` node could not be converted to Sub Graph [1227087](https://issuetracker.unity3d.com/issues/shadergraph-linear-blend-skinning-node-reports-an-error-and-prevents-shader-compilation-when-used-within-a-sub-graph)
 - Fixed a compilation error in preview shaders for nodes requiring view direction.
 - Fixed undo not being recorded properly for setting active master node, graph precision, and node defaults.
-- Fixed an issue where Custum Function nodes and Sub Graph Output nodes could no longer rename slots. 
+- Fixed an issue where Custum Function nodes and Sub Graph Output nodes could no longer rename slots.
 - Fixed a bug where searcher entries would not repopulate correctly after an undo was perfromed (https://fogbugz.unity3d.com/f/cases/1241018/)
 - Fixed a bug where Redirect Nodes did not work as inputs to Custom Function Nodes. [1235999](https://issuetracker.unity3d.com/product/unity/issues/guid/1235999/)
 - Fixed a bug where changeing the default value on a keyword would reset the node input type to vec4 (https://fogbugz.unity3d.com/f/cases/1216760/)
@@ -265,8 +274,8 @@ The version number for this package has increased due to a version update of a r
 ### Fixed
 - Fixed various dependency tracking issues with Sub Graphs and HLSL files from Custom Function Nodes.
 - Fixed an error that previously occurred when you used `Sampler State` input ports on Sub Graphs.
-- `Normal Reconstruct Z` node is now compatible with both fragment and vertex stages. 
-- `Position` node now draws the correct label for **Absolute World**. 
+- `Normal Reconstruct Z` node is now compatible with both fragment and vertex stages.
+- `Position` node now draws the correct label for **Absolute World**.
 - Node previews now inherit preview type correctly.
 - Normal maps now unpack correctly for mobile platforms.
 - Fixed an error that previously occurred when you used the Gradient Sample node and your system locale uses commas instead of periods.
@@ -284,7 +293,7 @@ The version number for this package has increased due to a version update of a r
 ### Changed
 - The `Custom Function Node` now uses an object field to reference its source when using `File` mode.
 - To enable master nodes to generate correct motion vectors for time-based vertex modification, time is now implemented as an input to the graph rather than as a global uniform.
-- **World** space on `Position Node` now uses the default world space coordinates of the active render pipeline. 
+- **World** space on `Position Node` now uses the default world space coordinates of the active render pipeline.
 
 ### Fixed
 - Fixed an error in `Custom Function Node` port naming.
@@ -309,7 +318,7 @@ The version number for this package has increased due to a version update of a r
 ### Fixed
 - When you click on the gear icon, Shader Graph now focuses on the selected node, and brings the settings menu to front view.
 - Sub Graph Output and Custom Function Node now validate slot names, and display an appropriate error badge when needed.
-- Remaining outdated documentation has been removed. 
+- Remaining outdated documentation has been removed.
 - When you perform an undo or redo to an inactive Shader Graph window, the window no longer breaks.
 - When you rapidly perform an undo or redo, Shader Graph windows no longer break.
 - Sub Graphs that contain references to non-existing Sub Graphs no longer break the Sub Graph Importer.
@@ -415,7 +424,7 @@ The version number for this package has increased due to a version update of a r
 - The `Is Infinite` and `Is NaN` nodes now use `Vector 1` input ports, but the output remains the same.
 - You can no longer convert a node inside a `Sub Graph` into a `Sub Graph`, which previously caused errors.
 - The `Transformation Matrix` node's Inverse Projection and Inverse View Projection modes no longer produce errors.
-- The term `Shader Graph` is now captilized correctly in the Save Graph prompt. 
+- The term `Shader Graph` is now captilized correctly in the Save Graph prompt.
 
 ## [5.2.0] - 2018-11-27
 ### Added
@@ -450,7 +459,7 @@ The version number for this package has increased due to a version update of a r
 - Corrected some instances of incorrect port dimensions on several nodes.
 - `Scene Depth` and `Scene Color` nodes now work in single pass stereo in Lightweight Render Pipeline.
 - `Channel Mask` node controls are now aligned correctly.
-- In Lightweight Render Pipeline, Pre-multiply surface type now matches the Lit shader. 
+- In Lightweight Render Pipeline, Pre-multiply surface type now matches the Lit shader.
 - Non-exposed properties in the blackboard no longer have a green dot next to them.
 - Default reference name for shader properties are now serialized. You cannot change them after initial creation.
 - When you save Shader Graph and Sub Graph files, they're now automatically checked out on version control.

--- a/com.unity.shadergraph/Editor/Generation/Processors/ShaderStringBuilder.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/ShaderStringBuilder.cs
@@ -31,6 +31,7 @@ namespace UnityEditor.ShaderGraph
         List<ShaderStringMapping> m_Mappings;
 
         const string k_IndentationString = "    ";
+        const string k_NewLineString = "\n";
 
         internal AbstractMaterialNode currentNode
         {
@@ -67,7 +68,7 @@ namespace UnityEditor.ShaderGraph
 
         public void AppendNewLine()
         {
-            m_StringBuilder.AppendLine();
+            m_StringBuilder.Append(k_NewLineString);
         }
 
         public void AppendLine(string value)
@@ -177,7 +178,7 @@ namespace UnityEditor.ShaderGraph
         {
             if(m_ScopeStack.Count == 0)
                 return;
-            
+
             switch (m_ScopeStack.Pop())
             {
                 case ScopeType.Indent:

--- a/com.unity.shadergraph/Editor/Serialization/MultiJsonInternal.cs
+++ b/com.unity.shadergraph/Editor/Serialization/MultiJsonInternal.cs
@@ -224,7 +224,7 @@ namespace UnityEditor.ShaderGraph.Serialization
                 SetOverrideActiveState(ActiveState.ExplicitInactive, false);
                 SetActive(false, false);
             }
-            public UnknownNodeType(string jsonData) 
+            public UnknownNodeType(string jsonData)
             {
                 this.jsonData = jsonData;
                 isValid = false;
@@ -524,11 +524,14 @@ namespace UnityEditor.ShaderGraph.Serialization
                     // We sort everything else by ID to consistently maintain positions in the output
                     x.Item1.CompareTo(y.Item1));
 
+
+                const string k_NewLineString = "\n";
                 var sb = new StringBuilder();
                 foreach (var (id, json) in idJsonList)
                 {
-                    sb.AppendLine(json);
-                    sb.AppendLine();
+                    sb.Append(json);
+                    sb.Append(k_NewLineString);
+                    sb.Append(k_NewLineString);
                 }
 
                 return sb.ToString();


### PR DESCRIPTION
    The system call uses the local environment newline which can cause
    problems when sharing shadergraph files between Windows and other
    systems.  This makes the newline explicitly "\n".
---
### Purpose of this PR
Fix for:
[https://fogbugz.unity3d.com/f/cases/1286430/](url)

New ShaderGraph shaders created on Windows had CR/LF line endings for certain scopes.  This could cause file difference detection to engage on an unmodified shader file when shared between users on different platforms.  This PR fixes that.

---
### Testing status
I created new shadergraph shaders on a Mac, and Chris could load them on Windows and show no differences after loading.
Chris was also able to create a new shader on Windows with no "\n" (CR) characters.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
