### PR TITLE
Fixed a bug where keyword nodes would get stuck highlighted if they w…

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where upgrading from an older version of ShaderGraph would cause Enum keywords to be not exposed [1332510]
 - Fixed an issue where a missing subgraph with a "Use Custom Binding" property would cause the parent graph to fail to load [1334621] (https://issuetracker.unity3d.com/issues/shadergraph-shadergraph-cannot-be-opened-if-containing-subgraph-with-custom-binding-that-has-been-deleted)
 - Fixed an issue where the ShaderGraph transform node would generate incorrect results when transforming a direction from view space to object space [1333781] (https://issuetracker.unity3d.com/product/unity/issues/guid/1333781/)
+- Fixed a ShaderGraph issue where keyword properties could get stuck highlighted when deleted [1333738].
 
 ## [11.0.0] - 2020-10-21
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -718,47 +718,42 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        void OnMouseHover(EventBase evt)
+        SGBlackboardRow GetAssociatedBlackboardRow()
         {
             var graphEditorView = GetFirstAncestorOfType<GraphEditorView>();
             if (graphEditorView == null)
-                return;
+                return null;
 
             var blackboardController = graphEditorView.blackboardController;
             if (blackboardController == null)
-                return;
+                return null;
 
-            // Keyword nodes should be highlighted when Blackboard entry is hovered
-            // TODO: Move to new NodeView type when keyword node has unique style
             if (node is KeywordNode keywordNode)
             {
-                var keywordRow = blackboardController.GetBlackboardRow(keywordNode.keyword);
-                if (keywordRow != null)
-                {
-                    if (evt.eventTypeId == MouseEnterEvent.TypeId())
-                    {
-                        keywordRow.AddToClassList("hovered");
-                    }
-                    else
-                    {
-                        keywordRow.RemoveFromClassList("hovered");
-                    }
-                }
+                return blackboardController.GetBlackboardRow(keywordNode.keyword);
             }
 
             if (node is DropdownNode dropdownNode)
             {
-                var dropdownRow = blackboardController.GetBlackboardRow(dropdownNode.dropdown);
-                if (dropdownRow != null)
+                return blackboardController.GetBlackboardRow(dropdownNode.dropdown);
+            }
+            return null;
+        }
+
+        void OnMouseHover(EventBase evt)
+        {
+            // Keyword/Dropdown nodes should be highlighted when Blackboard entry is hovered
+            // TODO: Move to new NodeView type when keyword node has unique style
+            var blackboardRow = GetAssociatedBlackboardRow();
+            if (blackboardRow != null)
+            {
+                if (evt.eventTypeId == MouseEnterEvent.TypeId())
                 {
-                    if (evt.eventTypeId == MouseEnterEvent.TypeId())
-                    {
-                        dropdownRow.AddToClassList("hovered");
-                    }
-                    else
-                    {
-                        dropdownRow.RemoveFromClassList("hovered");
-                    }
+                    blackboardRow.AddToClassList("hovered");
+                }
+                else
+                {
+                    blackboardRow.RemoveFromClassList("hovered");
                 }
             }
         }
@@ -791,6 +786,13 @@ namespace UnityEditor.ShaderGraph.Drawing
         {
             foreach (var portInputView in inputContainer.Query<PortInputView>().ToList())
                 portInputView.Dispose();
+
+            var propRow = GetAssociatedBlackboardRow();
+            // If this node view is deleted, remove highlighting from associated blackboard row
+            if (propRow != null)
+            {
+                propRow.RemoveFromClassList("hovered");
+            }
 
             node = null;
             userData = null;


### PR DESCRIPTION
…ere deleted while being hovered on. Fixes fogbugz 1333738

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1333738/
Keyword and dropdown properties would get stuck in a highlighted state if you deleted their nodes while they were hovered over. The fix was copied from the property node view which is to handle this on Dispose.

---
### Testing status
Tested locally by following the provided steps in the bug.
Tried this with the Bool Keyword, Enum Keyword, and Dropdown properties.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
