### PR TITLE
Fixed a ShaderGraph issue where the right click menu doesn't work whe…

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where users can't create multiple Boolean or Enum keywords on the blackboard. [1329021](https://issuetracker.unity3d.com/issues/shadergraph-cant-create-multiple-boolean-or-enum-keywords)
 - Fixed an issue where generated property reference names could conflict with Shader Graph reserved keywords [1328762] (https://issuetracker.unity3d.com/product/unity/issues/guid/1328762/)
 - Fixed a ShaderGraph issue where ObjectField focus and Node selections would both capture deletion commands [1313943].
+- Fixed a ShaderGraph issue where the right click menu doesn't work when a stack block node is selected [1320212].
 
 
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -197,12 +197,20 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         internal bool ResetSelectedBlockNodes()
         {
+            bool anyNodesWereReset = false;
             var selectedBlocknodes = selection.FindAll(e => e is MaterialNodeView && ((MaterialNodeView)e).node is BlockNode).Cast<MaterialNodeView>().ToArray();
             foreach (var mNode in selectedBlocknodes)
             {
                 var bNode = mNode.node as BlockNode;
                 var context = GetContext(bNode.contextData);
 
+                // Check if the node is currently floating (it's parent isn't the context view that owns it).
+                // If the node's not floating then the block doesn't need to be reset.
+                bool isFloating = mNode.parent != context;
+                if (!isFloating)
+                    continue;
+
+                anyNodesWereReset = true;
                 RemoveElement(mNode);
                 context.InsertBlock(mNode);
 
@@ -212,7 +220,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
             if (selectedBlocknodes.Length > 0)
                 graph.ValidateCustomBlockLimit();
-            return selectedBlocknodes.Length > 0;
+            return anyNodesWereReset;
         }
 
         public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)


### PR DESCRIPTION
…n a stack block node is selected. Fixes fogbugz 1320212.

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Fixing https://fogbugz.unity3d.com/f/cases/1320212/

The root issue was the logic to check for and handle floating block nodes was preventing the right click context menus. To get around this, I fixed block node resetting to only operate on floating blocks (one's whose parent wasn't the context view).

---
### Testing status
- [x] Select a block node then right-click on the graph in empty space. A context menu appears.
- [x] Select multiple block nodes then right-click on the graph in empty space. A context menu appears.
- [x] Select a non block node then right-click on the graph in empty space. A context menu appears.
- [x] Select a block node and drag it out. While still dragging middle click. The block nodes should go back into the stack. (This is what the code I had to fix was for).
- [x] Select a block node and drag it out. While still dragging right click. The block nodes should go back into the stack and no right-click menu appears.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
