### PR TITLE
Bugfix 1287335: Enum keywords would fail when an entry was given a du…

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fixed the Custom Editor GUI field in the Graph settings that was ignored.
 - Node included HLSL files are now tracked more robustly, so they work after file moves and renames [1301915] (https://issuetracker.unity3d.com/product/unity/issues/guid/1301915/)
+- Prevent users from setting enum keywords with duplicate reference names and invalid characters [1287335]
 - Fixed a bug where old preview property values would be used for node previews after an undo operation.
 - Clean up console error reporting from node shader compilation so errors are reported in the graph rather than the Editor console [1296291] (https://issuetracker.unity3d.com/product/unity/issues/guid/1296291/)
 - Fixed treatment of node precision in subgraphs, now allows subgraphs to switch precisions based on the subgraph node [1304050] (https://issuetracker.unity3d.com/issues/precision-errors-when-theres-a-precision-discrepancy-between-subgraphs-and-parent-graphs)

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderInputPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderInputPropertyDrawer.cs
@@ -23,7 +23,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
     class ShaderInputPropertyDrawer : IPropertyDrawer
     {
         internal delegate void ChangeExposedFieldCallback(bool newValue);
-        internal delegate  void ChangeDisplayNameCallback(string newValue);
+        internal delegate void ChangeDisplayNameCallback(string newValue);
         internal delegate void ChangeReferenceNameCallback(string newValue);
         internal delegate void ChangeValueCallback(object newValue);
         internal delegate void PreChangeValueCallback(string actionName);
@@ -54,6 +54,9 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
         Toggle exposedToggle;
         VisualElement keywordScopeField;
 
+        const string m_DisplayNameDisallowedPattern = "[^\\w_ ]";
+        const string m_ReferenceNameDisallowedPattern = @"(?:[^A-Za-z_0-9_])";
+
         public ShaderInputPropertyDrawer()
         {
             greyLabel = new GUIStyle(EditorStyles.label);
@@ -63,7 +66,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
         }
 
         GraphData graphData;
-        bool isSubGraph { get; set;  }
+        bool isSubGraph { get; set; }
         ChangeExposedFieldCallback _exposedFieldChangedCallback;
         Action _precisionChangedCallback;
         Action _keywordChangedCallback;
@@ -1211,18 +1214,27 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
                 Rect displayRect = new Rect(rect.x, rect.y, rect.width / 2, EditorGUIUtility.singleLineHeight);
                 var displayName = EditorGUI.DelayedTextField(displayRect, entry.displayName, EditorStyles.label);
                 //This is gross but I cant find any other way to make a DelayedTextField have a tooltip (tried doing the empty label on the field itself and it didnt work either)
-                EditorGUI.LabelField(displayRect, new GUIContent("", "Enum keyword display names can only use alphanumeric characters and `_`"));
+                EditorGUI.LabelField(displayRect, new GUIContent("", "Enum keyword display names can only use alphanumeric characters, whitespace and `_`"));
                 var referenceName = EditorGUI.TextField(new Rect(rect.x + rect.width / 2, rect.y, rect.width / 2, EditorGUIUtility.singleLineHeight), entry.referenceName,
                     keyword.isBuiltIn ? EditorStyles.label : greyLabel);
 
-                displayName = GetDuplicateSafeDisplayName(entry.id, displayName);
-                referenceName = GetDuplicateSafeReferenceName(entry.id, displayName.ToUpper());
-
                 if (EditorGUI.EndChangeCheck())
                 {
-                    keyword.entries[index] = new KeywordEntry(index + 1, displayName, referenceName);
+                    displayName = GetSanitizedDisplayName(displayName);
+                    referenceName = GetSanitizedReferenceName(displayName.ToUpper());
+                    var duplicateIndex = FindDuplicateReferenceNameIndex(entry.id, referenceName);
+                    if (duplicateIndex != -1)
+                    {
+                        var duplicateEntry = ((KeywordEntry)m_KeywordReorderableList.list[duplicateIndex]);
+                        Debug.LogWarning($"Display name '{displayName}' will create the same reference name '{referenceName}' as entry {duplicateIndex + 1} with display name '{duplicateEntry.displayName}'.");
+                    }
+                    else if (string.IsNullOrWhiteSpace(displayName))
+                        Debug.LogWarning("Invalid display name. Display names cannot be empty or all whitespace.");
+                    else if (int.TryParse(displayName, out int intVal) || float.TryParse(displayName, out float floatVal))
+                        Debug.LogWarning("Invalid display name. Display names cannot be valid integer or floating point numbers.");
+                    else
+                        keyword.entries[index] = new KeywordEntry(index + 1, displayName, referenceName);
 
-                    // Rebuild();
                     this._postChangeValueCallback(true);
                 }
             };
@@ -1291,8 +1303,9 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
             if (index <= 0)
                 return; // Error has already occured, don't attempt to add this entry.
 
-            var displayName = GetDuplicateSafeDisplayName(index, "New");
-            var referenceName = GetDuplicateSafeReferenceName(index, "NEW");
+            var displayName = "New";
+            var referenceName = "NEW";
+            GetDuplicateSafeEnumNames(index, "New", out displayName, out referenceName);
 
             // Add new entry
             keyword.entries.Add(new KeywordEntry(index, displayName, referenceName));
@@ -1334,14 +1347,57 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
         {
             name = name.Trim();
             var entryList = m_KeywordReorderableList.list as List<KeywordEntry>;
-            return GraphUtil.SanitizeName(entryList.Where(p => p.id != id).Select(p => p.displayName), "{0} ({1})", name, "[^\\w_#() .]");
+            return GraphUtil.SanitizeName(entryList.Where(p => p.id != id).Select(p => p.displayName), "{0} ({1})", name, m_DisplayNameDisallowedPattern);
+        }
+
+        public string GetDuplicateSafeEnumDisplayName(int id, string name)
+        {
+            name = name.Trim();
+            var entryList = m_KeywordReorderableList.list as List<KeywordEntry>;
+            return GraphUtil.SanitizeName(entryList.Where(p => p.id != id).Select(p => p.displayName), "{0} {1}", name, m_DisplayNameDisallowedPattern);
+        }
+
+        void GetDuplicateSafeEnumNames(int id, string name, out string displayName, out string referenceName)
+        {
+            name = name.Trim();
+            // Get de-duplicated display and reference names
+            displayName = GetDuplicateSafeEnumDisplayName(id, name);
+            referenceName = GetDuplicateSafeReferenceName(id, displayName.ToUpper());
+            // Check when the simple reference name should be for the display name.
+            // If these don't match then there will be a desync which causes the enum entry to not work.
+            // An example where this happens is ["new 1", "NEW_1"] already exists.
+            // The display name "New_1" is added.
+            // This new display name doesn't exist, but it finds the reference name of "NEW_1" already exists so we get the pair ["New_1", "NEW_2"] which is invalid.
+            // The easiest fix in this case is to just use the safe reference name as the new display name which is guaranteed to be unique.
+            var simpleReferenceName = Regex.Replace(displayName.ToUpper(), m_ReferenceNameDisallowedPattern, "_");
+            if (referenceName != simpleReferenceName)
+                displayName = referenceName;
+        }
+
+        string GetSanitizedDisplayName(string name)
+        {
+            name = name.Trim();
+            return Regex.Replace(name, m_DisplayNameDisallowedPattern, "_");
         }
 
         public string GetDuplicateSafeReferenceName(int id, string name)
         {
             name = name.Trim();
             var entryList = m_KeywordReorderableList.list as List<KeywordEntry>;
-            return GraphUtil.SanitizeName(entryList.Where(p => p.id != id).Select(p => p.referenceName), "{0}_{1}", name, @"(?:[^A-Za-z_0-9_])");
+            return GraphUtil.SanitizeName(entryList.Where(p => p.id != id).Select(p => p.referenceName), "{0}_{1}", name, m_ReferenceNameDisallowedPattern);
         }
+
+        string GetSanitizedReferenceName(string name)
+        {
+            name = name.Trim();
+            return Regex.Replace(name, m_ReferenceNameDisallowedPattern, "_");
+        }
+
+        int FindDuplicateReferenceNameIndex(int id, string referenceName)
+        {
+            var entryList = m_KeywordReorderableList.list as List<KeywordEntry>;
+            return entryList.FindIndex(entry => entry.id != id && entry.referenceName == referenceName);
+        }
+
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderInputPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/ShaderInputPropertyDrawer.cs
@@ -1398,6 +1398,5 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
             var entryList = m_KeywordReorderableList.list as List<KeywordEntry>;
             return entryList.FindIndex(entry => entry.id != id && entry.referenceName == referenceName);
         }
-
     }
 }


