### PR TITLE
[10.x.x] Backport fix for shader graph sticky note copy pasting

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -12,6 +12,7 @@ The version number for this package has increased due to a version update of a r
 ### Fixed
 - Fixed an issue where an integer property would be exposed in the material inspector as a float [1332564]
 - Fixed an issue where the normal vector in object space would scale with the objects scale, causing non-normalized normal vectors
+- Fixed a bug in ShaderGraph where sticky notes couldn't be copied and pasted [1221042].
 
 ## [10.5.0] - 2021-04-19
 

--- a/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
@@ -1684,7 +1684,9 @@ namespace UnityEditor.ShaderGraph
                 position.y += 30;
 
                 StickyNoteData pastedStickyNote = new StickyNoteData(stickyNote.title, stickyNote.content, position);
-                if (groupMap.ContainsKey(stickyNote.group))
+                pastedStickyNote.textSize = stickyNote.textSize;
+                pastedStickyNote.theme = stickyNote.theme;
+                if (stickyNote.group != null && groupMap.ContainsKey(stickyNote.group))
                 {
                     pastedStickyNote.group = groupMap[stickyNote.group];
                 }

--- a/com.unity.shadergraph/Editor/Data/Graphs/StickyNoteData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/StickyNoteData.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph
 {
     [Serializable]
-    class StickyNoteData : JsonObject, IGroupItem
+    class StickyNoteData : JsonObject, IGroupItem, IRectInterface
     {
 
         [SerializeField]
@@ -51,6 +51,15 @@ namespace UnityEditor.ShaderGraph
         {
             get => m_Position;
             set => m_Position = value;
+        }
+
+        Rect IRectInterface.rect
+        {
+            get => position;
+            set
+            {
+                position = value;
+            }
         }
 
         [SerializeField]

--- a/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
@@ -12,7 +12,7 @@ using UnityEngine.Assertions;
 namespace UnityEditor.ShaderGraph
 {
     [Serializable]
-    abstract class AbstractMaterialNode : JsonObject, IGroupItem
+    abstract class AbstractMaterialNode : JsonObject, IGroupItem, IRectInterface
     {
         [SerializeField]
         JsonRef<GroupData> m_Group = null;
@@ -88,6 +88,17 @@ namespace UnityEditor.ShaderGraph
             {
                 m_DrawState = value;
                 Dirty(ModificationScope.Layout);
+            }
+        }
+
+        Rect IRectInterface.rect
+        {
+            get => drawState.position;
+            set
+            {
+                var state = drawState;
+                state.position = value;
+                drawState = state;
             }
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEditor.Graphing;
+using UnityEditor.ShaderGraph.Drawing.Colors;
+using UnityEditor.ShaderGraph.Internal;
+using UnityEditor.ShaderGraph.Drawing;
+using UnityEditor.ShaderGraph.Serialization;
+using UnityEngine.Assertions;
+using UnityEngine.Pool;
+
+namespace UnityEditor.ShaderGraph
+{
+    interface IRectInterface
+    {
+        Rect rect
+        {
+            get;
+            internal set;
+        }
+    }
+}

--- a/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs
@@ -1,14 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-using UnityEditor.Graphing;
-using UnityEditor.ShaderGraph.Drawing.Colors;
-using UnityEditor.ShaderGraph.Internal;
-using UnityEditor.ShaderGraph.Drawing;
-using UnityEditor.ShaderGraph.Serialization;
-using UnityEngine.Assertions;
-using UnityEngine.Pool;
 
 namespace UnityEditor.ShaderGraph
 {

--- a/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs.meta
+++ b/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7268d6a70314cc41bc1a502cd86b4f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.shadergraph/Editor/Drawing/Views/StickyNote.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/StickyNote.cs
@@ -208,7 +208,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             tpl.CloneTree(this);
 
-            capabilities = Capabilities.Movable | Capabilities.Deletable | Capabilities.Ascendable | Capabilities.Selectable;
+            capabilities = Capabilities.Movable | Capabilities.Deletable | Capabilities.Ascendable | Capabilities.Selectable | Capabilities.Copiable | Capabilities.Groupable;
 
             m_Title = this.Q<Label>(name: "title");
             if (m_Title != null)
@@ -243,6 +243,9 @@ namespace UnityEditor.ShaderGraph.Drawing
             AddToClassList("selectable");
             UpdateThemeClasses();
             UpdateSizeClasses();
+            // Manually set the layer of the sticky note so it's always on top. This used to be in the uss
+            // but that causes issues with re-laying out at times that can do weird things to selection.
+            this.layer = -100;
 
             this.AddManipulator(new ContextualMenuManipulator(BuildContextualMenu));
         }

--- a/com.unity.shadergraph/Editor/Resources/StickyNote.uss
+++ b/com.unity.shadergraph/Editor/Resources/StickyNote.uss
@@ -10,7 +10,6 @@
     position:absolute;
     flex-direction:column;
     align-items:stretch;
-    --layer:-100;
     border-radius:0;
     margin-left: 0;
     margin-right: 0;


### PR DESCRIPTION
Bugfix https://fogbugz.unity3d.com/f/cases/1336810
backport of https://github.com/Unity-Technologies/Graphics/pull/4395

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
Backport of https://github.com/Unity-Technologies/Graphics/pull/4395
Sticky notes cannot be copied/cut/pasted right now.
Also fixed sticky notes not being able to be dragged into a group which would cause some odd behaviors since you could right-click to group a sticky note with other nodes, but you could never drag it in.

---
### Testing status

- Within a graph:
  - [x] Simply copy paste of a sticky note. Note's contents/title are the same and it's selected
  - [x] Copy two sticky notes. Both get pasted and selected
  - [x] Copy a sticky note and a node. Both are pasted and selected
  - [x] Cut/Paste works.
  - [x] Right click copy/paste/cut/duplicate works (menu option is in an odd location, see notes below)
  - [x] Copy of groups works (stickynote in a group, group with a sticky note, etc...)
  - [x] Copy a sticky note and a node and pan the graph view way to the side so the original location is very far away. Paste and verify that both nodes are within the current viewport (see comments for some details).
  - [x] Validate the size and theme is correct when copying sticky nodes (change to dark theme or change text size then copy/cut + paste)
- Do all of the above for:
  - [x] Between two different graphs
  - [x] From a graph to a sub-graph
  - [x] From a sub-graph to a graph
  - [x] Between two sub-graphs


- [x] Additionally verify you can drag sticky notes into a group.
 
---
### Comments to reviewers

There are a lot of cases with sticky notes, I hope I tried them all, but any additional testing is appreciated. 

Known issues:
- The copy/cut/duplicate commands on right-click are not in the same location as for normal nodes. This is controlled in GraphView so there's no way to fix this without changing the package.
- When notes/nodes are pasted they aren't always perfectly within the viewport, but they should be mostly inside (you can at least somewhat see them) as opposed to way off where they were copied. The core "framing" logic wasn't changed to be better, only to include sticky notes.
