### PR TITLE
Broken Master Preview link in TOC fix

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed an issue where nodes with ports on one side would appear incorrectly on creation [1262050]
+- Fixed a broken link in the TOC to Main Preview (was Master Preview) [?]
 
 ## [10.3.0] - 2020-11-06
 
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed an issue where shaders could be generated with CR/LF ("\r\n") instead of just LF ("\n") line endings [1286430]
+-
 
 ## [10.2.0] - 2020-10-19
 


### PR DESCRIPTION
Master Preview changed to Main Preview from 9 onwards. However TOC link and name was not updated. This is now fixed. PR 2685 Commit

# **Please read;**
## **PR Workflow for the Graphics repository:**
* **All PRs must be opened as draft initially**
* Reviewers can be added while the PR is still in draft
* The PR can be marked as “Ready for Review” once the reviewers have confirmed that **no more changes are needed**
* Tests will start automatically after the PR is marked as “Ready for Review”
* **Do not use [skip ci]** - this can break some of our tooling
* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [N/A ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ N/A this is the changelog] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [N/A ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ N/A] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
I added a change to the changelog for PR https://github.com/Unity-Technologies/Graphics/pull/2685

---
### Testing status
N/A

---
### Comments to reviewers
I'll fix the number when I have it, only then merge the PR.
