### PR TITLE
Fixed an unhelpful error message when custom function nodes don't have a valid file

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where property deduplication was failing and spamming errors [1317809] (https://issuetracker.unity3d.com/issues/console-error-when-adding-a-sample-texture-operator-when-a-sampler-state-property-is-present-in-blackboard)
 - Fixed a bug where synchronously compiling an unencountered shader variant for preview was causing long delays in graph updates [1323744]
 - Fixed a regression where custom function node file-included functions could not access shadergraph properties [1322467]
+- Fixed an unhelpful error message when custom function nodes didn't have a valid file [1323493].
 
 
 ## [11.0.0] - 2020-10-21

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -400,7 +400,7 @@ namespace UnityEditor.ShaderGraph
                 if (!string.IsNullOrEmpty(functionSource))
                 {
                     string path = AssetDatabase.GUIDToAssetPath(functionSource);
-                    if (!string.IsNullOrEmpty(path))
+                    if (!string.IsNullOrEmpty(path) && AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path) != null)
                     {
                         string extension = path.Substring(path.LastIndexOf('.'));
                         if (!s_ValidExtensions.Contains(extension))

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -51,8 +51,16 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
+        enum SourceFileStatus
+        {
+            Empty,        // No File specified
+            DoesNotExist, // Either file doesn't exist (empty name) or guid points to a non-existant file
+            Invalid,      // File exists but isn't of a valid type (such as wrong extension)
+            Valid
+        };
         public static string[] s_ValidExtensions = { ".hlsl", ".cginc" };
         const string k_InvalidFileType = "Source file is not a valid file type. Valid file extensions are .hlsl and .cginc";
+        const string k_MissingFile = "Source file does not exist. A valid .hlsl or .cginc file must be referenced";
         const string k_MissingOutputSlot = "A Custom Function Node must have at least one output slot";
 
         public CustomFunctionNode()
@@ -387,6 +395,7 @@ namespace UnityEditor.ShaderGraph
         {
             if (sourceType == HlslSourceType.File)
             {
+                SourceFileStatus fileStatus = SourceFileStatus.Empty; 
                 if (!string.IsNullOrEmpty(functionSource))
                 {
                     string path = AssetDatabase.GUIDToAssetPath(functionSource);
@@ -394,15 +403,20 @@ namespace UnityEditor.ShaderGraph
                     {
                         string extension = path.Substring(path.LastIndexOf('.'));
                         if (!s_ValidExtensions.Contains(extension))
-                        {
-                            owner.AddValidationError(objectId, k_InvalidFileType, ShaderCompilerMessageSeverity.Error);
-                        }
+                            fileStatus = SourceFileStatus.Invalid;
                         else
-                        {
-                            owner.ClearErrorsForNode(this);
-                        }
+                            fileStatus = SourceFileStatus.Valid;
                     }
+                    else
+                        fileStatus = SourceFileStatus.DoesNotExist;
                 }
+
+                if(fileStatus == SourceFileStatus.DoesNotExist)
+                    owner.AddValidationError(objectId, k_MissingFile, ShaderCompilerMessageSeverity.Error);
+                else if(fileStatus == SourceFileStatus.Invalid)
+                    owner.AddValidationError(objectId, k_InvalidFileType, ShaderCompilerMessageSeverity.Error);
+                else if(fileStatus == SourceFileStatus.Valid)
+                    owner.ClearErrorsForNode(this);
             }
             if (!this.GetOutputSlots<MaterialSlot>().Any())
             {

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -396,7 +396,7 @@ namespace UnityEditor.ShaderGraph
             bool hasAnyOutputs = this.GetOutputSlots<MaterialSlot>().Any();
             if (sourceType == HlslSourceType.File)
             {
-                SourceFileStatus fileStatus = SourceFileStatus.Empty; 
+                SourceFileStatus fileStatus = SourceFileStatus.Empty;
                 if (!string.IsNullOrEmpty(functionSource))
                 {
                     string path = AssetDatabase.GUIDToAssetPath(functionSource);
@@ -404,19 +404,23 @@ namespace UnityEditor.ShaderGraph
                     {
                         string extension = path.Substring(path.LastIndexOf('.'));
                         if (!s_ValidExtensions.Contains(extension))
+                        {
                             fileStatus = SourceFileStatus.Invalid;
+                        }
                         else
+                        {
                             fileStatus = SourceFileStatus.Valid;
+                        }
                     }
                     else
                         fileStatus = SourceFileStatus.DoesNotExist;
                 }
 
-                if(fileStatus == SourceFileStatus.DoesNotExist || (fileStatus == SourceFileStatus.Empty && hasAnyOutputs))
+                if (fileStatus == SourceFileStatus.DoesNotExist || (fileStatus == SourceFileStatus.Empty && hasAnyOutputs))
                     owner.AddValidationError(objectId, k_MissingFile, ShaderCompilerMessageSeverity.Error);
-                else if(fileStatus == SourceFileStatus.Invalid)
+                else if (fileStatus == SourceFileStatus.Invalid)
                     owner.AddValidationError(objectId, k_InvalidFileType, ShaderCompilerMessageSeverity.Error);
-                else if(fileStatus == SourceFileStatus.Valid)
+                else if (fileStatus == SourceFileStatus.Valid)
                     owner.ClearErrorsForNode(this);
             }
             if (!hasAnyOutputs)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -393,6 +393,7 @@ namespace UnityEditor.ShaderGraph
 
         public override void ValidateNode()
         {
+            bool hasAnyOutputs = this.GetOutputSlots<MaterialSlot>().Any();
             if (sourceType == HlslSourceType.File)
             {
                 SourceFileStatus fileStatus = SourceFileStatus.Empty; 
@@ -411,14 +412,14 @@ namespace UnityEditor.ShaderGraph
                         fileStatus = SourceFileStatus.DoesNotExist;
                 }
 
-                if(fileStatus == SourceFileStatus.DoesNotExist)
+                if(fileStatus == SourceFileStatus.DoesNotExist || (fileStatus == SourceFileStatus.Empty && hasAnyOutputs))
                     owner.AddValidationError(objectId, k_MissingFile, ShaderCompilerMessageSeverity.Error);
                 else if(fileStatus == SourceFileStatus.Invalid)
                     owner.AddValidationError(objectId, k_InvalidFileType, ShaderCompilerMessageSeverity.Error);
                 else if(fileStatus == SourceFileStatus.Valid)
                     owner.ClearErrorsForNode(this);
             }
-            if (!this.GetOutputSlots<MaterialSlot>().Any())
+            if (!hasAnyOutputs)
             {
                 owner.AddValidationError(objectId, k_MissingOutputSlot, ShaderCompilerMessageSeverity.Warning);
             }


### PR DESCRIPTION
Fix for https://fogbugz.unity3d.com/f/cases/1323493/

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
When a custom function node in a shader graph had a guid to a file that didn't exist it displayed an incomprehensible error. This fix clarifies that error by saying the file doesn't exist.

---
### Testing status
- [x] Tested the attached shader graph in the bug (file guid set but to an invalid file).


| Old | New |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/76977132/113050423-acabf700-9159-11eb-857c-65597bca1854.png) | ![image](https://user-images.githubusercontent.com/76977132/113048973-f7c50a80-9157-11eb-8811-4b89db9f4368.png) |

Validated old behavior as well:
- [x] Valid file has no errors
- [x] File guid is valid, but the extension is wrong displays an error (same behavior as before):

| Old | New |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/76977132/113051198-918db700-915a-11eb-83c2-5ce037552c7c.png) | ![image](https://user-images.githubusercontent.com/76977132/113049097-1aefba00-9158-11eb-8538-efd44fab7f58.png) |

- [x] Default custom function node (File guid is empty, no outputs). No error but a warning about no output slot. This isn't an error because it's not used in the graph so the node gets removed. This preserves old behavior.

| Old | New |
| ------------- | ------------- | 
| ![image](https://user-images.githubusercontent.com/76977132/113051318-b1bd7600-915a-11eb-86ee-901141ab16f2.png) | ![image](https://user-images.githubusercontent.com/76977132/113049695-cac52780-9158-11eb-9b29-209941dfc092.png) |

- [x] File guid is empty and there is an output slot. This is the same as the bug and used to display an incomprehensible message. New error: 

| Old | New |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/76977132/113051402-c4d04600-915a-11eb-8674-bd44baa704e6.png) | ![image](https://user-images.githubusercontent.com/76977132/113049807-ef210400-9158-11eb-9682-03a08068f3d8.png) |

---
### Comments to reviewers
Notes for the reviewers you have assigned.
