### PR TITLE
Added a zero initialize to the packed structure for shader graph. The…

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a ShaderGraph issue where ObjectField focus and Node selections would both capture deletion commands [1313943].
 - Fixed a ShaderGraph issue where the right click menu doesn't work when a stack block node is selected [1320212].
 - Fixed a bug when a node was both vertex and fragment exclusive but could still be used causing a shader compiler error [1316128].
+- Fixed a ShaderGraph issue where a warning about an uninitialized value was being displayed on newly created graphs [1331377].
 - Fixed divide by zero warnings when using the Sample Gradient Node
 - Fixed the default dimension (1) for vector material slots so that it is consistent with other nodes. (https://issuetracker.unity3d.com/product/unity/issues/guid/1328756/)
 - Fixed reordering when renaming enum keywords. (https://issuetracker.unity3d.com/product/unity/issues/guid/1328761/)

--- a/com.unity.shadergraph/Editor/Generation/Processors/GenerationUtils.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/GenerationUtils.cs
@@ -202,6 +202,7 @@ namespace UnityEditor.ShaderGraph
             packBuilder.AppendLine("{");
             packBuilder.IncreaseIndent();
             packBuilder.AppendLine($"{packedStruct} output;");
+            packBuilder.AppendLine($"ZERO_INITIALIZE({packedStruct}, output);");
 
             unpackBuilder.AppendLine($"{shaderStruct.name} Unpack{shaderStruct.name} ({packedStruct} input)");
             unpackBuilder.AppendLine("{");


### PR DESCRIPTION
…re are some cases where certain variants add fields that won't get used but won't be initialized so it's easiest to clear out everything. Fixes fogbugz 1331377

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1331377/

---
### Testing status
Created a new shader graph and verified the warning was not present.

---
### Comments to reviewers
The issue was that some values on the interpolator struct were not always cleared out to zero depending on how variants were set.
