### PR TITLE
Fixed edge connections being replaced to not run the auto block remov…

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where an integer property would be exposed in the material inspector as a float [1330302](https://issuetracker.unity3d.com/product/unity/issues/guid/1330302/)
 - Fixed an issue where upgrading from an older version of ShaderGraph would cause Enum keywords to be not exposed [1332510]
 - Fixed an issue where a missing subgraph with a "Use Custom Binding" property would cause the parent graph to fail to load [1334621] (https://issuetracker.unity3d.com/issues/shadergraph-shadergraph-cannot-be-opened-if-containing-subgraph-with-custom-binding-that-has-been-deleted)
+- Fixed a ShaderGraph issue where unused blocks get removed on edge replacement [1334341].
 - Fixed an issue where the ShaderGraph transform node would generate incorrect results when transforming a direction from view space to object space [1333781] (https://issuetracker.unity3d.com/product/unity/issues/guid/1333781/)
 
 ## [11.0.0] - 2020-10-21

--- a/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
@@ -342,6 +342,10 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
+        // Some state has been changed that requires checking for the auto add/removal of blocks.
+        // This needs to be checked at a later point in time so actions like replace (remove + add) don't remove blocks.
+        internal bool checkAutoAddRemoveBlocks { get; set; }
+
         public void SetGraphDefaultPrecision(GraphPrecision newGraphDefaultPrecision)
         {
             if ((!isSubGraph) && (newGraphDefaultPrecision == GraphPrecision.Graph))
@@ -1150,11 +1154,10 @@ namespace UnityEditor.ShaderGraph
                 throw new ArgumentException("Trying to remove an edge that does not exist.", "e");
             m_Edges.Remove(e as Edge);
 
-            BlockNode b = null;
             AbstractMaterialNode input = e.inputSlot.node, output = e.outputSlot.node;
             if (input != null && ShaderGraphPreferences.autoAddRemoveBlocks)
             {
-                b = input as BlockNode;
+                checkAutoAddRemoveBlocks = true;
             }
 
             List<IEdge> inputNodeEdges;
@@ -1167,19 +1170,6 @@ namespace UnityEditor.ShaderGraph
 
             m_AddedEdges.Remove(e);
             m_RemovedEdges.Add(e);
-            if (b != null)
-            {
-                var activeBlockDescriptors = GetActiveBlocksForAllActiveTargets();
-                if (!activeBlockDescriptors.Contains(b.descriptor))
-                {
-                    var slot = b.FindSlot<MaterialSlot>(0);
-                    if (slot.IsUsingDefaultValue()) // TODO: How to check default value
-                    {
-                        RemoveNodeNoValidate(b);
-                        input = null;
-                    }
-                }
-            }
 
             if (reevaluateActivity)
             {

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -847,7 +847,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             {
                 node.UnregisterCallback(OnNodeChanged);
                 var nodeView = m_GraphView.nodes.ToList().OfType<IShaderNodeView>()
-                        .FirstOrDefault(p => p.node != null && p.node == node);
+                    .FirstOrDefault(p => p.node != null && p.node == node);
                 if (nodeView != null)
                 {
                     nodeView.Dispose();

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -679,40 +679,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             m_GroupHashSet.Clear();
 
-            foreach (var node in m_Graph.removedNodes)
-            {
-                node.UnregisterCallback(OnNodeChanged);
-                var nodeView = m_GraphView.nodes.ToList().OfType<IShaderNodeView>()
-                    .FirstOrDefault(p => p.node != null && p.node == node);
-                if (nodeView != null)
-                {
-                    nodeView.Dispose();
-
-                    if (node is BlockNode blockNode)
-                    {
-                        var context = m_GraphView.GetContext(blockNode.contextData);
-                        // blocknode may be floating and not actually in the stacknode's visual hierarchy.
-                        if (context.Contains(nodeView as Node))
-                        {
-                            context.RemoveElement(nodeView as Node);
-                        }
-                        else
-                        {
-                            m_GraphView.RemoveElement((Node)nodeView);
-                        }
-                    }
-                    else
-                    {
-                        m_GraphView.RemoveElement((Node)nodeView);
-                    }
-
-                    if (node.group != null)
-                    {
-                        var shaderGroup = m_GraphView.graphElements.ToList().OfType<ShaderGroup>().First(g => g.userData == node.group);
-                        m_GroupHashSet.Add(shaderGroup);
-                    }
-                }
-            }
+            HandleRemovedNodes();
 
             foreach (var noteData in m_Graph.removedNotes)
             {
@@ -859,9 +826,57 @@ namespace UnityEditor.ShaderGraph.Drawing
                 }
             }
 
+            // If we auto-remove blocks and something has happened to trigger a check (don't re-check constantly)
+            if (m_Graph.checkAutoAddRemoveBlocks && ShaderGraphPreferences.autoAddRemoveBlocks)
+            {
+                var activeBlocks = m_Graph.GetActiveBlocksForAllActiveTargets();
+                m_Graph.AddRemoveBlocksFromActiveList(activeBlocks);
+                m_Graph.checkAutoAddRemoveBlocks = false;
+                // We have to re-check any nodes views that need to be removed since we already handled this above. After leaving this function the states on m_Graph will be cleared so we'll lose track of removed blocks.
+                HandleRemovedNodes();
+            }
+
             UpdateBadges();
 
             RegisterGraphViewCallbacks();
+        }
+
+        void HandleRemovedNodes()
+        {
+            foreach (var node in m_Graph.removedNodes)
+            {
+                node.UnregisterCallback(OnNodeChanged);
+                var nodeView = m_GraphView.nodes.ToList().OfType<IShaderNodeView>()
+                        .FirstOrDefault(p => p.node != null && p.node == node);
+                if (nodeView != null)
+                {
+                    nodeView.Dispose();
+
+                    if (node is BlockNode blockNode)
+                    {
+                        var context = m_GraphView.GetContext(blockNode.contextData);
+                        // blocknode may be floating and not actually in the stacknode's visual hierarchy.
+                        if (context.Contains(nodeView as Node))
+                        {
+                            context.RemoveElement(nodeView as Node);
+                        }
+                        else
+                        {
+                            m_GraphView.RemoveElement((Node)nodeView);
+                        }
+                    }
+                    else
+                    {
+                        m_GraphView.RemoveElement((Node)nodeView);
+                    }
+
+                    if (node.group != null)
+                    {
+                        var shaderGroup = m_GraphView.graphElements.ToList().OfType<ShaderGroup>().First(g => g.userData == node.group);
+                        m_GroupHashSet.Add(shaderGroup);
+                    }
+                }
+            }
         }
 
         void UpdateBadges()


### PR DESCRIPTION
…al logic. Fixes fogbugz 1334341

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1334341/
Replacing the connection to block node that was considered inactive from the target's perspective would hide the node if "auto add or remove blocks" is enabled.

---
### Testing status
Make an empty graph and manually add the "Base Color" block.
Connect a node to the "Base Color" Block
- [x] Replace the connection to the block with itself. The block doesn't disappear.
- [x] Drag the edge off and back on the block node (in one click). The block doesn't disappear.
- [x] Replace the connection with the block with the connection from another node. The block doesn't disappear.
- [x] Convert the block to a property (e.g. with a color node). The block doesn't disappear.
- [x] Convert the block to a sub-graph (might require more than a single block like color -> add). The block doesn't disappear.
- [x] Delete the edge. The block disappears
- [x] Delete the node connected to the block. The block disappears.
- [x] Drag the edge connection to something else (not connected to the block). The block disappears.
- [x] Drag the edge off the block and release. The edge and the block disappear.

---
### Comments to reviewers
Added a catch all in `HandleGraphChanges` to remove any unused blocks after all operations so that things like replacing an edge wouldn't trigger the check in-between the remove and add. This was slightly tricky as it requires checking after edges are removed which is after block views are removed. This requires visited the block views a second time so that the views are properly deleted. In addition, a flag was added to GraphData so this path is only checked when an edge is removed.