### PR DESCRIPTION
…plicate name that differed only by case. In addition there were various symbols that could be used that would break enum keywords due to how the material enum property editor sanitized display names.

https://fogbugz.unity3d.com/f/cases/1287335/

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Originally the bug was that giving two enum keywords the same display name with different cases would make the keyword not function properly.

After digging deeper, the bigger problem is that the material property editor uses the display name to enable the keyword, since the names didn't match (e.g. `A(1)` vs. `A_1_`) the keyword would never get set. This was the root cause with the duplicate names as one would have a display name of `a` but a reference name of `A_1`.

To fix this, enum keyword display names are now sanitized to match the same rules that the material editor expects, this way the same reference name is looked up. That is only allowing alpha numeric, spaces, and underscores.

---
### Testing status
- [x] Tested enums with duplicate display names: [`A`, `a`]
- [x] Partially invalid display names: `A(1)`
- [x] Empty display names: `""`
- [x] Whitespace display names: `" "`

---
### Comments to reviewers
While changing the rules for names could have the potential to break things, the rules are only changed for things that were already invalid hlsl identifiers. Anything that was valid before will have the same reference name and anything else didn't work.

Also, during investigation, I determined that display names that were empty or completely white space would break things. In this case, one entry would be missing (e.g. if you make: ["A", "", "C"] then what's displayed is ["A", "C"]).
