### PR TITLE
[ShaderGraph] Removing "public" API that was never meant to be public

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Attributes/InspectableAttribute.cs
+++ b/com.unity.shadergraph/Editor/Data/Attributes/InspectableAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace UnityEditor.ShaderGraph.Drawing
 {
     [AttributeUsage(AttributeTargets.Property)]
-    public class InspectableAttribute : Attribute
+    internal class InspectableAttribute : Attribute
     {
         // String value to use in the Property name TextLabel
         public string labelName { get; private set; }

--- a/com.unity.shadergraph/Editor/Data/Attributes/SGPropertyDrawerAttribute.cs
+++ b/com.unity.shadergraph/Editor/Data/Attributes/SGPropertyDrawerAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace UnityEditor.ShaderGraph.Drawing
 {
     [AttributeUsage(AttributeTargets.Class)]
-    public class SGPropertyDrawerAttribute : Attribute
+    internal class SGPropertyDrawerAttribute : Attribute
     {
         public Type propertyType { get; private set; }
 

--- a/com.unity.shadergraph/Editor/Data/Enumerations/Precision.cs
+++ b/com.unity.shadergraph/Editor/Data/Enumerations/Precision.cs
@@ -7,7 +7,7 @@ namespace UnityEditor.ShaderGraph.Internal
         Half,
     }
 
-    public enum ConcretePrecision
+    internal enum ConcretePrecision
     {
         Single,
         Half,

--- a/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Internal
 {
     [Serializable]
-    public abstract class AbstractShaderProperty : ShaderInput
+    internal abstract class AbstractShaderProperty : ShaderInput
     {
         public abstract PropertyType propertyType { get; }
 
@@ -154,7 +154,7 @@ namespace UnityEditor.ShaderGraph.Internal
         }
     }
 
-    public enum HLSLType
+    internal enum HLSLType
     {
         // value types
         _float,

--- a/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/AbstractShaderProperty.cs
@@ -112,7 +112,7 @@ namespace UnityEditor.ShaderGraph.Internal
     }
 
     [Serializable]
-    public abstract class AbstractShaderProperty<T> : AbstractShaderProperty
+    internal abstract class AbstractShaderProperty<T> : AbstractShaderProperty
     {
         [SerializeField]
         T m_Value;

--- a/com.unity.shadergraph/Editor/Data/Graphs/BooleanShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/BooleanShaderProperty.cs
@@ -9,7 +9,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [Serializable]
     [FormerName("UnityEditor.ShaderGraph.BooleanShaderProperty")]
     [BlackboardInputInfo(20)]
-    public sealed class BooleanShaderProperty : AbstractShaderProperty<bool>
+    internal sealed class BooleanShaderProperty : AbstractShaderProperty<bool>
     {
         internal BooleanShaderProperty()
         {

--- a/com.unity.shadergraph/Editor/Data/Graphs/ColorShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/ColorShaderProperty.cs
@@ -8,7 +8,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [Serializable]
     [FormerName("UnityEditor.ShaderGraph.ColorShaderProperty")]
     [BlackboardInputInfo(10)]
-    public sealed class ColorShaderProperty : AbstractShaderProperty<Color>
+    internal sealed class ColorShaderProperty : AbstractShaderProperty<Color>
     {
         // 0 - original (broken color space)
         // 1 - fixed color space

--- a/com.unity.shadergraph/Editor/Data/Graphs/CubemapShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/CubemapShaderProperty.cs
@@ -8,7 +8,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [Serializable]
     [FormerName("UnityEditor.ShaderGraph.CubemapShaderProperty")]
     [BlackboardInputInfo(53)]
-    public sealed class CubemapShaderProperty : AbstractShaderProperty<SerializableCubemap>
+    internal sealed class CubemapShaderProperty : AbstractShaderProperty<SerializableCubemap>
     {
         internal CubemapShaderProperty()
         {

--- a/com.unity.shadergraph/Editor/Data/Graphs/GroupData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GroupData.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph
 {
     [Serializable]
-    public class GroupData : JsonObject
+    internal class GroupData : JsonObject
     {
         [SerializeField]
         string m_Title;

--- a/com.unity.shadergraph/Editor/Data/Graphs/SerializableCubemap.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SerializableCubemap.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Internal
 {
     [Serializable]
-    public sealed class SerializableCubemap : ISerializationCallbackReceiver
+    internal sealed class SerializableCubemap : ISerializationCallbackReceiver
     {
         [SerializeField]
         string m_SerializedCubemap;

--- a/com.unity.shadergraph/Editor/Data/Graphs/SerializableTexture.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SerializableTexture.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Internal
 {
     [Serializable]
-    public sealed class SerializableTexture : ISerializationCallbackReceiver
+    internal sealed class SerializableTexture : ISerializationCallbackReceiver
     {
         [SerializeField]
         string m_SerializedTexture;

--- a/com.unity.shadergraph/Editor/Data/Graphs/SerializableTextureArray.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SerializableTextureArray.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Internal
 {
     [Serializable]
-    public sealed class SerializableTextureArray : ISerializationCallbackReceiver
+    internal sealed class SerializableTextureArray : ISerializationCallbackReceiver
     {
         [SerializeField]
         string m_SerializedTexture;

--- a/com.unity.shadergraph/Editor/Data/Graphs/ShaderGraphRequirements.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/ShaderGraphRequirements.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Internal
 {
     [Serializable]
-    public struct ShaderGraphRequirements
+    internal struct ShaderGraphRequirements
     {
         [SerializeField] NeededCoordinateSpace m_RequiresNormal;
         [SerializeField] NeededCoordinateSpace m_RequiresBitangent;

--- a/com.unity.shadergraph/Editor/Data/Graphs/ShaderInput.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/ShaderInput.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace UnityEditor.ShaderGraph.Internal
 {
-    public abstract class ShaderInput : JsonObject
+    internal abstract class ShaderInput : JsonObject
     {
         [SerializeField]
         SerializableGuid m_Guid = new SerializableGuid();

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture2DArrayShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture2DArrayShaderProperty.cs
@@ -6,7 +6,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [Serializable]
     [FormerName("UnityEditor.ShaderGraph.Texture2DArrayShaderProperty")]
     [BlackboardInputInfo(51)]
-    public class Texture2DArrayShaderProperty : AbstractShaderProperty<SerializableTextureArray>
+    internal class Texture2DArrayShaderProperty : AbstractShaderProperty<SerializableTextureArray>
     {
         internal Texture2DArrayShaderProperty()
         {

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture2DShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture2DShaderProperty.cs
@@ -8,7 +8,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [Serializable]
     [FormerName("UnityEditor.ShaderGraph.TextureShaderProperty")]
     [BlackboardInputInfo(50)]
-    public sealed class Texture2DShaderProperty : AbstractShaderProperty<SerializableTexture>
+    internal sealed class Texture2DShaderProperty : AbstractShaderProperty<SerializableTexture>
     {
         public enum DefaultType { White, Black, Grey, Bump }
 

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture3DShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture3DShaderProperty.cs
@@ -6,7 +6,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [Serializable]
     [FormerName("UnityEditor.ShaderGraph.Texture3DShaderProperty")]
     [BlackboardInputInfo(52)]
-    public sealed class Texture3DShaderProperty : AbstractShaderProperty<SerializableTexture>
+    internal sealed class Texture3DShaderProperty : AbstractShaderProperty<SerializableTexture>
     {
         internal Texture3DShaderProperty()
         {

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
@@ -11,7 +11,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [FormerName("UnityEditor.ShaderGraph.FloatShaderProperty")]
     [FormerName("UnityEditor.ShaderGraph.Vector1ShaderProperty")]
     [BlackboardInputInfo(0, "Float")]
-    public sealed class Vector1ShaderProperty : AbstractShaderProperty<float>
+    internal sealed class Vector1ShaderProperty : AbstractShaderProperty<float>
     {
         internal Vector1ShaderProperty()
         {
@@ -176,7 +176,7 @@ namespace UnityEditor.ShaderGraph.Internal
         }
     }
 
-    public enum FloatType { Default, Slider, Integer, Enum }
+    internal enum FloatType { Default, Slider, Integer, Enum }
 
-    public enum EnumType { Enum, CSharpEnum, KeywordEnum, }
+    internal enum EnumType { Enum, CSharpEnum, KeywordEnum, }
 }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector2ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector2ShaderProperty.cs
@@ -7,7 +7,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [Serializable]
     [FormerName("UnityEditor.ShaderGraph.Vector2ShaderProperty")]
     [BlackboardInputInfo(1)]
-    public sealed class Vector2ShaderProperty : VectorShaderProperty
+    internal sealed class Vector2ShaderProperty : VectorShaderProperty
     {
         internal Vector2ShaderProperty()
         {

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector3ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector3ShaderProperty.cs
@@ -7,7 +7,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [Serializable]
     [FormerName("UnityEditor.ShaderGraph.Vector3ShaderProperty")]
     [BlackboardInputInfo(3)]
-    public sealed class Vector3ShaderProperty : VectorShaderProperty
+    internal sealed class Vector3ShaderProperty : VectorShaderProperty
     {
         internal Vector3ShaderProperty()
         {

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector4ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector4ShaderProperty.cs
@@ -7,7 +7,7 @@ namespace UnityEditor.ShaderGraph.Internal
     [Serializable]
     [FormerName("UnityEditor.ShaderGraph.Vector4ShaderProperty")]
     [BlackboardInputInfo(4)]
-    public sealed class Vector4ShaderProperty : VectorShaderProperty
+    internal sealed class Vector4ShaderProperty : VectorShaderProperty
     {
         internal Vector4ShaderProperty()
         {

--- a/com.unity.shadergraph/Editor/Data/Graphs/VectorShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/VectorShaderProperty.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Internal
 {
     [Serializable]
-    public abstract class VectorShaderProperty : AbstractShaderProperty<Vector4>
+    internal abstract class VectorShaderProperty : AbstractShaderProperty<Vector4>
     {
         internal override bool isExposable => true;
         internal override bool isRenamable => true;

--- a/com.unity.shadergraph/Editor/Data/Interfaces/IPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Data/Interfaces/IPropertyDrawer.cs
@@ -6,7 +6,7 @@ using UnityEngine.UIElements;
 namespace UnityEditor.ShaderGraph.Drawing
 {
     // Interface that should be implemented by any property drawer for the inspector view
-    public interface IPropertyDrawer
+    internal interface IPropertyDrawer
     {
         Action inspectorUpdateDelegate { get; set; }
 

--- a/com.unity.shadergraph/Editor/Data/Interfaces/NeededCoordinateSpace.cs
+++ b/com.unity.shadergraph/Editor/Data/Interfaces/NeededCoordinateSpace.cs
@@ -4,7 +4,7 @@ using System.Linq;
 namespace UnityEditor.ShaderGraph.Internal
 {
     [Flags]
-    public enum NeededCoordinateSpace
+    internal enum NeededCoordinateSpace
     {
         None = 0,
         Object = 1 << 0,
@@ -14,7 +14,7 @@ namespace UnityEditor.ShaderGraph.Internal
         AbsoluteWorld = 1 << 4
     }
 
-    public enum CoordinateSpace
+    internal enum CoordinateSpace
     {
         Object,
         View,
@@ -23,7 +23,7 @@ namespace UnityEditor.ShaderGraph.Internal
         AbsoluteWorld
     }
 
-    public enum InterpolatorType
+    internal enum InterpolatorType
     {
         Normal,
         BiTangent,
@@ -32,7 +32,7 @@ namespace UnityEditor.ShaderGraph.Internal
         Position
     }
 
-    public static class CoordinateSpaceExtensions
+    internal static class CoordinateSpaceExtensions
     {
         static int s_SpaceCount = Enum.GetValues(typeof(CoordinateSpace)).Length;
         static int s_InterpolatorCount = Enum.GetValues(typeof(InterpolatorType)).Length;

--- a/com.unity.shadergraph/Editor/Data/Legacy/IMasterNode1.cs
+++ b/com.unity.shadergraph/Editor/Data/Legacy/IMasterNode1.cs
@@ -1,6 +1,6 @@
 namespace UnityEditor.ShaderGraph.Legacy
 {
-    public interface IMasterNode1
+    internal interface IMasterNode1
     {
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ColorNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ColorNode.cs
@@ -7,7 +7,7 @@ using UnityEditor.ShaderGraph.Internal;
 
 namespace UnityEditor.ShaderGraph.Internal
 {
-    public enum ColorMode
+    internal enum ColorMode
     {
         Default,
         HDR

--- a/com.unity.shadergraph/Editor/Data/Nodes/RedirectNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/RedirectNode.cs
@@ -5,7 +5,7 @@ using UnityEngine.UIElements;
 
 namespace UnityEditor.ShaderGraph
 {
-    public class RedirectNode : Node
+    internal class RedirectNode : Node
     {
         public RedirectNode()
         {

--- a/com.unity.shadergraph/Editor/Data/Util/KeywordDependentCollection.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/KeywordDependentCollection.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace UnityEditor.ShaderGraph.Internal
 {
-    public static class KeywordDependentCollection
+    internal static class KeywordDependentCollection
     {
         public enum KeywordPermutationInstanceType
         {
@@ -24,7 +24,7 @@ namespace UnityEditor.ShaderGraph.Internal
         }
     }
 
-    public abstract class KeywordDependentCollection<TStorage, TAll, TAllPermutations, TForPermutation, TBase, TIInstance, TISet>
+    internal abstract class KeywordDependentCollection<TStorage, TAll, TAllPermutations, TForPermutation, TBase, TIInstance, TISet>
         where TAll : TISet
         where TAllPermutations : TISet
         where TForPermutation : TISet, TIInstance

--- a/com.unity.shadergraph/Editor/Data/Util/TextUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/TextUtil.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 
 namespace UnityEditor.ShaderGraph
 {
-    public static class TextUtil
+    internal static class TextUtil
     {
         public static string PascalToLabel(this string pascalString)
         {

--- a/com.unity.shadergraph/Editor/Data/Util/UvChannel.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/UvChannel.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace UnityEditor.ShaderGraph.Internal
 {
-    public enum UVChannel
+    internal enum UVChannel
     {
         UV0 = 0,
         UV1 = 1,

--- a/com.unity.shadergraph/Editor/Drawing/Colors/CustomColorData.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Colors/CustomColorData.cs
@@ -18,7 +18,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Colors
     }
 
     [Serializable]
-    public class CustomColorData : ISerializationCallbackReceiver
+    internal class CustomColorData : ISerializationCallbackReceiver
     {
         Dictionary<string, Color> m_CustomColors = new Dictionary<string, Color>();
         [SerializeField]

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/InspectorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/InspectorView.cs
@@ -163,7 +163,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector
         }
     }
 
-    public static class InspectorUtils
+    internal static class InspectorUtils
     {
         internal static void GatherInspectorContent(
             List<Type> propertyDrawerList,

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawerUtils.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawerUtils.cs
@@ -8,7 +8,7 @@ using UnityEditor.ShaderGraph.Internal;
 
 namespace UnityEditor.ShaderGraph.Drawing.Inspector
 {
-    public static class PropertyDrawerUtils
+    internal static class PropertyDrawerUtils
     {
         public static Label CreateLabel(string text, int indentLevel = 0, FontStyle fontStyle = FontStyle.Normal)
         {

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/AbstractMaterialNodePropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/AbstractMaterialNodePropertyDrawer.cs
@@ -18,7 +18,7 @@ namespace  UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
     }
 
     [SGPropertyDrawer(typeof(AbstractMaterialNode))]
-    public class AbstractMaterialNodePropertyDrawer : IPropertyDrawer, IGetNodePropertyDrawerPropertyData
+    internal class AbstractMaterialNodePropertyDrawer : IPropertyDrawer, IGetNodePropertyDrawerPropertyData
     {
         public Action inspectorUpdateDelegate { get; set; }
 

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/CustomFunctionNodePropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/CustomFunctionNodePropertyDrawer.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 namespace  UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
 {
     [SGPropertyDrawer(typeof(CustomFunctionNode))]
-    public class CustomFunctionNodePropertyDrawer : IPropertyDrawer, IGetNodePropertyDrawerPropertyData
+    internal class CustomFunctionNodePropertyDrawer : IPropertyDrawer, IGetNodePropertyDrawerPropertyData
     {
         Action m_setNodesAsDirtyCallback;
         Action m_updateNodeViewsCallback;

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GraphDataPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GraphDataPropertyDrawer.cs
@@ -14,7 +14,7 @@ using UnityEditor.ShaderGraph.Serialization;
 namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
 {
     [SGPropertyDrawer(typeof(GraphData))]
-    public class GraphDataPropertyDrawer : IPropertyDrawer
+    internal class GraphDataPropertyDrawer : IPropertyDrawer
     {
         public delegate void ChangeConcretePrecisionCallback(ConcretePrecision newValue);
         public delegate void PostTargetSettingsChangedCallback();

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/SampleVirtualTextureNodePropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/SampleVirtualTextureNodePropertyDrawer.cs
@@ -15,7 +15,7 @@ using UnityEngine.UIElements;
 namespace  UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
 {
     [SGPropertyDrawer(typeof(SampleVirtualTextureNode))]
-    public class SampleVirtualTextureNodePropertyDrawer : IPropertyDrawer
+    internal class SampleVirtualTextureNodePropertyDrawer : IPropertyDrawer
     {
         VisualElement CreateGUI(SampleVirtualTextureNode node, InspectableAttribute attribute,
             out VisualElement propertyVisualElement)

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/SubGraphOutputNodePropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/SubGraphOutputNodePropertyDrawer.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 namespace  UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
 {
     [SGPropertyDrawer(typeof(SubGraphOutputNode))]
-    public class SubGraphOutputNodePropertyDrawer : IPropertyDrawer
+    internal class SubGraphOutputNodePropertyDrawer : IPropertyDrawer
     {
         VisualElement CreateGUI(SubGraphOutputNode node, InspectableAttribute attribute,
             out VisualElement propertyVisualElement)

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/TabbedView/TabButton.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/TabbedView/TabButton.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-public class TabButton : VisualElement
+internal class TabButton : VisualElement
 {
     internal new class UxmlFactory : UxmlFactory<TabButton, UxmlTraits> {}
 

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/TabbedView/TabbedView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/TabbedView/TabbedView.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-public class TabbedView : VisualElement
+internal class TabbedView : VisualElement
 {
     public new class UxmlFactory : UxmlFactory<TabbedView, UxmlTraits> {}
 

--- a/com.unity.shadergraph/Editor/Drawing/SearchWindowAdapter.cs
+++ b/com.unity.shadergraph/Editor/Drawing/SearchWindowAdapter.cs
@@ -6,7 +6,7 @@ using UnityEditor.Searcher;
 
 namespace UnityEditor.ShaderGraph
 {
-    public class SearchWindowAdapter : SearcherAdapter
+    internal class SearchWindowAdapter : SearcherAdapter
     {
         readonly VisualTreeAsset m_DefaultItemTemplate;
         public override bool HasDetailsPanel => false;

--- a/com.unity.shadergraph/Editor/Drawing/Views/HlslFunctionView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/HlslFunctionView.cs
@@ -8,7 +8,7 @@ using UnityEditor.Graphing;
 namespace UnityEditor.ShaderGraph.Drawing
 {
     [Serializable]
-    public enum HlslSourceType { File, String };
+    internal enum HlslSourceType { File, String };
 
     internal class HlslFunctionView : VisualElement
     {

--- a/com.unity.shadergraph/Editor/Drawing/Views/IdentifierField.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/IdentifierField.cs
@@ -9,7 +9,7 @@ namespace UnityEditor.ShaderGraph.Drawing
         (variable name, function name, ...) this means
         no spaces, no funny characters, never starts with a number, ...
     */
-    public class IdentifierField : UIElements.TextValueField<string>
+    internal class IdentifierField : UIElements.TextValueField<string>
     {
         IdentifierInput tsInput => (IdentifierInput)textInputBase;
 

--- a/com.unity.shadergraph/Editor/Generation/Controls.cs
+++ b/com.unity.shadergraph/Editor/Generation/Controls.cs
@@ -9,12 +9,12 @@ namespace UnityEditor.ShaderGraph
     // All MaterialSlot types required by a BlockFieldDescriptor need a matching Control here.
     // We also need a corresponding case in BlockNode.AddSlot for each control.
 
-    public interface IControl
+    internal interface IControl
     {
         ShaderGraphRequirements GetRequirements();
     }
 
-    public class PositionControl : IControl
+    internal class PositionControl : IControl
     {
         public CoordinateSpace space { get; private set; }
 
@@ -29,7 +29,7 @@ namespace UnityEditor.ShaderGraph
         }
     }
 
-    public class NormalControl : IControl
+    internal class NormalControl : IControl
     {
         public CoordinateSpace space { get; private set; }
 
@@ -44,7 +44,7 @@ namespace UnityEditor.ShaderGraph
         }
     }
 
-    public class TangentControl : IControl
+    internal class TangentControl : IControl
     {
         public CoordinateSpace space { get; private set; }
 
@@ -59,7 +59,7 @@ namespace UnityEditor.ShaderGraph
         }
     }
 
-    public class ColorControl : IControl
+    internal class ColorControl : IControl
     {
         public Color value { get; private set; }
         public bool hdr { get; private set; }
@@ -76,7 +76,7 @@ namespace UnityEditor.ShaderGraph
         }
     }
 
-    public class ColorRGBAControl : IControl
+    internal class ColorRGBAControl : IControl
     {
         public Color value { get; private set; }
 
@@ -91,7 +91,7 @@ namespace UnityEditor.ShaderGraph
         }
     }
 
-    public class FloatControl : IControl
+    internal class FloatControl : IControl
     {
         public float value { get; private set; }
 
@@ -106,7 +106,7 @@ namespace UnityEditor.ShaderGraph
         }
     }
 
-    public class Vector2Control : IControl
+    internal class Vector2Control : IControl
     {
         public Vector2 value { get; private set; }
 
@@ -121,7 +121,7 @@ namespace UnityEditor.ShaderGraph
         }
     }
 
-    public class Vector3Control : IControl
+    internal class Vector3Control : IControl
     {
         public Vector3 value { get; private set; }
 

--- a/com.unity.shadergraph/Editor/Generation/Controls.cs
+++ b/com.unity.shadergraph/Editor/Generation/Controls.cs
@@ -136,7 +136,7 @@ namespace UnityEditor.ShaderGraph
         }
     }
 
-    public class VertexColorControl : IControl
+    internal class VertexColorControl : IControl
     {
         public Color value { get; private set; }
 

--- a/com.unity.shadergraph/Editor/Generation/Enumerations/PropertyType.cs
+++ b/com.unity.shadergraph/Editor/Generation/Enumerations/PropertyType.cs
@@ -1,7 +1,7 @@
 namespace UnityEditor.ShaderGraph.Internal
 {
     [GenerationAPI]
-    public enum PropertyType
+    internal enum PropertyType
     {
         Color,
         Texture2D,

--- a/com.unity.shadergraph/Editor/Generation/GraphCode.cs
+++ b/com.unity.shadergraph/Editor/Generation/GraphCode.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace UnityEditor.ShaderGraph.Internal
 {
-    public struct GraphCode
+    internal struct GraphCode
     {
         public string code { get; internal set; }
         public ShaderGraphRequirements requirements { get; internal set; }

--- a/com.unity.shadergraph/Editor/Generation/OutputMetadata.cs
+++ b/com.unity.shadergraph/Editor/Generation/OutputMetadata.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Internal
 {
     [Serializable]
-    public struct OutputMetadata
+    internal struct OutputMetadata
     {
         [SerializeField]
         int m_Index;

--- a/com.unity.shadergraph/Editor/Generation/ShaderGraphVfxAsset.cs
+++ b/com.unity.shadergraph/Editor/Generation/ShaderGraphVfxAsset.cs
@@ -8,13 +8,13 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Internal
 {
     [Serializable]
-    public struct TextureInfo
+    internal struct TextureInfo
     {
         public string name;
         public Texture texture;
     }
 
-    public sealed class ShaderGraphVfxAsset : ScriptableObject, ISerializationCallbackReceiver
+    internal sealed class ShaderGraphVfxAsset : ScriptableObject, ISerializationCallbackReceiver
     {
         private class ShaderGraphVfxAssetData : JsonObject
         {

--- a/com.unity.shadergraph/Editor/Serialization/FakeJsonObject.cs
+++ b/com.unity.shadergraph/Editor/Serialization/FakeJsonObject.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Serialization
 {
     [Serializable]
-    public class FakeJsonObject
+    internal class FakeJsonObject
     {
         [SerializeField]
         string m_Type;

--- a/com.unity.shadergraph/Editor/Serialization/JsonObject.cs
+++ b/com.unity.shadergraph/Editor/Serialization/JsonObject.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph.Serialization
 {
     [Serializable]
-    public class JsonObject : ISerializationCallbackReceiver
+    internal class JsonObject : ISerializationCallbackReceiver
     {
         public virtual int latestVersion { get; } = 0;
 


### PR DESCRIPTION
### Purpose of this PR
ShaderGraph makes public a lot of it's internal structures, that were never meant to be public API; but were made public for the purposes of allowing HDRP and URP packages to use them.

We marked a lot of it by putting it in the "Internal" namespace, but now with the documentation requirements we can't keep them public.

This PR converts them all to "Internal" and instead makes use of the "InternalsVisibleTo" construct to allow HDRP and URP to continue using them.

I used this list to find all of the public API points:   https://docs.google.com/spreadsheets/d/1U9ai0fAF9KTI5yTIky5fn_nLOUndxIUzhrJZdYnlzao/edit#gid=1243794439

---
### Testing status
Tested that ShaderGraph still opens (PC, windows) on a selection of different graphs, and standard lit and unlit shadergraphs still operate in HDRP and URP.

Running FULL Yamato pass:
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/sg%252Fclose-the-gates/.yamato%252F_abv.yml%2523all_project_ci_trunk/4878369/job/pipeline

master equivalent:


---
### Comments to reviewers
Notes for the reviewers you have assigned.
