### PR TITLE
Fixed a bug where a node could be both vertex and fragment exclusive …

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where generated property reference names could conflict with Shader Graph reserved keywords [1328762] (https://issuetracker.unity3d.com/product/unity/issues/guid/1328762/)
 - Fixed a ShaderGraph issue where ObjectField focus and Node selections would both capture deletion commands [1313943].
 
+- Fixed a bug when a node was both vertex and fragment exclusive but could still be used causing a shader compiler error [1316128].
 
 
 ## [11.0.0] - 2020-10-21

--- a/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
+++ b/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
@@ -486,15 +486,12 @@ namespace UnityEditor.Graphing
             while (s_SlotStack.Any())
             {
                 var slot = s_SlotStack.Pop();
-                ShaderStage stage;
-                if (slot.stageCapability.TryGetShaderStage(out stage))
-                {
-                    // Clear any stages from the total capabilities that this slot doesn't support (e.g. if this is vertex, clear pixel)
-                    capabilities &= slot.stageCapability;
-                    // Can early out if we know nothing is compatible, otherwise we have to keep checking everything we can reach.
-                    if (capabilities == ShaderStageCapability.None)
-                        return capabilities;
-                }
+
+                // Clear any stages from the total capabilities that this slot doesn't support (e.g. if this is vertex, clear pixel)
+                capabilities &= slot.stageCapability;
+                // Can early out if we know nothing is compatible, otherwise we have to keep checking everything we can reach.
+                if (capabilities == ShaderStageCapability.None)
+                    return capabilities;
 
                 if (goingBackwards && slot.isInputSlot)
                 {

--- a/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
+++ b/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
@@ -482,12 +482,19 @@ namespace UnityEditor.Graphing
             var graph = initialSlot.owner.owner;
             s_SlotStack.Clear();
             s_SlotStack.Push(initialSlot);
+            ShaderStageCapability capabilities = ShaderStageCapability.All;
             while (s_SlotStack.Any())
             {
                 var slot = s_SlotStack.Pop();
                 ShaderStage stage;
                 if (slot.stageCapability.TryGetShaderStage(out stage))
-                    return slot.stageCapability;
+                {
+                    // Clear any stages from the total capabilities that this slot doesn't support (e.g. if this is vertex, clear pixel)
+                    capabilities &= slot.stageCapability;
+                    // Can early out if we know nothing is compatible, otherwise we have to keep checking everything we can reach.
+                    if (capabilities == ShaderStageCapability.None)
+                        return capabilities;
+                }
 
                 if (goingBackwards && slot.isInputSlot)
                 {
@@ -517,7 +524,7 @@ namespace UnityEditor.Graphing
                 }
             }
 
-            return ShaderStageCapability.All;
+            return capabilities;
         }
 
         public static string GetSlotDimension(ConcreteSlotValueType slotValue)

--- a/com.unity.shadergraph/Editor/Data/Nodes/ShaderStage.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/ShaderStage.cs
@@ -5,6 +5,7 @@ namespace UnityEditor.ShaderGraph
     [Flags]
     enum ShaderStageCapability
     {
+        None = 0,
         Vertex = 1 << 0,
         Fragment = 1 << 1,
         All = Vertex | Fragment


### PR DESCRIPTION
…but the editor let you use the node anyways, causing shader compiler errors. Fixes fogbugz 1316128

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1316128/

---
### Testing status
Made an add node, a sampled texture, and a vertex location node. Checked:
 - [x] Both plugged into add -> can't hook up to any block node
 - [x] Both plugged into add -> can plug into another add node (not hooked up to anything)
 - [x] Only texture plugged into add -> can't hook up to a vertex block node but can to a fragment
 - [x] Only vertex id plugged into add -> can't hook up to a fragment block node but can to a vertex
 - [x] Hook up output to a vertex block node -> can only connect an input to vertex id
 - [x] Hook up an output to a fragment block node -> can only connect an input to the texture sample

---
### Comments to reviewers
The issue was caused by the stage capability check terminating as soon as it found a node that wasn't "All", but this meant it wouldn't handle the none case.
