### PR TITLE
Missing keyword for SHADOW_VERY_HIGH in shadergraph

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/ShaderGraph/HDTarget.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/ShaderGraph/HDTarget.cs
@@ -1235,6 +1235,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 new KeywordEntry() { displayName = "Low", referenceName = "LOW" },
                 new KeywordEntry() { displayName = "Medium", referenceName = "MEDIUM" },
                 new KeywordEntry() { displayName = "High", referenceName = "HIGH" },
+                new KeywordEntry() { displayName = "VeryHigh", referenceName = "VERY_HIGH" },
             },
             stages = KeywordShaderStage.Fragment,
         };


### PR DESCRIPTION
Probably forgot to push the commit that added the keyword :/ As I remember checking this. 

Anyhow, a one liner fix. 