### PR TITLE
[2021.1] Backport fix for shader graph sticky note copy pasting

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a issue when clicking a property in subgraph blackboard will throw null exception errors.[1328377](https://issuetracker.unity3d.com/product/unity/issues/guid/1328377/)
 - Fixed an issue where an integer property would be exposed in the material inspector as a float [1332563]
 - Fixed an issue where upgrading from an older version of ShaderGraph would cause Enum keywords to be not exposed [1332510]
+- Fixed a bug in ShaderGraph where sticky notes couldn't be copied and pasted [1221042].
 
 ## [10.3.0] - 2020-11-03
 

--- a/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
@@ -1740,7 +1740,9 @@ namespace UnityEditor.ShaderGraph
                 position.y += 30;
 
                 StickyNoteData pastedStickyNote = new StickyNoteData(stickyNote.title, stickyNote.content, position);
-                if (groupMap.ContainsKey(stickyNote.group))
+                pastedStickyNote.textSize = stickyNote.textSize;
+                pastedStickyNote.theme = stickyNote.theme;
+                if (stickyNote.group != null && groupMap.ContainsKey(stickyNote.group))
                 {
                     pastedStickyNote.group = groupMap[stickyNote.group];
                 }

--- a/com.unity.shadergraph/Editor/Data/Graphs/StickyNoteData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/StickyNoteData.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph
 {
     [Serializable]
-    class StickyNoteData : JsonObject, IGroupItem
+    class StickyNoteData : JsonObject, IGroupItem, IRectInterface
     {
         [SerializeField]
         string m_Title;
@@ -50,6 +50,15 @@ namespace UnityEditor.ShaderGraph
         {
             get => m_Position;
             set => m_Position = value;
+        }
+
+        Rect IRectInterface.rect
+        {
+            get => position;
+            set
+            {
+                position = value;
+            }
         }
 
         [SerializeField]

--- a/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
@@ -13,7 +13,7 @@ using UnityEngine.Pool;
 namespace UnityEditor.ShaderGraph
 {
     [Serializable]
-    abstract class AbstractMaterialNode : JsonObject, IGroupItem
+    abstract class AbstractMaterialNode : JsonObject, IGroupItem, IRectInterface
     {
         [SerializeField]
         JsonRef<GroupData> m_Group = null;
@@ -89,6 +89,17 @@ namespace UnityEditor.ShaderGraph
             {
                 m_DrawState = value;
                 Dirty(ModificationScope.Layout);
+            }
+        }
+
+        Rect IRectInterface.rect
+        {
+            get => drawState.position;
+            set
+            {
+                var state = drawState;
+                state.position = value;
+                drawState = state;
             }
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEditor.Graphing;
+using UnityEditor.ShaderGraph.Drawing.Colors;
+using UnityEditor.ShaderGraph.Internal;
+using UnityEditor.ShaderGraph.Drawing;
+using UnityEditor.ShaderGraph.Serialization;
+using UnityEngine.Assertions;
+using UnityEngine.Pool;
+
+namespace UnityEditor.ShaderGraph
+{
+    interface IRectInterface
+    {
+        Rect rect
+        {
+            get;
+            internal set;
+        }
+    }
+}

--- a/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs.meta
+++ b/com.unity.shadergraph/Editor/Drawing/Interfaces/IRectInterface.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7268d6a70314cc41bc1a502cd86b4f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -34,12 +34,12 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         protected override bool canCutSelection
         {
-            get { return selection.OfType<IShaderNodeView>().Any(x => x.node.canCutNode) || selection.OfType<Group>().Any() || selection.OfType<BlackboardField>().Any(); }
+            get { return selection.OfType<IShaderNodeView>().Any(x => x.node.canCutNode) || selection.OfType<Group>().Any() || selection.OfType<BlackboardField>().Any() || selection.OfType<StickyNote>().Any(); }
         }
 
         protected override bool canCopySelection
         {
-            get { return selection.OfType<IShaderNodeView>().Any(x => x.node.canCopyNode) || selection.OfType<Group>().Any() || selection.OfType<BlackboardField>().Any(); }
+            get { return selection.OfType<IShaderNodeView>().Any(x => x.node.canCopyNode) || selection.OfType<Group>().Any() || selection.OfType<BlackboardField>().Any() || selection.OfType<StickyNote>().Any(); }
         }
 
         public MaterialGraphView(GraphData graph, Action previewUpdateDelegate) : this()
@@ -342,6 +342,15 @@ namespace UnityEditor.ShaderGraph.Drawing
             {
                 evt.menu.AppendAction("Delete", (e) => DeleteSelectionImplementation("Delete", AskUser.DontAskUser), (e) => canDeleteSelection ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
                 evt.menu.AppendAction("Duplicate %d", (e) => DuplicateSelection(), (a) => canDuplicateSelection ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
+            }
+
+            // Sticky notes aren't given these context menus in GraphView because it checks for specific types.
+            // We can manually add them back in here (although the context menu ordering is different).
+            if (evt.target is StickyNote)
+            {
+                evt.menu.AppendAction("Copy %d", (e) => CopySelectionCallback(), (a) => canCopySelection ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
+                evt.menu.AppendAction("Cut %d", (e) => CutSelectionCallback(), (a) => canCutSelection ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
+                evt.menu.AppendAction("Duplicate %d", (e) => DuplicateSelectionCallback(), (a) => canDuplicateSelection ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
             }
 
             // Contextual menu
@@ -1297,7 +1306,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     var nodeList = copyGraph.GetNodes<AbstractMaterialNode>();
 
-                    ClampNodesWithinView(graphView, nodeList);
+                    ClampNodesWithinView(graphView, new List<IRectInterface>().Union(nodeList).Union(copyGraph.stickyNotes));
 
                     graphView.graph.PasteGraph(copyGraph, remappedNodes, remappedEdges);
 
@@ -1315,22 +1324,21 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        private static void ClampNodesWithinView(MaterialGraphView graphView, IEnumerable<AbstractMaterialNode> nodeList)
+        private static void ClampNodesWithinView(MaterialGraphView graphView, IEnumerable<IRectInterface> rectList)
         {
-            // Compute the centroid of the copied nodes at their original positions
-            var nodePositions = nodeList.Select(n => n.drawState.position.position);
-            var centroid = UIUtilities.CalculateCentroid(nodePositions);
+            // Compute the centroid of the copied elements at their original positions
+            var positions = rectList.Select(n => n.rect.position);
+            var centroid = UIUtilities.CalculateCentroid(positions);
 
             /* Ensure nodes get pasted at cursor */
             var graphMousePosition = graphView.contentViewContainer.WorldToLocal(graphView.cachedMousePosition);
             var copiedNodesOrigin = graphMousePosition;
             float xMin = float.MaxValue, xMax = float.MinValue, yMin = float.MaxValue, yMax = float.MinValue;
 
-            // Calculate bounding rectangle min and max coordinates for these nodes, to use in clamping later
-            foreach (var node in nodeList)
+            // Calculate bounding rectangle min and max coordinates for these elements, to use in clamping later
+            foreach (var element in rectList)
             {
-                var drawState = node.drawState;
-                var position = drawState.position;
+                var position = element.rect.position;
                 xMin = Mathf.Min(xMin, position.x);
                 yMin = Mathf.Min(yMin, position.y);
                 xMax = Mathf.Max(xMax, position.x);
@@ -1351,7 +1359,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             if ((Mathf.Abs(mouseOffset.x) + widthThreshold > graphViewScaledHalfWidth ||
                  (Mathf.Abs(mouseOffset.y) + heightThreshold > graphViewScaledHalfHeight)))
             {
-                // Out of bounds - Adjust taking into account the size of the bounding box around nodes and the current graph zoom level
+                // Out of bounds - Adjust taking into account the size of the bounding box around elements and the current graph zoom level
                 var adjustedPositionX = (xMax - xMin) + widthThreshold * zoomAdjustedViewScale;
                 var adjustedPositionY = (yMax - yMin) + heightThreshold * zoomAdjustedViewScale;
                 adjustedPositionY *= -1.0f * Mathf.Sign(copiedNodesOrigin.y);
@@ -1360,18 +1368,16 @@ namespace UnityEditor.ShaderGraph.Drawing
                 copiedNodesOrigin.y += adjustedPositionY;
             }
 
-            foreach (var node in nodeList)
+            foreach (var element in rectList)
             {
-                var drawState = node.drawState;
-                var position = drawState.position;
+                var rect = element.rect;
 
                 // Get the relative offset from the calculated centroid
-                var relativeOffsetFromCentroid = position.position - centroid;
-                // Reapply that offset to ensure node positions are consistent when multiple nodes are copied
-                position.x = copiedNodesOrigin.x + relativeOffsetFromCentroid.x;
-                position.y = copiedNodesOrigin.y + relativeOffsetFromCentroid.y;
-                drawState.position = position;
-                node.drawState = drawState;
+                var relativeOffsetFromCentroid = rect.position - centroid;
+                // Reapply that offset to ensure element positions are consistent when multiple elements are copied
+                rect.x = copiedNodesOrigin.x + relativeOffsetFromCentroid.x;
+                rect.y = copiedNodesOrigin.y + relativeOffsetFromCentroid.y;
+                element.rect = rect;
             }
         }
     }

--- a/com.unity.shadergraph/Editor/Drawing/Views/StickyNote.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/StickyNote.cs
@@ -208,7 +208,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             tpl.CloneTree(this);
 
-            capabilities = Capabilities.Movable | Capabilities.Deletable | Capabilities.Ascendable | Capabilities.Selectable;
+            capabilities = Capabilities.Movable | Capabilities.Deletable | Capabilities.Ascendable | Capabilities.Selectable | Capabilities.Copiable | Capabilities.Groupable;
 
             m_Title = this.Q<Label>(name: "title");
             if (m_Title != null)
@@ -243,6 +243,9 @@ namespace UnityEditor.ShaderGraph.Drawing
             AddToClassList("selectable");
             UpdateThemeClasses();
             UpdateSizeClasses();
+            // Manually set the layer of the sticky note so it's always on top. This used to be in the uss
+            // but that causes issues with re-laying out at times that can do weird things to selection.
+            this.layer = -100;
 
             this.AddManipulator(new ContextualMenuManipulator(BuildContextualMenu));
         }

--- a/com.unity.shadergraph/Editor/Resources/StickyNote.uss
+++ b/com.unity.shadergraph/Editor/Resources/StickyNote.uss
@@ -10,7 +10,6 @@
     position:absolute;
     flex-direction:column;
     align-items:stretch;
-    --layer:-100;
     border-radius:0;
     margin-left: 0;
     margin-right: 0;


### PR DESCRIPTION
Bugfix https://fogbugz.unity3d.com/f/cases/1336809/
Backport of https://github.com/Unity-Technologies/Graphics/pull/4395

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
Backport Bug: https://fogbugz.unity3d.com/f/cases/1336809/
Backport of https://github.com/Unity-Technologies/Graphics/pull/4395
Sticky notes cannot be copied/cut/pasted right now.
Also fixed sticky notes not being able to be dragged into a group which would cause some odd behaviors since you could right-click to group a sticky note with other nodes, but you could never drag it in.

---
### Testing status

- Within a graph:
  - [x] Simply copy paste of a sticky note. Note's contents/title are the same and it's selected
  - [x] Copy two sticky notes. Both get pasted and selected
  - [x] Copy a sticky note and a node. Both are pasted and selected
  - [x] Cut/Paste works.
  - [x] Right click copy/paste/cut/duplicate works (menu option is in an odd location, see notes below)
  - [x] Copy of groups works (stickynote in a group, group with a sticky note, etc...)
  - [x] Copy a sticky note and a node and pan the graph view way to the side so the original location is very far away. Paste and verify that both nodes are within the current viewport (see comments for some details).
  - [x] Validate the size and theme is correct when copying sticky nodes (change to dark theme or change text size then copy/cut + paste)
- Do all of the above for:
  - [x] Between two different graphs
  - [x] From a graph to a sub-graph
  - [x] From a sub-graph to a graph
  - [x] Between two sub-graphs


- [x] Additionally verify you can drag sticky notes into a group.
 
---
### Comments to reviewers

There are a lot of cases with sticky notes, I hope I tried them all, but any additional testing is appreciated. 

Known issues:
- The copy/cut/duplicate commands on right-click are not in the same location as for normal nodes. This is controlled in GraphView so there's no way to fix this without changing the package.
- When notes/nodes are pasted they aren't always perfectly within the viewport, but they should be mostly inside (you can at least somewhat see them) as opposed to way off where they were copied. The core "framing" logic wasn't changed to be better, only to include sticky notes.
