### PR TITLE
Bugfix 1304162: When importing a shader graph make sure to log any er…

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Newly created properties and keywords will no longer use obfuscated GUID-based reference names in the shader code [1300484]
 - Fixed ParallaxMapping node compile issue on GLES2
 - Fixed a selection bug with block nodes after changing tabs [1312222]
+- Fixed some shader graph compiler errors not being logged [1304162].
 
 ## [10.3.0] - 2020-11-03
 

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -267,17 +267,17 @@ Shader ""Hidden/GraphErrorShader2""
             bool anyNodeHasError = graph.messageManager.nodeMessagesChanged && graph.messageManager.AnyError();
             // Find the first compiler message that's an error
             int firstShaderUtilErrorIndex = -1;
-            if(messages != null)
+            if (messages != null)
                 firstShaderUtilErrorIndex = Array.FindIndex(messages, m => (m.severity == Rendering.ShaderCompilerMessageSeverity.Error));
 
             // Display only one message. Bias towards shader compiler messages over node messages and within that bias errors over warnings.
             if (firstShaderUtilErrorIndex != -1)
                 MessageManager.Log(path, messages[firstShaderUtilErrorIndex], shader);
-            else if(anyNodeHasError)
+            else if (anyNodeHasError)
                 Debug.LogError($"Test Shader Graph at {path} has at least one error.");
-            else if(messages.Length != 0)
+            else if (messages.Length != 0)
                 MessageManager.Log(path, messages[0], shader);
-            else if(graph.messageManager.nodeMessagesChanged)
+            else if (graph.messageManager.nodeMessagesChanged)
                 Debug.LogWarning($"Test Shader Graph at {path} has at least one warning.");
         }
 

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -274,11 +274,11 @@ Shader ""Hidden/GraphErrorShader2""
             if (firstShaderUtilErrorIndex != -1)
                 MessageManager.Log(path, messages[firstShaderUtilErrorIndex], shader);
             else if (anyNodeHasError)
-                Debug.LogError($"Test Shader Graph at {path} has at least one error.");
+                Debug.LogError($"Shader Graph at {path} has at least one error.");
             else if (messages.Length != 0)
                 MessageManager.Log(path, messages[0], shader);
             else if (graph.messageManager.nodeMessagesChanged)
-                Debug.LogWarning($"Test Shader Graph at {path} has at least one warning.");
+                Debug.LogWarning($"Shader Graph at {path} has at least one warning.");
         }
 
         internal static string GetShaderText(string path, out List<PropertyCollector.TextureInfo> configuredTextures, AssetCollection assetCollection, GraphData graph)

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -175,6 +175,15 @@ Shader ""Hidden/GraphErrorShader2""
                     }
                 }
 
+                if (ShaderUtil.ShaderHasError(shader))
+                {
+                    var messages = ShaderUtil.GetShaderMessages(shader);
+                    if (messages.Length > 0)
+                    {
+                        MessageManager.Log(path, messages[0], shader);
+                    }
+                }
+
                 EditorMaterialUtility.SetShaderDefaults(
                     shader,
                     configuredTextures.Where(x => x.modifiable).Select(x => x.name).ToArray(),

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -175,6 +175,8 @@ Shader ""Hidden/GraphErrorShader2""
                     }
                 }
 
+                // Temp fix to make sure all errors are caught and displayed. Currently this will log an error on every save,
+                // but it's better than not display anything. Long-term this should be improved.
                 if (ShaderUtil.ShaderHasError(shader))
                 {
                     var messages = ShaderUtil.GetShaderMessages(shader);

--- a/com.unity.shadergraph/Editor/Util/MessageManager.cs
+++ b/com.unity.shadergraph/Editor/Util/MessageManager.cs
@@ -156,6 +156,19 @@ namespace UnityEditor.Graphing.Util
             }
         }
 
+        public static void Log(string path, ShaderMessage message, Object context)
+        {
+            var errString = $"{message.severity} in Graph at {path}: {message.message}";
+            if (message.severity == ShaderCompilerMessageSeverity.Error)
+            {
+                Debug.LogError(errString, context);
+            }
+            else
+            {
+                Debug.LogWarning(errString, context);
+            }
+        }
+
         public bool AnyError()
         {
             foreach (var messages in m_Messages.Values)

--- a/com.unity.shadergraph/Editor/Util/MessageManager.cs
+++ b/com.unity.shadergraph/Editor/Util/MessageManager.cs
@@ -158,7 +158,7 @@ namespace UnityEditor.Graphing.Util
 
         public static void Log(string path, ShaderMessage message, Object context)
         {
-            var errString = $"{message.severity} in Graph at {path}: {message.message}";
+            var errString = $"{message.severity} in Graph at {path} on line {message.line}: {message.message}";
             if (message.severity == ShaderCompilerMessageSeverity.Error)
             {
                 Debug.LogError(errString, context);


### PR DESCRIPTION
…rors as some were getting dropped.

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Some errors in shader graph weren't getting reported at all. These errors aren't in a node so they can't be detected earlier. The errors can be fetched via ShaderUtils though, so on import grab and report the errors. 

---
### Testing status
Create a virtual texture property and give it an invalid layer reference name (via pasting not typing). On saving the shader graph this should print an error to the console.

---
### Comments to reviewers
Unfortunately, there doesn't seem to be a way to limit the console message so it only shows up once. That means this will print a message every time you hit save, but this seems better than not printing anything. In light of this, the preview was also left alone as it was deemed to be too noise if it logged every time.
