### PR TITLE
Adding "Allow Material Override" option to BuiltIn Targets

### DIFF
--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClipDoubleSided.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClipDoubleSided.mat
@@ -1,5 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-1487155876456533515
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5
 --- !u!21 &2100000
 Material:
   serializedVersion: 6

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClipDoubleSided_Override.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClipDoubleSided_Override.mat
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-6930716006456355820
+--- !u!114 &-1487155876456533515
 MonoBehaviour:
   m_ObjectHideFlags: 11
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13,19 +13,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   version: 5
---- !u!114 &-4983144574417607693
-MonoBehaviour:
-  m_ObjectHideFlags: 11
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  version: 0
 --- !u!21 &2100000
 Material:
   serializedVersion: 6
@@ -33,10 +20,10 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BI-LitOpaqueAlphaClip
-  m_Shader: {fileID: -6465566751694194690, guid: 5740befc4973aa14e9dc2c462b053678,
+  m_Name: BI-LitOpaqueAlphaClipDoubleSided_Override
+  m_Shader: {fileID: -6465566751694194690, guid: 94ad5dc65b3a8294e8f99ffc790ec0ba,
     type: 3}
-  m_ShaderKeywords: _ALPHATEST_ON _AlphaClip _BUILTIN_ALPHATEST_ON _BUILTIN_AlphaClip
+  m_ShaderKeywords: _BUILTIN_ALPHATEST_ON _BUILTIN_AlphaClip
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -108,7 +95,7 @@ Material:
     - Alpha_Clip_Threshold: 0.5
     - _BUILTIN_AlphaClip: 1
     - _BUILTIN_Blend: 0
-    - _BUILTIN_CullMode: 2
+    - _BUILTIN_CullMode: 0
     - _BUILTIN_DstBlend: 0
     - _BUILTIN_QueueOffset: 0
     - _BUILTIN_SrcBlend: 1
@@ -140,3 +127,16 @@ Material:
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
+--- !u!114 &3121037281211421810
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClipDoubleSided_Override.mat.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClipDoubleSided_Override.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b16e30a475dda24aa5583ef45757a72
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClip_Override.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClip_Override.mat
@@ -33,8 +33,8 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BI-LitOpaqueAlphaClip
-  m_Shader: {fileID: -6465566751694194690, guid: 5740befc4973aa14e9dc2c462b053678,
+  m_Name: BI-LitOpaqueAlphaClip_Override
+  m_Shader: {fileID: -6465566751694194690, guid: ec0b9ef0317288142baf38584bc8f6f9,
     type: 3}
   m_ShaderKeywords: _ALPHATEST_ON _AlphaClip _BUILTIN_ALPHATEST_ON _BUILTIN_AlphaClip
   m_LightmapFlags: 4

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClip_Override.mat.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitOpaqueAlphaClip_Override.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 21505c51fdfea264191c9e542878d80a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAdditive.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAdditive.mat
@@ -171,4 +171,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 4
+  version: 5

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAdditive_Override.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAdditive_Override.mat
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-2145937234992653446
+--- !u!114 &-2450555901696256800
 MonoBehaviour:
   m_ObjectHideFlags: 11
   m_CorrespondingSourceObject: {fileID: 0}
@@ -20,10 +20,10 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BI-LitTransparentPreMultiply
-  m_Shader: {fileID: -6465566751694194690, guid: fdec8950d1cf73e4a9335a7288932b14,
+  m_Name: BI-LitTransparentAdditive_Override
+  m_Shader: {fileID: -6465566751694194690, guid: 1d873841e428bd949859783ad9fbcf31,
     type: 3}
-  m_ShaderKeywords: _BUILTIN_ALPHAPREMULTIPLY_ON _BUILTIN_SURFACE_TYPE_TRANSPARENT
+  m_ShaderKeywords: _BUILTIN_SURFACE_TYPE_TRANSPARENT
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -108,11 +108,12 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - Alpha_Clip_Threshold: 0
     - _AlphaClip: 0
     - _BUILTIN_AlphaClip: 0
-    - _BUILTIN_Blend: 1
+    - _BUILTIN_Blend: 2
     - _BUILTIN_CullMode: 2
-    - _BUILTIN_DstBlend: 10
+    - _BUILTIN_DstBlend: 1
     - _BUILTIN_QueueOffset: 0
     - _BUILTIN_SrcBlend: 1
     - _BUILTIN_Surface: 1

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAdditive_Override.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAdditive_Override.mat
@@ -21,7 +21,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: BI-LitTransparentAdditive_Override
-  m_Shader: {fileID: -6465566751694194690, guid: 1d873841e428bd949859783ad9fbcf31,
+  m_Shader: {fileID: -6465566751694194690, guid: ec0b9ef0317288142baf38584bc8f6f9,
     type: 3}
   m_ShaderKeywords: _BUILTIN_SURFACE_TYPE_TRANSPARENT
   m_LightmapFlags: 4
@@ -115,7 +115,7 @@ Material:
     - _BUILTIN_CullMode: 2
     - _BUILTIN_DstBlend: 1
     - _BUILTIN_QueueOffset: 0
-    - _BUILTIN_SrcBlend: 1
+    - _BUILTIN_SrcBlend: 5
     - _BUILTIN_Surface: 1
     - _BUILTIN_ZTest: 4
     - _BUILTIN_ZWrite: 0

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAdditive_Override.mat.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAdditive_Override.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78d8b501c2461b8498e955e3f9b23e96
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAlpha.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAlpha.mat
@@ -171,4 +171,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 4
+  version: 5

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAlpha_Override.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAlpha_Override.mat
@@ -1,18 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-2145937234992653446
-MonoBehaviour:
-  m_ObjectHideFlags: 11
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  version: 0
 --- !u!21 &2100000
 Material:
   serializedVersion: 6
@@ -20,10 +7,10 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BI-LitTransparentPreMultiply
-  m_Shader: {fileID: -6465566751694194690, guid: fdec8950d1cf73e4a9335a7288932b14,
+  m_Name: BI-LitTransparentAlpha_Override
+  m_Shader: {fileID: -6465566751694194690, guid: ec0b9ef0317288142baf38584bc8f6f9,
     type: 3}
-  m_ShaderKeywords: _BUILTIN_ALPHAPREMULTIPLY_ON _BUILTIN_SURFACE_TYPE_TRANSPARENT
+  m_ShaderKeywords: _BUILTIN_SURFACE_TYPE_TRANSPARENT
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -108,13 +95,14 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - Alpha_Clip_Threshold: 0
     - _AlphaClip: 0
     - _BUILTIN_AlphaClip: 0
-    - _BUILTIN_Blend: 1
+    - _BUILTIN_Blend: 0
     - _BUILTIN_CullMode: 2
     - _BUILTIN_DstBlend: 10
     - _BUILTIN_QueueOffset: 0
-    - _BUILTIN_SrcBlend: 1
+    - _BUILTIN_SrcBlend: 5
     - _BUILTIN_Surface: 1
     - _BUILTIN_ZTest: 4
     - _BUILTIN_ZWrite: 0
@@ -159,6 +147,19 @@ Material:
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []
+--- !u!114 &2489787373511946085
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 639247ca83abc874e893eb93af2b5e44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0
 --- !u!114 &2496664280657295510
 MonoBehaviour:
   m_ObjectHideFlags: 11

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAlpha_Override.mat.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentAlpha_Override.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 306b5111dbc500c4f98d5eea7b819660
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentMultiply.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentMultiply.mat
@@ -171,4 +171,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 4
+  version: 5

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentMultiply_Override.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentMultiply_Override.mat
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-2145937234992653446
+--- !u!114 &-853963047616451457
 MonoBehaviour:
   m_ObjectHideFlags: 11
   m_CorrespondingSourceObject: {fileID: 0}
@@ -20,10 +20,10 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BI-LitTransparentPreMultiply
-  m_Shader: {fileID: -6465566751694194690, guid: fdec8950d1cf73e4a9335a7288932b14,
+  m_Name: BI-LitTransparentMultiply_Override
+  m_Shader: {fileID: -6465566751694194690, guid: ec0b9ef0317288142baf38584bc8f6f9,
     type: 3}
-  m_ShaderKeywords: _BUILTIN_ALPHAPREMULTIPLY_ON _BUILTIN_SURFACE_TYPE_TRANSPARENT
+  m_ShaderKeywords: _BUILTIN_SURFACE_TYPE_TRANSPARENT
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -108,13 +108,14 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - Alpha_Clip_Threshold: 0
     - _AlphaClip: 0
     - _BUILTIN_AlphaClip: 0
-    - _BUILTIN_Blend: 1
+    - _BUILTIN_Blend: 3
     - _BUILTIN_CullMode: 2
-    - _BUILTIN_DstBlend: 10
+    - _BUILTIN_DstBlend: 0
     - _BUILTIN_QueueOffset: 0
-    - _BUILTIN_SrcBlend: 1
+    - _BUILTIN_SrcBlend: 2
     - _BUILTIN_Surface: 1
     - _BUILTIN_ZTest: 4
     - _BUILTIN_ZWrite: 0

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentMultiply_Override.mat.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentMultiply_Override.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc4a799f216fbb1479d12041a0a78807
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentPreMultiply_Override.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentPreMultiply_Override.mat
@@ -20,8 +20,8 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BI-LitTransparentPreMultiply
-  m_Shader: {fileID: -6465566751694194690, guid: fdec8950d1cf73e4a9335a7288932b14,
+  m_Name: BI-LitTransparentPreMultiply_Override
+  m_Shader: {fileID: -6465566751694194690, guid: ec0b9ef0317288142baf38584bc8f6f9,
     type: 3}
   m_ShaderKeywords: _BUILTIN_ALPHAPREMULTIPLY_ON _BUILTIN_SURFACE_TYPE_TRANSPARENT
   m_LightmapFlags: 4
@@ -108,6 +108,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - Alpha_Clip_Threshold: 0
     - _AlphaClip: 0
     - _BUILTIN_AlphaClip: 0
     - _BUILTIN_Blend: 1

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentPreMultiply_Override.mat.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-LitTransparentPreMultiply_Override.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07e34a69dfc96324484a2fd2c2790302
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-Unlit.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-Unlit.mat
@@ -14,9 +14,8 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2000
-  stringTagMap:
-    RenderType: Opaque
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -109,3 +108,16 @@ Material:
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
+--- !u!114 &1646316809586768575
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-UnlitAlphaClip_Override.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-UnlitAlphaClip_Override.mat
@@ -20,15 +20,16 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BI-UnlitAlphaClip
-  m_Shader: {fileID: -6465566751694194690, guid: 5f702968f996bf84b925425777d9a686,
+  m_Name: BI-UnlitAlphaClip_Override
+  m_Shader: {fileID: -6465566751694194690, guid: 758a7800273a8b241844d58e6311cf3c,
     type: 3}
-  m_ShaderKeywords: 
+  m_ShaderKeywords: _BUILTIN_ALPHATEST_ON _BUILTIN_AlphaClip
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
+  m_CustomRenderQueue: 2450
+  stringTagMap:
+    RenderType: TransparentCutout
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-UnlitAlphaClip_Override.mat.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-UnlitAlphaClip_Override.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6adca46360202fb4d8515f2f67bda4bb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-Unlit_Override.mat
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-Unlit_Override.mat
@@ -1,18 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-6448161905367451616
-MonoBehaviour:
-  m_ObjectHideFlags: 11
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  version: 5
 --- !u!21 &2100000
 Material:
   serializedVersion: 6
@@ -20,8 +7,8 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BI-UnlitAlphaClip
-  m_Shader: {fileID: -6465566751694194690, guid: 5f702968f996bf84b925425777d9a686,
+  m_Name: BI-Unlit_Override
+  m_Shader: {fileID: -6465566751694194690, guid: 758a7800273a8b241844d58e6311cf3c,
     type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
@@ -88,7 +75,7 @@ Material:
     m_Ints: []
     m_Floats:
     - Alpha_Clip_Threshold: 0.5
-    - _BUILTIN_AlphaClip: 1
+    - _BUILTIN_AlphaClip: 0
     - _BUILTIN_Blend: 0
     - _BUILTIN_CullMode: 2
     - _BUILTIN_DstBlend: 0
@@ -121,3 +108,16 @@ Material:
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Offset: {r: 0, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
+--- !u!114 &1646316809586768575
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-Unlit_Override.mat.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Materials/BI-Unlit_Override.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7cbbff6a70f55ef48a0c1b554bb8ee51
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitOpaqueAlphaClipDoubleSided.shadergraph
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitOpaqueAlphaClipDoubleSided.shadergraph
@@ -41,7 +41,12 @@
         }
     ],
     "m_Keywords": [],
-    "m_CategoryData": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "fbfbe7eb0ccf471288b54722d1a1e278"
+        }
+    ],
     "m_Nodes": [
         {
             "m_Id": "b4b8333b49704019abfd1d01eb98f0b5"
@@ -761,7 +766,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -849,6 +856,8 @@
     "m_DefaultReferenceName": "BumpScale",
     "m_OverrideReferenceName": "_BumpScale",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -934,6 +943,8 @@
     "m_DefaultReferenceName": "Base_Color",
     "m_OverrideReferenceName": "_BaseColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -944,6 +955,7 @@
         "b": 1.0,
         "a": 0.0
     },
+    "isMainColor": false,
     "m_ColorMode": 0
 }
 
@@ -1259,7 +1271,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -1275,6 +1289,8 @@
     "m_DefaultReferenceName": "Normal_Map",
     "m_OverrideReferenceName": "_NormalMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1283,6 +1299,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 3
 }
@@ -1576,6 +1594,8 @@
     "m_DefaultReferenceName": "_Offset",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1636,6 +1656,8 @@
     "m_DefaultReferenceName": "Tiling",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1715,6 +1737,8 @@
     "m_DefaultReferenceName": "MetallicGlossMap",
     "m_OverrideReferenceName": "_MetallicGlossMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1723,6 +1747,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1765,6 +1791,8 @@
     "m_DefaultReferenceName": "Emission_Map",
     "m_OverrideReferenceName": "_EmissionMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1773,6 +1801,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1920,7 +1950,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2190,7 +2222,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2206,6 +2240,8 @@
     "m_DefaultReferenceName": "Base_Map",
     "m_OverrideReferenceName": "_BaseMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -2214,20 +2250,25 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 2,
     "m_Type": "UnityEditor.Rendering.BuiltIn.ShaderGraph.BuiltInTarget",
     "m_ObjectId": "9c63881675274c348c82ca8ece984318",
     "m_ActiveSubTarget": {
         "m_Id": "bd33894092ba43b184ac3e1bcb77e220"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 0,
+    "m_ZWriteControl": 0,
+    "m_ZTestMode": 4,
     "m_AlphaMode": 0,
-    "m_TwoSided": true,
+    "m_RenderFace": 0,
     "m_AlphaClip": true,
     "m_CustomEditorGUI": ""
 }
@@ -2380,6 +2421,8 @@
     "m_DefaultReferenceName": "Alpha_Clip_Threshold",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -2640,16 +2683,21 @@
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 1,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
     "m_ObjectId": "b8e8489bec2c4f40b8032bb8f33d309a",
     "m_ActiveSubTarget": {
         "m_Id": "dc50e046ca464db19cf7b97b52b15aed"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 0,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
     "m_AlphaMode": 0,
-    "m_TwoSided": true,
+    "m_RenderFace": 0,
     "m_AlphaClip": true,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
     "m_CustomEditorGUI": ""
 }
 
@@ -2865,6 +2913,8 @@
     "m_DefaultReferenceName": "Metallic",
     "m_OverrideReferenceName": "_Metallic",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3394,6 +3444,8 @@
     "m_DefaultReferenceName": "Smoothness",
     "m_OverrideReferenceName": "_Smoothness",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3470,6 +3522,8 @@
     "m_DefaultReferenceName": "Emission_Color",
     "m_OverrideReferenceName": "_EmissionColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3480,7 +3534,53 @@
         "b": 4.594794750213623,
         "a": 1.0
     },
+    "isMainColor": false,
     "m_ColorMode": 1
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "fbfbe7eb0ccf471288b54722d1a1e278",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "9ab59b29bb084c88949097ce898f4f40"
+        },
+        {
+            "m_Id": "1aa1b8b796b04627a615a8e6c98349ee"
+        },
+        {
+            "m_Id": "c4c0d4d566cb48e5889e3e59ea2d0d4d"
+        },
+        {
+            "m_Id": "69e4f03ed727479fa4e0fc892cce35e0"
+        },
+        {
+            "m_Id": "f343e813ccfe4a4f968dc18b016733f9"
+        },
+        {
+            "m_Id": "3c3f245f532c4c99a3452bef44b2cfc6"
+        },
+        {
+            "m_Id": "70fa831c8a5b4232ba7cd98efc173dbf"
+        },
+        {
+            "m_Id": "f5b9e214c46c42ac8a6d899f1da80954"
+        },
+        {
+            "m_Id": "5ef6c1e52f7d41938f6487b38a0f60f1"
+        },
+        {
+            "m_Id": "58fabe42ee444085b5ab055deac2316b"
+        },
+        {
+            "m_Id": "150113ee1dce4fc58c70fa499b6318c5"
+        },
+        {
+            "m_Id": "aa9074485aba4d52841ab6222217ab1d"
+        }
+    ]
 }
 
 {

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitTransparentAdditive.shadergraph
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitTransparentAdditive.shadergraph
@@ -38,7 +38,12 @@
         }
     ],
     "m_Keywords": [],
-    "m_CategoryData": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "d25bf899ecbf43a494b74d86380a6d8c"
+        }
+    ],
     "m_Nodes": [
         {
             "m_Id": "b4b8333b49704019abfd1d01eb98f0b5"
@@ -764,7 +769,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -852,6 +859,8 @@
     "m_DefaultReferenceName": "BumpScale",
     "m_OverrideReferenceName": "_BumpScale",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -922,6 +931,8 @@
     "m_DefaultReferenceName": "Base_Color",
     "m_OverrideReferenceName": "_BaseColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -932,6 +943,7 @@
         "b": 1.0,
         "a": 0.0
     },
+    "isMainColor": false,
     "m_ColorMode": 0
 }
 
@@ -1277,7 +1289,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -1308,6 +1322,8 @@
     "m_DefaultReferenceName": "Normal_Map",
     "m_OverrideReferenceName": "_NormalMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1316,6 +1332,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 3
 }
@@ -1594,6 +1612,8 @@
     "m_DefaultReferenceName": "_Offset",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1654,6 +1674,8 @@
     "m_DefaultReferenceName": "Tiling",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1700,6 +1722,8 @@
     "m_DefaultReferenceName": "MetallicGlossMap",
     "m_OverrideReferenceName": "_MetallicGlossMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1708,6 +1732,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1750,6 +1776,8 @@
     "m_DefaultReferenceName": "Emission_Map",
     "m_OverrideReferenceName": "_EmissionMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1758,6 +1786,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1905,7 +1935,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2149,7 +2181,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2180,6 +2214,8 @@
     "m_DefaultReferenceName": "Base_Map",
     "m_OverrideReferenceName": "_BaseMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -2188,20 +2224,25 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 2,
     "m_Type": "UnityEditor.Rendering.BuiltIn.ShaderGraph.BuiltInTarget",
     "m_ObjectId": "9c63881675274c348c82ca8ece984318",
     "m_ActiveSubTarget": {
         "m_Id": "bd33894092ba43b184ac3e1bcb77e220"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 1,
+    "m_ZWriteControl": 0,
+    "m_ZTestMode": 4,
     "m_AlphaMode": 2,
-    "m_TwoSided": false,
+    "m_RenderFace": 2,
     "m_AlphaClip": false,
     "m_CustomEditorGUI": ""
 }
@@ -2556,16 +2597,21 @@
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 1,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
     "m_ObjectId": "b8e8489bec2c4f40b8032bb8f33d309a",
     "m_ActiveSubTarget": {
         "m_Id": "dc50e046ca464db19cf7b97b52b15aed"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 1,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
     "m_AlphaMode": 2,
-    "m_TwoSided": false,
+    "m_RenderFace": 2,
     "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
     "m_CustomEditorGUI": ""
 }
 
@@ -2781,6 +2827,8 @@
     "m_DefaultReferenceName": "Metallic",
     "m_OverrideReferenceName": "_Metallic",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -2839,6 +2887,48 @@
         "e32": 0.0,
         "e33": 1.0
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "d25bf899ecbf43a494b74d86380a6d8c",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "9ab59b29bb084c88949097ce898f4f40"
+        },
+        {
+            "m_Id": "1aa1b8b796b04627a615a8e6c98349ee"
+        },
+        {
+            "m_Id": "c4c0d4d566cb48e5889e3e59ea2d0d4d"
+        },
+        {
+            "m_Id": "69e4f03ed727479fa4e0fc892cce35e0"
+        },
+        {
+            "m_Id": "f343e813ccfe4a4f968dc18b016733f9"
+        },
+        {
+            "m_Id": "3c3f245f532c4c99a3452bef44b2cfc6"
+        },
+        {
+            "m_Id": "70fa831c8a5b4232ba7cd98efc173dbf"
+        },
+        {
+            "m_Id": "f5b9e214c46c42ac8a6d899f1da80954"
+        },
+        {
+            "m_Id": "5ef6c1e52f7d41938f6487b38a0f60f1"
+        },
+        {
+            "m_Id": "58fabe42ee444085b5ab055deac2316b"
+        },
+        {
+            "m_Id": "150113ee1dce4fc58c70fa499b6318c5"
+        }
+    ]
 }
 
 {
@@ -3245,6 +3335,8 @@
     "m_DefaultReferenceName": "Smoothness",
     "m_OverrideReferenceName": "_Smoothness",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3306,6 +3398,8 @@
     "m_DefaultReferenceName": "Emission_Color",
     "m_OverrideReferenceName": "_EmissionColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3316,6 +3410,7 @@
         "b": 4.594794750213623,
         "a": 1.0
     },
+    "isMainColor": false,
     "m_ColorMode": 1
 }
 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitTransparentAlpha.shadergraph
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitTransparentAlpha.shadergraph
@@ -38,7 +38,12 @@
         }
     ],
     "m_Keywords": [],
-    "m_CategoryData": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "b22abcd0325a4016978fa1fb9df07760"
+        }
+    ],
     "m_Nodes": [
         {
             "m_Id": "b4b8333b49704019abfd1d01eb98f0b5"
@@ -126,9 +131,6 @@
         },
         {
             "m_Id": "e01106a9423b46f99425ab9d1ee7f2ba"
-        },
-        {
-            "m_Id": "a2e1f5ed57dc4e76952c7121031f4f16"
         },
         {
             "m_Id": "afd63a780b144218a17e994b5064d3fa"
@@ -720,7 +722,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -808,6 +812,8 @@
     "m_DefaultReferenceName": "BumpScale",
     "m_OverrideReferenceName": "_BumpScale",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -878,6 +884,8 @@
     "m_DefaultReferenceName": "Base_Color",
     "m_OverrideReferenceName": "_BaseColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -888,6 +896,7 @@
         "b": 1.0,
         "a": 0.0
     },
+    "isMainColor": false,
     "m_ColorMode": 0
 }
 
@@ -1020,21 +1029,6 @@
         "b": 0.5,
         "a": 1.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "23bb84de5d6144959c4ab3304c3c28fd",
-    "m_Id": 1,
-    "m_DisplayName": "X",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "X",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
 }
 
 {
@@ -1203,7 +1197,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -1219,6 +1215,8 @@
     "m_DefaultReferenceName": "Normal_Map",
     "m_OverrideReferenceName": "_NormalMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1227,6 +1225,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 3
 }
@@ -1505,6 +1505,8 @@
     "m_DefaultReferenceName": "_Offset",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1565,6 +1567,8 @@
     "m_DefaultReferenceName": "Tiling",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1611,6 +1615,8 @@
     "m_DefaultReferenceName": "MetallicGlossMap",
     "m_OverrideReferenceName": "_MetallicGlossMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1619,6 +1625,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1676,6 +1684,8 @@
     "m_DefaultReferenceName": "Emission_Map",
     "m_OverrideReferenceName": "_EmissionMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1684,6 +1694,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1831,7 +1843,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2005,23 +2019,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "938b7f9c6c644faca97518121af33d52",
-    "m_Id": 2,
-    "m_DisplayName": "Y",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Y",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [
-        "Y"
-    ]
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "96c0af28929947b581e797abe6a6dfef",
     "m_Id": 837880471,
@@ -2095,7 +2092,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2126,6 +2125,8 @@
     "m_DefaultReferenceName": "Base_Map",
     "m_OverrideReferenceName": "_BaseMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -2134,20 +2135,25 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 2,
     "m_Type": "UnityEditor.Rendering.BuiltIn.ShaderGraph.BuiltInTarget",
     "m_ObjectId": "9c63881675274c348c82ca8ece984318",
     "m_ActiveSubTarget": {
         "m_Id": "bd33894092ba43b184ac3e1bcb77e220"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 1,
+    "m_ZWriteControl": 0,
+    "m_ZTestMode": 4,
     "m_AlphaMode": 0,
-    "m_TwoSided": false,
+    "m_RenderFace": 2,
     "m_AlphaClip": false,
     "m_CustomEditorGUI": ""
 }
@@ -2211,52 +2217,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3Node",
-    "m_ObjectId": "a2e1f5ed57dc4e76952c7121031f4f16",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Vector 3",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -285.6600036621094,
-            "y": 398.072509765625,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "23bb84de5d6144959c4ab3304c3c28fd"
-        },
-        {
-            "m_Id": "938b7f9c6c644faca97518121af33d52"
-        },
-        {
-            "m_Id": "b4f046c59a434c3786a1b9e04246ab02"
-        },
-        {
-            "m_Id": "a9a6eec09ff14b2ebb0575470563e5ca"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
     "m_ObjectId": "a37959d0a94643279e319ccdd436243a",
     "m_Id": -964393785,
@@ -2285,29 +2245,6 @@
     "m_StageCapability": 2,
     "m_Value": 0.5,
     "m_DefaultValue": 0.5,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "a9a6eec09ff14b2ebb0575470563e5ca",
-    "m_Id": 0,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
     "m_Labels": []
 }
 
@@ -2462,6 +2399,48 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "b22abcd0325a4016978fa1fb9df07760",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "9ab59b29bb084c88949097ce898f4f40"
+        },
+        {
+            "m_Id": "1aa1b8b796b04627a615a8e6c98349ee"
+        },
+        {
+            "m_Id": "c4c0d4d566cb48e5889e3e59ea2d0d4d"
+        },
+        {
+            "m_Id": "69e4f03ed727479fa4e0fc892cce35e0"
+        },
+        {
+            "m_Id": "f343e813ccfe4a4f968dc18b016733f9"
+        },
+        {
+            "m_Id": "3c3f245f532c4c99a3452bef44b2cfc6"
+        },
+        {
+            "m_Id": "70fa831c8a5b4232ba7cd98efc173dbf"
+        },
+        {
+            "m_Id": "f5b9e214c46c42ac8a6d899f1da80954"
+        },
+        {
+            "m_Id": "5ef6c1e52f7d41938f6487b38a0f60f1"
+        },
+        {
+            "m_Id": "58fabe42ee444085b5ab055deac2316b"
+        },
+        {
+            "m_Id": "150113ee1dce4fc58c70fa499b6318c5"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "b4b8333b49704019abfd1d01eb98f0b5",
     "m_Group": {
@@ -2496,23 +2475,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "b4f046c59a434c3786a1b9e04246ab02",
-    "m_Id": 3,
-    "m_DisplayName": "Z",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Z",
-    "m_StageCapability": 3,
-    "m_Value": 1.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [
-        "Z"
-    ]
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "b8073d5ec9984952b984ee925605f83e",
     "m_Id": 0,
     "m_DisplayName": "Ambient Occlusion",
@@ -2526,16 +2488,21 @@
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 1,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
     "m_ObjectId": "b8e8489bec2c4f40b8032bb8f33d309a",
     "m_ActiveSubTarget": {
         "m_Id": "dc50e046ca464db19cf7b97b52b15aed"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 1,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
     "m_AlphaMode": 0,
-    "m_TwoSided": false,
+    "m_RenderFace": 2,
     "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
     "m_CustomEditorGUI": ""
 }
 
@@ -2751,6 +2718,8 @@
     "m_DefaultReferenceName": "Metallic",
     "m_OverrideReferenceName": "_Metallic",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3215,6 +3184,8 @@
     "m_DefaultReferenceName": "Smoothness",
     "m_OverrideReferenceName": "_Smoothness",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3276,6 +3247,8 @@
     "m_DefaultReferenceName": "Emission_Color",
     "m_OverrideReferenceName": "_EmissionColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3286,6 +3259,7 @@
         "b": 4.594794750213623,
         "a": 1.0
     },
+    "isMainColor": false,
     "m_ColorMode": 1
 }
 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitTransparentMultiply.shadergraph
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitTransparentMultiply.shadergraph
@@ -38,7 +38,12 @@
         }
     ],
     "m_Keywords": [],
-    "m_CategoryData": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "0265d4352ad44ca0b16214f350d24552"
+        }
+    ],
     "m_Nodes": [
         {
             "m_Id": "b4b8333b49704019abfd1d01eb98f0b5"
@@ -553,6 +558,48 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "0265d4352ad44ca0b16214f350d24552",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "9ab59b29bb084c88949097ce898f4f40"
+        },
+        {
+            "m_Id": "1aa1b8b796b04627a615a8e6c98349ee"
+        },
+        {
+            "m_Id": "c4c0d4d566cb48e5889e3e59ea2d0d4d"
+        },
+        {
+            "m_Id": "69e4f03ed727479fa4e0fc892cce35e0"
+        },
+        {
+            "m_Id": "f343e813ccfe4a4f968dc18b016733f9"
+        },
+        {
+            "m_Id": "3c3f245f532c4c99a3452bef44b2cfc6"
+        },
+        {
+            "m_Id": "70fa831c8a5b4232ba7cd98efc173dbf"
+        },
+        {
+            "m_Id": "f5b9e214c46c42ac8a6d899f1da80954"
+        },
+        {
+            "m_Id": "5ef6c1e52f7d41938f6487b38a0f60f1"
+        },
+        {
+            "m_Id": "58fabe42ee444085b5ab055deac2316b"
+        },
+        {
+            "m_Id": "150113ee1dce4fc58c70fa499b6318c5"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "03b0b8b3ba5346759032e98c77f2b2f6",
     "m_Group": {
@@ -720,7 +767,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -808,6 +857,8 @@
     "m_DefaultReferenceName": "BumpScale",
     "m_OverrideReferenceName": "_BumpScale",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -878,6 +929,8 @@
     "m_DefaultReferenceName": "Base_Color",
     "m_OverrideReferenceName": "_BaseColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -888,6 +941,7 @@
         "b": 1.0,
         "a": 0.0
     },
+    "isMainColor": false,
     "m_ColorMode": 0
 }
 
@@ -1218,7 +1272,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -1234,6 +1290,8 @@
     "m_DefaultReferenceName": "Normal_Map",
     "m_OverrideReferenceName": "_NormalMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1242,6 +1300,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 3
 }
@@ -1520,6 +1580,8 @@
     "m_DefaultReferenceName": "_Offset",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1580,6 +1642,8 @@
     "m_DefaultReferenceName": "Tiling",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1626,6 +1690,8 @@
     "m_DefaultReferenceName": "MetallicGlossMap",
     "m_OverrideReferenceName": "_MetallicGlossMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1634,6 +1700,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1676,6 +1744,8 @@
     "m_DefaultReferenceName": "Emission_Map",
     "m_OverrideReferenceName": "_EmissionMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1684,6 +1754,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1831,7 +1903,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2090,7 +2164,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2121,6 +2197,8 @@
     "m_DefaultReferenceName": "Base_Map",
     "m_OverrideReferenceName": "_BaseMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -2129,20 +2207,25 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 2,
     "m_Type": "UnityEditor.Rendering.BuiltIn.ShaderGraph.BuiltInTarget",
     "m_ObjectId": "9c63881675274c348c82ca8ece984318",
     "m_ActiveSubTarget": {
         "m_Id": "bd33894092ba43b184ac3e1bcb77e220"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 1,
+    "m_ZWriteControl": 0,
+    "m_ZTestMode": 4,
     "m_AlphaMode": 3,
-    "m_TwoSided": false,
+    "m_RenderFace": 2,
     "m_AlphaClip": false,
     "m_CustomEditorGUI": ""
 }
@@ -2497,16 +2580,21 @@
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 1,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
     "m_ObjectId": "b8e8489bec2c4f40b8032bb8f33d309a",
     "m_ActiveSubTarget": {
         "m_Id": "dc50e046ca464db19cf7b97b52b15aed"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 1,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
     "m_AlphaMode": 3,
-    "m_TwoSided": false,
+    "m_RenderFace": 2,
     "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
     "m_CustomEditorGUI": ""
 }
 
@@ -2737,6 +2825,8 @@
     "m_DefaultReferenceName": "Metallic",
     "m_OverrideReferenceName": "_Metallic",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3245,6 +3335,8 @@
     "m_DefaultReferenceName": "Smoothness",
     "m_OverrideReferenceName": "_Smoothness",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3306,6 +3398,8 @@
     "m_DefaultReferenceName": "Emission_Color",
     "m_OverrideReferenceName": "_EmissionColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3316,6 +3410,7 @@
         "b": 4.594794750213623,
         "a": 1.0
     },
+    "isMainColor": false,
     "m_ColorMode": 1
 }
 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitTransparentPreMultiply.shadergraph
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/LitTransparentPreMultiply.shadergraph
@@ -38,7 +38,12 @@
         }
     ],
     "m_Keywords": [],
-    "m_CategoryData": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "bb6430bdd2e4468bb902f9d13f6767d8"
+        }
+    ],
     "m_Nodes": [
         {
             "m_Id": "b4b8333b49704019abfd1d01eb98f0b5"
@@ -720,7 +725,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -808,6 +815,8 @@
     "m_DefaultReferenceName": "BumpScale",
     "m_OverrideReferenceName": "_BumpScale",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -878,6 +887,8 @@
     "m_DefaultReferenceName": "Base_Color",
     "m_OverrideReferenceName": "_BaseColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -888,6 +899,7 @@
         "b": 1.0,
         "a": 0.0
     },
+    "isMainColor": false,
     "m_ColorMode": 0
 }
 
@@ -1247,7 +1259,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -1263,6 +1277,8 @@
     "m_DefaultReferenceName": "Normal_Map",
     "m_OverrideReferenceName": "_NormalMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1271,6 +1287,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 3
 }
@@ -1549,6 +1567,8 @@
     "m_DefaultReferenceName": "_Offset",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1609,6 +1629,8 @@
     "m_DefaultReferenceName": "Tiling",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1670,6 +1692,8 @@
     "m_DefaultReferenceName": "MetallicGlossMap",
     "m_OverrideReferenceName": "_MetallicGlossMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1678,6 +1702,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1720,6 +1746,8 @@
     "m_DefaultReferenceName": "Emission_Map",
     "m_OverrideReferenceName": "_EmissionMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1728,6 +1756,8 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1890,7 +1920,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2110,7 +2142,9 @@
         -1432557354,
         -964393785,
         516401862
-    ]
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -2126,6 +2160,8 @@
     "m_DefaultReferenceName": "Base_Map",
     "m_OverrideReferenceName": "_BaseMap",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -2134,20 +2170,25 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 2,
     "m_Type": "UnityEditor.Rendering.BuiltIn.ShaderGraph.BuiltInTarget",
     "m_ObjectId": "9c63881675274c348c82ca8ece984318",
     "m_ActiveSubTarget": {
         "m_Id": "bd33894092ba43b184ac3e1bcb77e220"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 1,
+    "m_ZWriteControl": 0,
+    "m_ZTestMode": 4,
     "m_AlphaMode": 1,
-    "m_TwoSided": false,
+    "m_RenderFace": 2,
     "m_AlphaClip": false,
     "m_CustomEditorGUI": ""
 }
@@ -2517,16 +2558,21 @@
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 1,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
     "m_ObjectId": "b8e8489bec2c4f40b8032bb8f33d309a",
     "m_ActiveSubTarget": {
         "m_Id": "dc50e046ca464db19cf7b97b52b15aed"
     },
+    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 1,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
     "m_AlphaMode": 1,
-    "m_TwoSided": false,
+    "m_RenderFace": 2,
     "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
     "m_CustomEditorGUI": ""
 }
 
@@ -2610,6 +2656,48 @@
         "w": 0.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "bb6430bdd2e4468bb902f9d13f6767d8",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "9ab59b29bb084c88949097ce898f4f40"
+        },
+        {
+            "m_Id": "1aa1b8b796b04627a615a8e6c98349ee"
+        },
+        {
+            "m_Id": "c4c0d4d566cb48e5889e3e59ea2d0d4d"
+        },
+        {
+            "m_Id": "69e4f03ed727479fa4e0fc892cce35e0"
+        },
+        {
+            "m_Id": "f343e813ccfe4a4f968dc18b016733f9"
+        },
+        {
+            "m_Id": "3c3f245f532c4c99a3452bef44b2cfc6"
+        },
+        {
+            "m_Id": "70fa831c8a5b4232ba7cd98efc173dbf"
+        },
+        {
+            "m_Id": "f5b9e214c46c42ac8a6d899f1da80954"
+        },
+        {
+            "m_Id": "5ef6c1e52f7d41938f6487b38a0f60f1"
+        },
+        {
+            "m_Id": "58fabe42ee444085b5ab055deac2316b"
+        },
+        {
+            "m_Id": "150113ee1dce4fc58c70fa499b6318c5"
+        }
+    ]
 }
 
 {
@@ -2766,6 +2854,8 @@
     "m_DefaultReferenceName": "Metallic",
     "m_OverrideReferenceName": "_Metallic",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3230,6 +3320,8 @@
     "m_DefaultReferenceName": "Smoothness",
     "m_OverrideReferenceName": "_Smoothness",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3291,6 +3383,8 @@
     "m_DefaultReferenceName": "Emission_Color",
     "m_OverrideReferenceName": "_EmissionColor",
     "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -3301,6 +3395,7 @@
         "b": 4.594794750213623,
         "a": 1.0
     },
+    "isMainColor": false,
     "m_ColorMode": 1
 }
 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Lit_Override.shadergraph
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Lit_Override.shadergraph
@@ -44,7 +44,7 @@
     "m_Dropdowns": [],
     "m_CategoryData": [
         {
-            "m_Id": "66cd106db58c4a02ae851c160dac58c6"
+            "m_Id": "bcd495fba89741858186c2100a4e692a"
         }
     ],
     "m_Nodes": [
@@ -1705,51 +1705,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
-    "m_ObjectId": "66cd106db58c4a02ae851c160dac58c6",
-    "m_Name": "",
-    "m_ChildObjectList": [
-        {
-            "m_Id": "9ab59b29bb084c88949097ce898f4f40"
-        },
-        {
-            "m_Id": "1aa1b8b796b04627a615a8e6c98349ee"
-        },
-        {
-            "m_Id": "c4c0d4d566cb48e5889e3e59ea2d0d4d"
-        },
-        {
-            "m_Id": "69e4f03ed727479fa4e0fc892cce35e0"
-        },
-        {
-            "m_Id": "f343e813ccfe4a4f968dc18b016733f9"
-        },
-        {
-            "m_Id": "3c3f245f532c4c99a3452bef44b2cfc6"
-        },
-        {
-            "m_Id": "70fa831c8a5b4232ba7cd98efc173dbf"
-        },
-        {
-            "m_Id": "f5b9e214c46c42ac8a6d899f1da80954"
-        },
-        {
-            "m_Id": "5ef6c1e52f7d41938f6487b38a0f60f1"
-        },
-        {
-            "m_Id": "58fabe42ee444085b5ab055deac2316b"
-        },
-        {
-            "m_Id": "150113ee1dce4fc58c70fa499b6318c5"
-        },
-        {
-            "m_Id": "aa9074485aba4d52841ab6222217ab1d"
-        }
-    ]
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "68d5933181564105a72b719f985e1732",
     "m_Id": 0,
@@ -2308,7 +2263,7 @@
     "m_ActiveSubTarget": {
         "m_Id": "bd33894092ba43b184ac3e1bcb77e220"
     },
-    "m_AllowMaterialOverride": false,
+    "m_AllowMaterialOverride": true,
     "m_SurfaceType": 0,
     "m_ZWriteControl": 0,
     "m_ZTestMode": 4,
@@ -2837,6 +2792,51 @@
     "m_Property": {
         "m_Id": "58fabe42ee444085b5ab055deac2316b"
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "bcd495fba89741858186c2100a4e692a",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "9ab59b29bb084c88949097ce898f4f40"
+        },
+        {
+            "m_Id": "1aa1b8b796b04627a615a8e6c98349ee"
+        },
+        {
+            "m_Id": "c4c0d4d566cb48e5889e3e59ea2d0d4d"
+        },
+        {
+            "m_Id": "69e4f03ed727479fa4e0fc892cce35e0"
+        },
+        {
+            "m_Id": "f343e813ccfe4a4f968dc18b016733f9"
+        },
+        {
+            "m_Id": "3c3f245f532c4c99a3452bef44b2cfc6"
+        },
+        {
+            "m_Id": "70fa831c8a5b4232ba7cd98efc173dbf"
+        },
+        {
+            "m_Id": "f5b9e214c46c42ac8a6d899f1da80954"
+        },
+        {
+            "m_Id": "5ef6c1e52f7d41938f6487b38a0f60f1"
+        },
+        {
+            "m_Id": "58fabe42ee444085b5ab055deac2316b"
+        },
+        {
+            "m_Id": "150113ee1dce4fc58c70fa499b6318c5"
+        },
+        {
+            "m_Id": "aa9074485aba4d52841ab6222217ab1d"
+        }
+    ]
 }
 
 {

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Lit_Override.shadergraph.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Lit_Override.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: ec0b9ef0317288142baf38584bc8f6f9
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Lit_Override2.shadergraph
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Lit_Override2.shadergraph
@@ -44,7 +44,7 @@
     "m_Dropdowns": [],
     "m_CategoryData": [
         {
-            "m_Id": "66cd106db58c4a02ae851c160dac58c6"
+            "m_Id": "52562e2960b14f169c4d6d4c7888d0ef"
         }
     ],
     "m_Nodes": [
@@ -1489,6 +1489,51 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "52562e2960b14f169c4d6d4c7888d0ef",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "9ab59b29bb084c88949097ce898f4f40"
+        },
+        {
+            "m_Id": "1aa1b8b796b04627a615a8e6c98349ee"
+        },
+        {
+            "m_Id": "c4c0d4d566cb48e5889e3e59ea2d0d4d"
+        },
+        {
+            "m_Id": "69e4f03ed727479fa4e0fc892cce35e0"
+        },
+        {
+            "m_Id": "f343e813ccfe4a4f968dc18b016733f9"
+        },
+        {
+            "m_Id": "3c3f245f532c4c99a3452bef44b2cfc6"
+        },
+        {
+            "m_Id": "70fa831c8a5b4232ba7cd98efc173dbf"
+        },
+        {
+            "m_Id": "f5b9e214c46c42ac8a6d899f1da80954"
+        },
+        {
+            "m_Id": "5ef6c1e52f7d41938f6487b38a0f60f1"
+        },
+        {
+            "m_Id": "58fabe42ee444085b5ab055deac2316b"
+        },
+        {
+            "m_Id": "150113ee1dce4fc58c70fa499b6318c5"
+        },
+        {
+            "m_Id": "aa9074485aba4d52841ab6222217ab1d"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "54a37f1b82ee4949aa22ebd4807f81e3",
     "m_Id": 0,
@@ -1701,51 +1746,6 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.Alpha"
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
-    "m_ObjectId": "66cd106db58c4a02ae851c160dac58c6",
-    "m_Name": "",
-    "m_ChildObjectList": [
-        {
-            "m_Id": "9ab59b29bb084c88949097ce898f4f40"
-        },
-        {
-            "m_Id": "1aa1b8b796b04627a615a8e6c98349ee"
-        },
-        {
-            "m_Id": "c4c0d4d566cb48e5889e3e59ea2d0d4d"
-        },
-        {
-            "m_Id": "69e4f03ed727479fa4e0fc892cce35e0"
-        },
-        {
-            "m_Id": "f343e813ccfe4a4f968dc18b016733f9"
-        },
-        {
-            "m_Id": "3c3f245f532c4c99a3452bef44b2cfc6"
-        },
-        {
-            "m_Id": "70fa831c8a5b4232ba7cd98efc173dbf"
-        },
-        {
-            "m_Id": "f5b9e214c46c42ac8a6d899f1da80954"
-        },
-        {
-            "m_Id": "5ef6c1e52f7d41938f6487b38a0f60f1"
-        },
-        {
-            "m_Id": "58fabe42ee444085b5ab055deac2316b"
-        },
-        {
-            "m_Id": "150113ee1dce4fc58c70fa499b6318c5"
-        },
-        {
-            "m_Id": "aa9074485aba4d52841ab6222217ab1d"
-        }
-    ]
 }
 
 {
@@ -2308,7 +2308,7 @@
     "m_ActiveSubTarget": {
         "m_Id": "bd33894092ba43b184ac3e1bcb77e220"
     },
-    "m_AllowMaterialOverride": false,
+    "m_AllowMaterialOverride": true,
     "m_SurfaceType": 0,
     "m_ZWriteControl": 0,
     "m_ZTestMode": 4,

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Lit_Override2.shadergraph.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Lit_Override2.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 94ad5dc65b3a8294e8f99ffc790ec0ba
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Unlit_AlphaClip.shadergraph
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Unlit_AlphaClip.shadergraph
@@ -23,7 +23,7 @@
     "m_Dropdowns": [],
     "m_CategoryData": [
         {
-            "m_Id": "0d2908c3df484dc78d63a0b2c0e60273"
+            "m_Id": "2f18dad67d534bfda63f1f54e1ba4df6"
         }
     ],
     "m_Nodes": [
@@ -509,30 +509,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
-    "m_ObjectId": "0d2908c3df484dc78d63a0b2c0e60273",
-    "m_Name": "",
-    "m_ChildObjectList": [
-        {
-            "m_Id": "4e683968f3c646878a7b9e6f40735a04"
-        },
-        {
-            "m_Id": "c8bdf3b26e2040bba53e8414cca061d0"
-        },
-        {
-            "m_Id": "03533db6df1f487a968237b78df92ea8"
-        },
-        {
-            "m_Id": "45fcf79645064ffa867141e43dd45078"
-        },
-        {
-            "m_Id": "e9f5a7f8c20c4056b66e89b73d8689c7"
-        }
-    ]
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "0e67efa0e283439d9bdc6ac23982a6b7",
     "m_Id": 4,
@@ -827,6 +803,30 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "2f18dad67d534bfda63f1f54e1ba4df6",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "4e683968f3c646878a7b9e6f40735a04"
+        },
+        {
+            "m_Id": "c8bdf3b26e2040bba53e8414cca061d0"
+        },
+        {
+            "m_Id": "03533db6df1f487a968237b78df92ea8"
+        },
+        {
+            "m_Id": "45fcf79645064ffa867141e43dd45078"
+        },
+        {
+            "m_Id": "e9f5a7f8c20c4056b66e89b73d8689c7"
+        }
+    ]
 }
 
 {
@@ -1518,7 +1518,7 @@
     "m_ZTestMode": 4,
     "m_AlphaMode": 0,
     "m_RenderFace": 2,
-    "m_AlphaClip": false,
+    "m_AlphaClip": true,
     "m_CustomEditorGUI": ""
 }
 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Unlit_AlphaClip.shadergraph.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Unlit_AlphaClip.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5f702968f996bf84b925425777d9a686
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Unlit_Override.shadergraph
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Unlit_Override.shadergraph
@@ -20,12 +20,7 @@
         }
     ],
     "m_Keywords": [],
-    "m_Dropdowns": [],
-    "m_CategoryData": [
-        {
-            "m_Id": "0d2908c3df484dc78d63a0b2c0e60273"
-        }
-    ],
+    "m_CategoryData": [],
     "m_Nodes": [
         {
             "m_Id": "69a955a259b24f0ab024962a86570db7"
@@ -357,8 +352,6 @@
     "m_DefaultReferenceName": "Tiling",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -509,30 +502,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
-    "m_ObjectId": "0d2908c3df484dc78d63a0b2c0e60273",
-    "m_Name": "",
-    "m_ChildObjectList": [
-        {
-            "m_Id": "4e683968f3c646878a7b9e6f40735a04"
-        },
-        {
-            "m_Id": "c8bdf3b26e2040bba53e8414cca061d0"
-        },
-        {
-            "m_Id": "03533db6df1f487a968237b78df92ea8"
-        },
-        {
-            "m_Id": "45fcf79645064ffa867141e43dd45078"
-        },
-        {
-            "m_Id": "e9f5a7f8c20c4056b66e89b73d8689c7"
-        }
-    ]
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "0e67efa0e283439d9bdc6ac23982a6b7",
     "m_Id": 4,
@@ -547,21 +516,16 @@
 }
 
 {
-    "m_SGVersion": 1,
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
     "m_ObjectId": "10dadbbda7ec4f7b8046ba31ba7374c3",
     "m_ActiveSubTarget": {
         "m_Id": "82e80e8cf77a4a6fb98f4a6f6992b6c6"
     },
-    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 0,
-    "m_ZTestMode": 4,
-    "m_ZWriteControl": 0,
     "m_AlphaMode": 0,
-    "m_RenderFace": 2,
+    "m_TwoSided": false,
     "m_AlphaClip": true,
-    "m_CastShadows": true,
-    "m_ReceiveShadows": true,
     "m_CustomEditorGUI": ""
 }
 
@@ -928,8 +892,6 @@
     "m_DefaultReferenceName": "_Offset",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1038,8 +1000,6 @@
     "m_DefaultReferenceName": "Base_Map",
     "m_OverrideReferenceName": "_BaseMap",
     "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1048,8 +1008,6 @@
         "m_SerializedTexture": "{\"texture\":{\"fileID\":2800000,\"guid\":\"5f951043386624d62a1d57cf247df28f\",\"type\":3}}",
         "m_Guid": ""
     },
-    "isMainTexture": false,
-    "useTilingAndOffset": false,
     "m_Modifiable": true,
     "m_DefaultType": 0
 }
@@ -1226,8 +1184,7 @@
         "m_SerializableColors": []
     },
     "m_TextureType": 0,
-    "m_NormalMapSpace": 0,
-    "m_DisableGlobalMipBias": false
+    "m_NormalMapSpace": 0
 }
 
 {
@@ -1506,13 +1463,12 @@
 }
 
 {
-    "m_SGVersion": 2,
+    "m_SGVersion": 1,
     "m_Type": "UnityEditor.Rendering.BuiltIn.ShaderGraph.BuiltInTarget",
     "m_ObjectId": "8a2b8ff56e0f4886a774766b18ae322e",
     "m_ActiveSubTarget": {
         "m_Id": "41b8ed21d1d84046a8f39ea703e9c24a"
     },
-    "m_AllowMaterialOverride": false,
     "m_SurfaceType": 0,
     "m_ZWriteControl": 0,
     "m_ZTestMode": 4,
@@ -1892,8 +1848,6 @@
     "m_DefaultReferenceName": "Base_Color",
     "m_OverrideReferenceName": "_BaseColor",
     "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -1904,7 +1858,6 @@
         "b": 1.0,
         "a": 1.0
     },
-    "isMainColor": false,
     "m_ColorMode": 0
 }
 
@@ -2033,8 +1986,6 @@
     "m_DefaultReferenceName": "Alpha_Clip_Threshold",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
     "m_Precision": 0,
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
@@ -2126,9 +2077,7 @@
         -1432557354,
         -964393785,
         516401862
-    ],
-    "m_Dropdowns": [],
-    "m_DropdownSelectedEntries": []
+    ]
 }
 
 {

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Unlit_Override.shadergraph.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/CommonAssets/Shaders/Unlit_Override.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 758a7800273a8b241844d58e6311cf3c
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/055_Lighting_BasicUnlit_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/055_Lighting_BasicUnlit_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:541e32c87fb7410ae2e20c19371871b72e254eca05758a8ab7838e131b1e8be8
+size 138209

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/055_Lighting_BasicUnlit_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/055_Lighting_BasicUnlit_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: c049bed0e6b77504b8c6113e78ef037e
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/056_Lighting_BasicAlphaCut_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/056_Lighting_BasicAlphaCut_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fc1ea9e3f4225b70aace920dd1bea040d352ee6f3c667466e5b4af7d285f57a
+size 150206

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/056_Lighting_BasicAlphaCut_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/056_Lighting_BasicAlphaCut_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 49c6b4bc3931d5b44848fd9a0d14b4e3
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/058_Lighting_BasicLitTransparency_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/058_Lighting_BasicLitTransparency_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c50314c0e66bed55f77a92d282fa896b12209d466fcd4596089fc7c83a7aeadd
+size 392186

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/058_Lighting_BasicLitTransparency_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/LinuxEditor/Vulkan/None/058_Lighting_BasicLitTransparency_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 9941a66441f8d5348a4c55f702fa598b
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/055_Lighting_BasicUnlit_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/055_Lighting_BasicUnlit_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5318bddb17e197045c574e0cac4faa044dd6f0bce062c6f513afebc821eede06
+size 134732

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/055_Lighting_BasicUnlit_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/055_Lighting_BasicUnlit_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: c820884b962bf2b459344272f593a814
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/056_Lighting_BasicAlphaCut_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/056_Lighting_BasicAlphaCut_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc9d152cc28d3d4358adab086bd4aa7d02496c1d51eb8b65b3334e82998228a4
+size 146303

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/056_Lighting_BasicAlphaCut_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/056_Lighting_BasicAlphaCut_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 3300549338a606d40855dd8411a6cbe8
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/058_Lighting_BasicLitTransparency_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/058_Lighting_BasicLitTransparency_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45376a7f69610eed7e818d17b556a9671fec4b37202721e477348735d18ccdfa
+size 425412

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/058_Lighting_BasicLitTransparency_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/Metal/None/058_Lighting_BasicLitTransparency_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 09455a6be94807f4ab774ee771dcd15c
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/055_Lighting_BasicUnlit_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/055_Lighting_BasicUnlit_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dceee75df1d38242e31d087f4afcf2de96c5ad700b2409182c49590837688d9
+size 130876

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/055_Lighting_BasicUnlit_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/055_Lighting_BasicUnlit_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 490211947ed88064e912d255d318aa8c
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/056_Lighting_BasicAlphaCut_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/056_Lighting_BasicAlphaCut_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:276c5a89fd17a0791852e71ac738ba3d5e0942c5b218d90af9f4db9c5196198a
+size 142421

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/056_Lighting_BasicAlphaCut_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/056_Lighting_BasicAlphaCut_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 3c2a8aecc22f83643a87062be2e9cf75
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/058_Lighting_BasicLitTransparency_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/058_Lighting_BasicLitTransparency_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88c67d207675bf3e98f712e7119e5e45af9126253d03decbcb0184c3bb8aa1ce
+size 435612

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/058_Lighting_BasicLitTransparency_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/OSXEditor/OpenGLCore/None/058_Lighting_BasicLitTransparency_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 68c0961ad39943a4dad2983f63cb486e
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/055_Lighting_BasicUnlit_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/055_Lighting_BasicUnlit_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdcc64ad4b31e9e1b127a7f17367fba5288ebf4d3cbbd1a2a786ff3fa940c0a1
+size 142722

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/055_Lighting_BasicUnlit_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/055_Lighting_BasicUnlit_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 04dbb7e12f1f23d4d8fe1628cfc71799
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 1
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/056_Lighting_BasicAlphaCut_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/056_Lighting_BasicAlphaCut_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d6afd3da5abb1e3e50fccbf3bfdfb85792797637d898ce0213308dc347b543f
+size 155392

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/056_Lighting_BasicAlphaCut_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/056_Lighting_BasicAlphaCut_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: a4d64abb6c4306349a8529617fe3c088
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 1
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/058_Lighting_BasicLitTransparency_Override.png
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/058_Lighting_BasicLitTransparency_Override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e98559994c7c9b12ef03fc59773315527e75eaf5929d95314c2f1bc38e2649a
+size 419977

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/058_Lighting_BasicLitTransparency_Override.png.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/058_Lighting_BasicLitTransparency_Override.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 9e59e5a633bacc74497faec32bf16522
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 1
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/055_Lighting_BasicUnlit_Override.unity
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/055_Lighting_BasicUnlit_Override.unity
@@ -1,0 +1,735 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.12732534, g: 0.13415334, b: 0.121077195, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 112000002, guid: 1dcc2e57ed04f431db0930f8b5467829,
+    type: 2}
+  m_LightingSettings: {fileID: 4890085278179872738, guid: 536e8e275dd8a1a478726a6f03afd73e,
+    type: 2}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &831697935
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 831697936}
+  - component: {fileID: 831697939}
+  - component: {fileID: 831697938}
+  - component: {fileID: 831697937}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &831697936
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.25, y: 1.5, z: 3}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1725603706}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &831697937
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7cbbff6a70f55ef48a0c1b554bb8ee51, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &831697938
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &831697939
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &889296552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 889296557}
+  - component: {fileID: 889296556}
+  - component: {fileID: 889296554}
+  - component: {fileID: 889296553}
+  - component: {fileID: 889296555}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &889296553
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+--- !u!124 &889296554
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+--- !u!114 &889296555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73231aa468d81ea49bc3d914080de185, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ImageComparisonSettings:
+    TargetWidth: 640
+    TargetHeight: 360
+    PerPixelCorrectnessThreshold: 0.005
+    PerPixelGammaThreshold: 0.003921569
+    PerPixelAlphaThreshold: 0.003921569
+    AverageCorrectnessThreshold: 0.0001
+    IncorrectPixelsThreshold: 0.0000038146973
+    UseHDR: 0
+    UseBackBuffer: 0
+    ImageResolution: 0
+    ActiveImageTests: 1
+    ActivePixelTests: 7
+  WaitFrames: 0
+  XRCompatible: 1
+--- !u!20 &889296556
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 30
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &889296557
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_LocalRotation: {x: 0.17364816, y: 0, z: 0, w: 0.9848078}
+  m_LocalPosition: {x: 0, y: 5, z: -6}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 20, y: 0, z: 0}
+--- !u!1 &1266012094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1266012095}
+  - component: {fileID: 1266012098}
+  - component: {fileID: 1266012097}
+  - component: {fileID: 1266012096}
+  m_Layer: 0
+  m_Name: Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &1266012095
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_LocalRotation: {x: -0.70710576, y: -0, z: -0, w: 0.70710784}
+  m_LocalPosition: {x: 0, y: 2.000493, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 0.4}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1725603706}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -90.00001, y: 0, z: 0}
+--- !u!23 &1266012096
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6c1f6702e36a045738957ce353a92f4a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &1266012097
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &1266012098
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1725603702
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1725603706}
+  - component: {fileID: 1725603705}
+  - component: {fileID: 1725603704}
+  - component: {fileID: 1725603703}
+  m_Layer: 0
+  m_Name: Plane (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!23 &1725603703
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6c1f6702e36a045738957ce353a92f4a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &1725603704
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &1725603705
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1725603706
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.2, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1266012095}
+  - {fileID: 831697936}
+  - {fileID: 1953141553}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1953141552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1953141553}
+  - component: {fileID: 1953141556}
+  - component: {fileID: 1953141555}
+  - component: {fileID: 1953141554}
+  m_Layer: 0
+  m_Name: Sphere (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &1953141553
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953141552}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1.25, y: 1.5, z: 3}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1725603706}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1953141554
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953141552}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6adca46360202fb4d8515f2f67bda4bb, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &1953141555
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953141552}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1953141556
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953141552}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2108741017
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2108741019}
+  - component: {fileID: 2108741018}
+  m_Layer: 0
+  m_Name: Point light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &2108741018
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2108741017}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 2
+  m_Range: 5
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &2108741019
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2108741017}
+  m_LocalRotation: {x: 0.35479712, y: -0.24072689, z: 0.09506759, w: 0.89840513}
+  m_LocalPosition: {x: 0, y: 2, z: 0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 43.1, y: -30, z: 0}

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/055_Lighting_BasicUnlit_Override.unity.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/055_Lighting_BasicUnlit_Override.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81a5c26d5da321d48b11784a11789c64
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/056_Lighting_BasicAlphaCut_Override.unity
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/056_Lighting_BasicAlphaCut_Override.unity
@@ -1,0 +1,735 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.12732534, g: 0.13415334, b: 0.121077195, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 112000002, guid: 1dcc2e57ed04f431db0930f8b5467829,
+    type: 2}
+  m_LightingSettings: {fileID: 4890085278179872738, guid: 536e8e275dd8a1a478726a6f03afd73e,
+    type: 2}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &831697935
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 831697936}
+  - component: {fileID: 831697939}
+  - component: {fileID: 831697938}
+  - component: {fileID: 831697937}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &831697936
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.25, y: 1.5, z: 3}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1725603706}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &831697937
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 21505c51fdfea264191c9e542878d80a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &831697938
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &831697939
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &889296552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 889296557}
+  - component: {fileID: 889296556}
+  - component: {fileID: 889296554}
+  - component: {fileID: 889296553}
+  - component: {fileID: 889296555}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &889296553
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+--- !u!124 &889296554
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+--- !u!114 &889296555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73231aa468d81ea49bc3d914080de185, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ImageComparisonSettings:
+    TargetWidth: 640
+    TargetHeight: 360
+    PerPixelCorrectnessThreshold: 0.005
+    PerPixelGammaThreshold: 0.003921569
+    PerPixelAlphaThreshold: 0.003921569
+    AverageCorrectnessThreshold: 0.0001
+    IncorrectPixelsThreshold: 0.0000038146973
+    UseHDR: 0
+    UseBackBuffer: 0
+    ImageResolution: 0
+    ActiveImageTests: 1
+    ActivePixelTests: 7
+  WaitFrames: 0
+  XRCompatible: 1
+--- !u!20 &889296556
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 30
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &889296557
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_LocalRotation: {x: 0.17364816, y: 0, z: 0, w: 0.9848078}
+  m_LocalPosition: {x: 0, y: 5, z: -6}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 20, y: 0, z: 0}
+--- !u!1 &1266012094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1266012095}
+  - component: {fileID: 1266012098}
+  - component: {fileID: 1266012097}
+  - component: {fileID: 1266012096}
+  m_Layer: 0
+  m_Name: Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &1266012095
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_LocalRotation: {x: -0.70710576, y: -0, z: -0, w: 0.70710784}
+  m_LocalPosition: {x: 0, y: 2.000493, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 0.4}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1725603706}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -90.00001, y: 0, z: 0}
+--- !u!23 &1266012096
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6c1f6702e36a045738957ce353a92f4a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &1266012097
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &1266012098
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1725603702
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1725603706}
+  - component: {fileID: 1725603705}
+  - component: {fileID: 1725603704}
+  - component: {fileID: 1725603703}
+  m_Layer: 0
+  m_Name: Plane (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!23 &1725603703
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6c1f6702e36a045738957ce353a92f4a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &1725603704
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &1725603705
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1725603706
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.2, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1266012095}
+  - {fileID: 831697936}
+  - {fileID: 1953141553}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1953141552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1953141553}
+  - component: {fileID: 1953141556}
+  - component: {fileID: 1953141555}
+  - component: {fileID: 1953141554}
+  m_Layer: 0
+  m_Name: Sphere (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &1953141553
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953141552}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1.25, y: 1.5, z: 3}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1725603706}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1953141554
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953141552}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9b16e30a475dda24aa5583ef45757a72, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &1953141555
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953141552}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1953141556
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953141552}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2108741017
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2108741019}
+  - component: {fileID: 2108741018}
+  m_Layer: 0
+  m_Name: Point light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &2108741018
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2108741017}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 2
+  m_Range: 5
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &2108741019
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2108741017}
+  m_LocalRotation: {x: 0.35479712, y: -0.24072689, z: 0.09506759, w: 0.89840513}
+  m_LocalPosition: {x: 0, y: 2, z: 0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 43.1, y: -30, z: 0}

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/056_Lighting_BasicAlphaCut_Override.unity.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/056_Lighting_BasicAlphaCut_Override.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d0373ff790b226145a1ffcea0d7df64a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/058_Lighting_BasicLitTransparency.unity
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/058_Lighting_BasicLitTransparency.unity
@@ -563,7 +563,7 @@ MonoBehaviour:
     PerPixelCorrectnessThreshold: 0.005
     PerPixelGammaThreshold: 0.003921569
     PerPixelAlphaThreshold: 0.003921569
-    AverageCorrectnessThreshold: 0.001
+    AverageCorrectnessThreshold: 0.0001
     IncorrectPixelsThreshold: 0.0000038146973
     UseHDR: 0
     UseBackBuffer: 0

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/058_Lighting_BasicLitTransparency_Override.unity
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/058_Lighting_BasicLitTransparency_Override.unity
@@ -1,0 +1,963 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.12732534, g: 0.13415334, b: 0.121077195, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 112000002, guid: 1dcc2e57ed04f431db0930f8b5467829,
+    type: 2}
+  m_LightingSettings: {fileID: 4890085278179872738, guid: 536e8e275dd8a1a478726a6f03afd73e,
+    type: 2}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &2483977
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2483978}
+  - component: {fileID: 2483981}
+  - component: {fileID: 2483980}
+  - component: {fileID: 2483979}
+  m_Layer: 0
+  m_Name: Sphere (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &2483978
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2483977}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 1.25, y: 1.5, z: 3}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 894700876}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!23 &2483979
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2483977}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: dc4a799f216fbb1479d12041a0a78807, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &2483980
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2483977}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &2483981
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2483977}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &360387999
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 360388000}
+  - component: {fileID: 360388003}
+  - component: {fileID: 360388002}
+  - component: {fileID: 360388001}
+  m_Layer: 0
+  m_Name: Sphere (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &360388000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 360387999}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 3.75, y: 1.5, z: 3}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 894700876}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!23 &360388001
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 360387999}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 07e34a69dfc96324484a2fd2c2790302, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &360388002
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 360387999}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &360388003
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 360387999}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &477619608
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 477619609}
+  - component: {fileID: 477619612}
+  - component: {fileID: 477619611}
+  - component: {fileID: 477619610}
+  m_Layer: 0
+  m_Name: Sphere (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &477619609
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477619608}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -1.25, y: 1.5, z: 3}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 894700876}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!23 &477619610
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477619608}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 306b5111dbc500c4f98d5eea7b819660, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &477619611
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477619608}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &477619612
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477619608}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &831697935
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 831697936}
+  - component: {fileID: 831697939}
+  - component: {fileID: 831697938}
+  - component: {fileID: 831697937}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &831697936
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -3.75, y: 1.5, z: 3}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 894700876}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!23 &831697937
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 78d8b501c2461b8498e955e3f9b23e96, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &831697938
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &831697939
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831697935}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &889296552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 889296557}
+  - component: {fileID: 889296556}
+  - component: {fileID: 889296554}
+  - component: {fileID: 889296553}
+  - component: {fileID: 889296555}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &889296553
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+--- !u!124 &889296554
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+--- !u!114 &889296555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73231aa468d81ea49bc3d914080de185, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ImageComparisonSettings:
+    TargetWidth: 640
+    TargetHeight: 360
+    PerPixelCorrectnessThreshold: 0.005
+    PerPixelGammaThreshold: 0.003921569
+    PerPixelAlphaThreshold: 0.003921569
+    AverageCorrectnessThreshold: 0.001
+    IncorrectPixelsThreshold: 0.0000038146973
+    UseHDR: 0
+    UseBackBuffer: 0
+    ImageResolution: 0
+    ActiveImageTests: 1
+    ActivePixelTests: 7
+  WaitFrames: 0
+  XRCompatible: 1
+--- !u!20 &889296556
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 30
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &889296557
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889296552}
+  m_LocalRotation: {x: 0.17364816, y: 0, z: 0, w: 0.9848078}
+  m_LocalPosition: {x: 0, y: 5, z: -7.21}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 20, y: 0, z: 0}
+--- !u!1 &894700875
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 894700876}
+  m_Layer: 0
+  m_Name: Group
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &894700876
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 894700875}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1725603706}
+  - {fileID: 1266012095}
+  - {fileID: 831697936}
+  - {fileID: 477619609}
+  - {fileID: 2483978}
+  - {fileID: 360388000}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1266012094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1266012095}
+  - component: {fileID: 1266012098}
+  - component: {fileID: 1266012097}
+  - component: {fileID: 1266012096}
+  m_Layer: 0
+  m_Name: Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &1266012095
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_LocalRotation: {x: -0.70710576, y: -0, z: -0, w: 0.70710784}
+  m_LocalPosition: {x: 0, y: 2.000493, z: 5}
+  m_LocalScale: {x: 1.5, y: 1, z: 0.4}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 894700876}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: -90.00001, y: 0, z: 0}
+--- !u!23 &1266012096
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a9c0348b0de99ef45904e10b3b3d4e8c, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &1266012097
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &1266012098
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1266012094}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1725603702
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1725603706}
+  - component: {fileID: 1725603705}
+  - component: {fileID: 1725603704}
+  - component: {fileID: 1725603703}
+  m_Layer: 0
+  m_Name: Plane (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!23 &1725603703
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a9c0348b0de99ef45904e10b3b3d4e8c, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &1725603704
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &1725603705
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1725603706
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725603702}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 894700876}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2108741017
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2108741019}
+  - component: {fileID: 2108741018}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &2108741018
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2108741017}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 2
+  m_Range: 5
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &2108741019
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2108741017}
+  m_LocalRotation: {x: 0.35479712, y: -0.24072689, z: 0.09506759, w: 0.89840513}
+  m_LocalPosition: {x: 0, y: 4.269, z: 0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 43.1, y: -30, z: 0}

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/058_Lighting_BasicLitTransparency_Override.unity
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/058_Lighting_BasicLitTransparency_Override.unity
@@ -567,7 +567,7 @@ MonoBehaviour:
     PerPixelCorrectnessThreshold: 0.005
     PerPixelGammaThreshold: 0.003921569
     PerPixelAlphaThreshold: 0.003921569
-    AverageCorrectnessThreshold: 0.001
+    AverageCorrectnessThreshold: 0.0001
     IncorrectPixelsThreshold: 0.0000038146973
     UseHDR: 0
     UseBackBuffer: 0

--- a/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/058_Lighting_BasicLitTransparency_Override.unity.meta
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/Assets/Scenes/058_Lighting_BasicLitTransparency_Override.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ec4db895a38d8b544bd73782c659f0ab
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/BuiltInGraphicsTest_Foundation/ProjectSettings/EditorBuildSettings.asset
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/ProjectSettings/EditorBuildSettings.asset
@@ -36,11 +36,17 @@ EditorBuildSettings:
     path: Assets/Scenes/056_Lighting_BasicAlphaCut.unity
     guid: ba30e2ead57624e42a64622b129e06fe
   - enabled: 1
+    path: Assets/Scenes/056_Lighting_BasicAlphaCut_Override.unity
+    guid: d0373ff790b226145a1ffcea0d7df64a
+  - enabled: 1
     path: Assets/Scenes/057_Lighting_DeferredSimple.unity
     guid: e20d7842295fc54428769e56f262fec9
   - enabled: 1
     path: Assets/Scenes/058_Lighting_BasicLitTransparency.unity
     guid: 2d9f712bea4002e47a18b95e8526f176
+  - enabled: 1
+    path: Assets/Scenes/058_Lighting_BasicLitTransparency_Override.unity
+    guid: ec4db895a38d8b544bd73782c659f0ab
   - enabled: 1
     path: Assets/Scenes/059_Lighting_BasicNormals.unity
     guid: 8bcc1f5676608a44e8fcf74707e3bb0d

--- a/TestProjects/BuiltInGraphicsTest_Foundation/ProjectSettings/EditorBuildSettings.asset
+++ b/TestProjects/BuiltInGraphicsTest_Foundation/ProjectSettings/EditorBuildSettings.asset
@@ -30,6 +30,9 @@ EditorBuildSettings:
     path: Assets/Scenes/055_Lighting_BasicUnlit.unity
     guid: b26153a0dfe8c4448835dd5d89134dd4
   - enabled: 1
+    path: Assets/Scenes/055_Lighting_BasicUnlit_Override.unity
+    guid: 81a5c26d5da321d48b11784a11789c64
+  - enabled: 1
     path: Assets/Scenes/056_Lighting_BasicAlphaCut.unity
     guid: ba30e2ead57624e42a64622b129e06fe
   - enabled: 1

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -258,6 +258,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `Compute Deformation` Node to read deformed vertex data from Dots Deformations.
 - Added new graph nodes that allow sampling Virtual Textures
 - Shader Graph now uses a new file format that is much friendlier towards version control systems and humans. Existing Shader Graphs and will use the new format next time they are saved.
+- Added 'Allow Material Override' option to the built-in target for shader graph.
 
 ### Changed
 - Changed the `Branch` node so that it uses a ternary operator (`Out = bool ? a : B`) instead of a linear interpolate function.

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/AssetPostProcessors/MaterialPostprocessor.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/AssetPostProcessors/MaterialPostprocessor.cs
@@ -104,7 +104,7 @@ namespace UnityEditor.Rendering.BuiltIn
                     }
                     else if (shaderID.IsShaderGraph())
                     {
-                        // Assumed to be version 0 since to asset version was found
+                        // Assumed to be version 0 since no asset version was found
                         assetVersion.version = 0;
                     }
 

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGUI/BaseShaderGUI.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGUI/BaseShaderGUI.cs
@@ -35,6 +35,8 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             public static readonly string[] blendModeNames = Enum.GetNames(typeof(BlendMode));
             public static readonly string[] renderFaceNames = Enum.GetNames(typeof(RenderFace));
             public static readonly string[] zwriteNames = Enum.GetNames(typeof(UnityEditor.Rendering.BuiltIn.ShaderGraph.ZWriteControl));
+            // need to skip the first entry for ztest (ZTestMode.Disabled is not a valid value)
+            public static readonly int[] ztestValues = (int[])Enum.GetValues(typeof(UnityEditor.Rendering.BuiltIn.ShaderGraph.ZTestMode));
             public static readonly string[] ztestNames = Enum.GetNames(typeof(UnityEditor.Rendering.BuiltIn.ShaderGraph.ZTestMode));
 
             public static readonly GUIContent surfaceType = EditorGUIUtility.TrTextContent("Surface Type",
@@ -109,7 +111,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             DoPopup(Styles.zwriteText, materialEditor, zWriteProp, Styles.zwriteNames);
 
             var ztestProp = FindProperty(Property.ZTest(), properties, false);
-            DoPopup(Styles.ztestText, materialEditor, ztestProp, Styles.ztestNames);
+            DoIntPopup(Styles.ztestText, materialEditor, ztestProp, Styles.ztestNames, Styles.ztestValues);
 
             var alphaClipProp = FindProperty(Property.AlphaClip(), properties, false);
             DrawFloatToggleProperty(Styles.alphaClipText, alphaClipProp);
@@ -231,6 +233,14 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             materialEditor.PopupShaderProperty(property, label, options);
         }
 
+        public static void DoIntPopup(GUIContent label, MaterialEditor materialEditor, MaterialProperty property, string[] options, int[] optionValues)
+        {
+            if (property == null)
+                return;
+
+            materialEditor.IntPopupShaderProperty(property, label.text, options, optionValues);
+        }
+
         public static void DrawFloatToggleProperty(GUIContent styles, MaterialProperty prop)
         {
             if (prop == null)
@@ -259,6 +269,23 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             if (EditorGUI.EndChangeCheck() && (newValue != val || prop.hasMixedValue))
             {
                 editor.RegisterPropertyChangeUndo(label.text);
+                prop.floatValue = val = newValue;
+            }
+
+            return val;
+        }
+
+        public static int IntPopupShaderProperty(this MaterialEditor editor, MaterialProperty prop, string label, string[] displayedOptions, int[] optionValues)
+        {
+            int val = (int)prop.floatValue;
+
+            EditorGUI.BeginChangeCheck();
+            EditorGUI.showMixedValue = prop.hasMixedValue;
+            int newValue = EditorGUILayout.IntPopup(label, val, displayedOptions, optionValues);
+            EditorGUI.showMixedValue = false;
+            if (EditorGUI.EndChangeCheck() && (newValue != val || prop.hasMixedValue))
+            {
+                editor.RegisterPropertyChangeUndo(label);
                 prop.floatValue = val = newValue;
             }
 

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGUI/BaseShaderGUI.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGUI/BaseShaderGUI.cs
@@ -179,7 +179,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                         else if (blendMode == BlendMode.Premultiply)
                             SetBlendMode(material, UnityEngine.Rendering.BlendMode.One, UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
                         else if (blendMode == BlendMode.Additive)
-                            SetBlendMode(material, UnityEngine.Rendering.BlendMode.One, UnityEngine.Rendering.BlendMode.One);
+                            SetBlendMode(material, UnityEngine.Rendering.BlendMode.SrcAlpha, UnityEngine.Rendering.BlendMode.One);
                         else if (blendMode == BlendMode.Multiply)
                             SetBlendMode(material, UnityEngine.Rendering.BlendMode.DstColor, UnityEngine.Rendering.BlendMode.Zero);
                         CoreUtils.SetKeyword(material, Keyword.SG_AlphaPremultiplyOn, blendMode == BlendMode.Premultiply);

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/BuiltInFields.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/BuiltInFields.cs
@@ -11,7 +11,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
         #endregion
 
         #region Fields
-        // TODO: figure which ones are actually URP only, leaver those here and put others shared/core Fields in Fields.cs
+        // TODO: figure which ones are actually URP only, leave those here and put others shared/core Fields in Fields.cs
         public static FieldDescriptor SurfaceOpaque =         new FieldDescriptor(kSurfaceType, "Opaque",                 "_SURFACE_TYPE_OPAQUE 1");
         public static FieldDescriptor SurfaceTransparent =    new FieldDescriptor(kSurfaceType, "Transparent",            "_SURFACE_TYPE_TRANSPARENT 1");
         public static FieldDescriptor BlendAdd =              new FieldDescriptor(kBlendMode,   "Add",                    "_BLENDMODE_ADD 1");

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Includes/UnlitPass.hlsl
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Includes/UnlitPass.hlsl
@@ -25,7 +25,7 @@ half4 frag(PackedVaryings packedInput) : SV_TARGET
     #endif
 
 #ifdef _ALPHAPREMULTIPLY_ON
-    surfaceDescription.BaseColor *= surfaceDescription.Alpha;
+    surfaceDescription.BaseColor *= alpha;
 #endif
 
     return half4(surfaceDescription.BaseColor, alpha);

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInLitSubTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInLitSubTarget.cs
@@ -76,14 +76,6 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
         public override void GetFields(ref TargetFieldContext context)
         {
             var descs = context.blocks.Select(x => x.descriptor);
-            // Surface Type & Blend Mode
-            // These must be set per SubTarget as Sprite SubTargets override them
-            context.AddField(BuiltInFields.SurfaceOpaque,       target.surfaceType == SurfaceType.Opaque);
-            context.AddField(BuiltInFields.SurfaceTransparent,  target.surfaceType != SurfaceType.Opaque);
-            context.AddField(BuiltInFields.BlendAdd,            target.surfaceType != SurfaceType.Opaque && target.alphaMode == AlphaMode.Additive);
-            context.AddField(Fields.BlendAlpha,                 target.surfaceType != SurfaceType.Opaque && target.alphaMode == AlphaMode.Alpha);
-            context.AddField(BuiltInFields.BlendMultiply,       target.surfaceType != SurfaceType.Opaque && target.alphaMode == AlphaMode.Multiply);
-            context.AddField(BuiltInFields.BlendPremultiply,    target.surfaceType != SurfaceType.Opaque && target.alphaMode == AlphaMode.Premultiply);
 
             // Lit
             context.AddField(BuiltInFields.NormalDropOffOS,     normalDropOffSpace == NormalDropOffSpace.Object);

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInLitSubTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInLitSubTarget.cs
@@ -278,7 +278,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                     fieldDependencies = CoreFieldDependencies.Default,
 
                     // Conditional State
-                    renderStates = CoreRenderStates.ForwardAdd,
+                    renderStates = CoreRenderStates.ForwardAdd(target),
                     pragmas  = CorePragmas.ForwardAdd,     // NOTE: SM 2.0 only GL
                     defines = new DefineCollection() { CoreDefines.BuiltInTargetAPI },
                     keywords = new KeywordCollection { LitKeywords.ForwardAdd },

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
@@ -88,6 +88,10 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
         [SerializeField]
         JsonData<SubTarget> m_ActiveSubTarget;
 
+        // When checked, allows the material to control ALL surface settings (uber shader style)
+        [SerializeField]
+        bool m_AllowMaterialOverride = false;
+
         [SerializeField]
         SurfaceType m_SurfaceType = SurfaceType.Opaque;
 
@@ -149,6 +153,11 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             get => m_ActiveSubTarget.value;
             set => m_ActiveSubTarget = value;
         }
+        public bool allowMaterialOverride
+        {
+            get => m_AllowMaterialOverride;
+            set => m_AllowMaterialOverride = value;
+        }
 
         public SurfaceType surfaceType
         {
@@ -190,6 +199,31 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
         {
             get => m_CustomEditorGUI;
             set => m_CustomEditorGUI = value;
+        }
+
+        // generally used to know if we need to build a depth pass
+        public bool mayWriteDepth
+        {
+            get
+            {
+                if (allowMaterialOverride)
+                {
+                    // material may or may not choose to write depth... we should create the depth pass
+                    return true;
+                }
+                else
+                {
+                    switch (zWriteControl)
+                    {
+                        case ZWriteControl.Auto:
+                            return (surfaceType == SurfaceType.Opaque);
+                        case ZWriteControl.ForceDisabled:
+                            return false;
+                        default:
+                            return true;
+                    }
+                }
+            }
         }
 
         public override bool IsActive()
@@ -303,6 +337,21 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             context.AddProperty("Custom Editor GUI", m_CustomGUIField, (evt) => {});
         }
 
+        public void AddDefaultMaterialOverrideGUI(ref TargetPropertyGUIContext context, Action onChange, Action<String> registerUndo)
+        {
+            // At some point we may want to convert this to be a per-property control
+            // or Unify the UX with the upcoming "lock" feature of the Material Variant properties
+            context.AddProperty("Allow Material Override", new Toggle() { value = allowMaterialOverride }, (evt) =>
+            {
+                if (Equals(allowMaterialOverride, evt.newValue))
+                    return;
+
+                registerUndo("Change Allow Material Override");
+                allowMaterialOverride = evt.newValue;
+                onChange();
+            });
+        }
+
         public void GetDefaultSurfacePropertiesGUI(ref TargetPropertyGUIContext context, Action onChange, Action<String> registerUndo)
         {
             context.AddProperty("Surface Type", new EnumField(SurfaceType.Opaque) { value = surfaceType }, (evt) =>
@@ -388,6 +437,21 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             return scriptableRenderPipeline == null;
         }
 
+        public override void OnAfterDeserialize(string json)
+        {
+            base.OnAfterDeserialize(json);
+
+            if (this.sgVersion < latestVersion)
+            {
+                // Version 0 didn't have m_AllowMaterialOverride but acted as if it was true
+                if (this.sgVersion == 0)
+                {
+                    this.m_AllowMaterialOverride = true;
+                }
+                ChangeVersion(latestVersion);
+            }
+        }
+
         #region Metadata
         string IHasMetadata.identifier
         {
@@ -414,128 +478,208 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
     #region Passes
     static class CorePasses
     {
-        public static readonly PassDescriptor DepthOnly = new PassDescriptor()
+
+        internal static void AddSurfaceTypeControlToPass(ref PassDescriptor pass, BuiltInTarget target)
         {
-            // Definition
-            displayName = "DepthOnly",
-            referenceName = "SHADERPASS_DEPTHONLY",
-            lightMode = "DepthOnly",
-            useInPreview = true,
+            if (target.allowMaterialOverride)
+            {
+                pass.keywords.Add(CoreKeywordDescriptors.SurfaceTypeTransparent);
+            }
+            else if(target.surfaceType == SurfaceType.Transparent)
+            {
+                pass.defines.Add(CoreKeywordDescriptors.SurfaceTypeTransparent, 1);
+            }
+        }
 
-            // Template
-            passTemplatePath = BuiltInTarget.kTemplatePath,
-            sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
-
-            // Port Mask
-            validVertexBlocks = CoreBlockMasks.Vertex,
-            validPixelBlocks = CoreBlockMasks.FragmentAlphaOnly,
-
-            // Fields
-            structs = CoreStructCollections.Default,
-            fieldDependencies = CoreFieldDependencies.Default,
-
-            // Conditional State
-            renderStates = CoreRenderStates.DepthOnly,
-            pragmas = CorePragmas.Instanced,
-            defines = CoreDefines.BuiltInTargetAPI,
-            includes = CoreIncludes.DepthOnly,
-
-            // Custom Interpolator Support
-            customInterpolators = CoreCustomInterpDescriptors.Common
-        };
-
-        public static readonly PassDescriptor ShadowCaster = new PassDescriptor()
+        internal static void AddAlphaPremultiplyControlToPass(ref PassDescriptor pass, BuiltInTarget target)
         {
-            // Definition
-            displayName = "ShadowCaster",
-            referenceName = "SHADERPASS_SHADOWCASTER",
-            lightMode = "ShadowCaster",
-
-            // Template
-            passTemplatePath = BuiltInTarget.kTemplatePath,
-            sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
-
-            // Port Mask
-            validVertexBlocks = CoreBlockMasks.Vertex,
-            validPixelBlocks = CoreBlockMasks.FragmentAlphaOnly,
-
-            // Fields
-            structs = CoreStructCollections.Default,
-            requiredFields = CoreRequiredFields.ShadowCaster,
-            fieldDependencies = CoreFieldDependencies.Default,
-
-            // Conditional State
-            renderStates = CoreRenderStates.ShadowCaster,
-            pragmas = CorePragmas.ShadowCaster,
-            defines = CoreDefines.BuiltInTargetAPI,
-            keywords = CoreKeywords.ShadowCaster,
-            includes = CoreIncludes.ShadowCaster,
-
-            // Custom Interpolator Support
-            customInterpolators = CoreCustomInterpDescriptors.Common
-        };
-
-        public static readonly PassDescriptor SceneSelection = new PassDescriptor()
+            if (target.allowMaterialOverride)
+            {
+                pass.keywords.Add(CoreKeywordDescriptors.AlphaPremultiplyOn);
+            }
+            else if (target.alphaMode == AlphaMode.Premultiply)
+            {
+                pass.defines.Add(CoreKeywordDescriptors.AlphaPremultiplyOn, 1);
+            }
+        }
+        internal static void AddAlphaClipControlToPass(ref PassDescriptor pass, BuiltInTarget target)
         {
-            // Definition
-            displayName = "SceneSelectionPass",
-            referenceName = "SceneSelectionPass",
-            lightMode = "SceneSelectionPass",
-            useInPreview = true,
+            if (target.allowMaterialOverride)
+            {
+                pass.keywords.Add(CoreKeywordDescriptors.AlphaClip);
+                pass.keywords.Add(CoreKeywordDescriptors.AlphaTestOn);
+            }
+            else if (target.alphaClip)
+            {
+                pass.defines.Add(CoreKeywordDescriptors.AlphaClip, 1);
+                pass.defines.Add(CoreKeywordDescriptors.AlphaTestOn, 1);
+            }
+        }
 
-            // Template
-            passTemplatePath = BuiltInTarget.kTemplatePath,
-            sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
-
-            // Port Mask
-            validVertexBlocks = CoreBlockMasks.Vertex,
-            validPixelBlocks = CoreBlockMasks.FragmentAlphaOnly,
-
-            // Fields
-            structs = CoreStructCollections.Default,
-            fieldDependencies = CoreFieldDependencies.Default,
-
-            // Conditional State
-            renderStates = CoreRenderStates.SceneSelection,
-            pragmas = CorePragmas.Instanced,
-            defines = CoreDefines.SceneSelection,
-            keywords = CoreKeywords.Common,
-            includes = CoreIncludes.SceneSelection,
-
-            // Custom Interpolator Support
-            customInterpolators = CoreCustomInterpDescriptors.Common
-        };
-
-        public static readonly PassDescriptor ScenePicking = new PassDescriptor()
+        internal static void AddTargetSurfaceControlsToPass(ref PassDescriptor pass, BuiltInTarget target)
         {
-            // Definition
-            displayName = "ScenePickingPass",
-            referenceName = "ScenePickingPass",
-            lightMode = "Picking",
-            useInPreview = true,
+            AddSurfaceTypeControlToPass(ref pass, target);
+            AddAlphaPremultiplyControlToPass(ref pass, target);
+            AddAlphaClipControlToPass(ref pass, target);
+        }
 
-            // Template
-            passTemplatePath = BuiltInTarget.kTemplatePath,
-            sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
+        internal static void AddCommonPassSurfaceControlsToPass(ref PassDescriptor pass, BuiltInTarget target)
+        {
+            AddSurfaceTypeControlToPass(ref pass, target);
+            AddAlphaClipControlToPass(ref pass, target);
+        }
 
-            // Port Mask
-            validVertexBlocks = CoreBlockMasks.Vertex,
-            validPixelBlocks = CoreBlockMasks.FragmentAlphaOnly,
+        public static PassDescriptor DepthOnly(BuiltInTarget target)
+        {
+            var result = new PassDescriptor()
+            {
+                // Definition
+                displayName = "DepthOnly",
+                referenceName = "SHADERPASS_DEPTHONLY",
+                lightMode = "DepthOnly",
+                useInPreview = true,
 
-            // Fields
-            structs = CoreStructCollections.Default,
-            fieldDependencies = CoreFieldDependencies.Default,
+                // Template
+                passTemplatePath = BuiltInTarget.kTemplatePath,
+                sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
 
-            // Conditional State
-            renderStates = CoreRenderStates.ScenePicking,
-            pragmas = CorePragmas.Instanced,
-            defines = CoreDefines.ScenePicking,
-            keywords = CoreKeywords.Common,
-            includes = CoreIncludes.ScenePicking,
+                // Port Mask
+                validVertexBlocks = CoreBlockMasks.Vertex,
+                validPixelBlocks = CoreBlockMasks.FragmentAlphaOnly,
 
-            // Custom Interpolator Support
-            customInterpolators = CoreCustomInterpDescriptors.Common
-        };
+                // Fields
+                structs = CoreStructCollections.Default,
+                fieldDependencies = CoreFieldDependencies.Default,
+
+                // Conditional State
+                renderStates = CoreRenderStates.DepthOnly(target),
+                pragmas = CorePragmas.Instanced,
+                defines = new DefineCollection() { CoreDefines.BuiltInTargetAPI },
+                keywords = new KeywordCollection(),
+                includes = CoreIncludes.DepthOnly,
+
+                // Custom Interpolator Support
+                customInterpolators = CoreCustomInterpDescriptors.Common
+            };
+
+            AddAlphaClipControlToPass(ref result, target);
+
+            return result;
+        }
+
+        public static PassDescriptor ShadowCaster(BuiltInTarget target)
+        {
+            var result = new PassDescriptor()
+            {
+                // Definition
+                displayName = "ShadowCaster",
+                referenceName = "SHADERPASS_SHADOWCASTER",
+                lightMode = "ShadowCaster",
+
+                // Template
+                passTemplatePath = BuiltInTarget.kTemplatePath,
+                sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
+
+                // Port Mask
+                validVertexBlocks = CoreBlockMasks.Vertex,
+                validPixelBlocks = CoreBlockMasks.FragmentAlphaOnly,
+
+                // Fields
+                structs = CoreStructCollections.Default,
+                requiredFields = CoreRequiredFields.ShadowCaster,
+                fieldDependencies = CoreFieldDependencies.Default,
+
+                // Conditional State
+                renderStates = CoreRenderStates.ShadowCaster(target),
+                pragmas = CorePragmas.ShadowCaster,
+                defines = new DefineCollection() { CoreDefines.BuiltInTargetAPI },
+                keywords = new KeywordCollection { CoreKeywords.ShadowCaster },
+                includes = CoreIncludes.ShadowCaster,
+
+                // Custom Interpolator Support
+                customInterpolators = CoreCustomInterpDescriptors.Common
+            };
+
+            AddCommonPassSurfaceControlsToPass(ref result, target);
+
+            return result;
+        }
+
+        public static PassDescriptor SceneSelection(BuiltInTarget target)
+        {
+            var result = new PassDescriptor()
+            {
+                // Definition
+                displayName = "SceneSelectionPass",
+                referenceName = "SceneSelectionPass",
+                lightMode = "SceneSelectionPass",
+                useInPreview = true,
+
+                // Template
+                passTemplatePath = BuiltInTarget.kTemplatePath,
+                sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
+
+                // Port Mask
+                validVertexBlocks = CoreBlockMasks.Vertex,
+                validPixelBlocks = CoreBlockMasks.FragmentAlphaOnly,
+
+                // Fields
+                structs = CoreStructCollections.Default,
+                fieldDependencies = CoreFieldDependencies.Default,
+
+                // Conditional State
+                renderStates = CoreRenderStates.SceneSelection(target),
+                pragmas = CorePragmas.Instanced,
+                defines = CoreDefines.SceneSelection,
+                keywords = new KeywordCollection(),
+                includes = CoreIncludes.SceneSelection,
+
+                // Custom Interpolator Support
+                customInterpolators = CoreCustomInterpDescriptors.Common
+            };
+
+            AddCommonPassSurfaceControlsToPass(ref result, target);
+
+            return result;
+        }
+
+        public static PassDescriptor ScenePicking(BuiltInTarget target)
+        {
+            var result = new PassDescriptor()
+            {
+                // Definition
+                displayName = "ScenePickingPass",
+                referenceName = "ScenePickingPass",
+                lightMode = "Picking",
+                useInPreview = true,
+
+                // Template
+                passTemplatePath = BuiltInTarget.kTemplatePath,
+                sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
+
+                // Port Mask
+                validVertexBlocks = CoreBlockMasks.Vertex,
+                validPixelBlocks = CoreBlockMasks.FragmentAlphaOnly,
+
+                // Fields
+                structs = CoreStructCollections.Default,
+                fieldDependencies = CoreFieldDependencies.Default,
+
+                // Conditional State
+                renderStates = CoreRenderStates.ScenePicking(target),
+                pragmas = CorePragmas.Instanced,
+                defines = CoreDefines.ScenePicking,
+                keywords = new KeywordCollection(),
+                includes = CoreIncludes.ScenePicking,
+
+                // Custom Interpolator Support
+                customInterpolators = CoreCustomInterpDescriptors.Common
+            };
+
+            AddCommonPassSurfaceControlsToPass(ref result, target);
+
+            return result;
+        }
     }
     #endregion
 
@@ -611,7 +755,86 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             public static readonly string zTest = "[" + Property.SG_ZTest + "]";
         }
 
-        public static readonly RenderStateCollection Default = new RenderStateCollection
+        public static Cull RenderFaceToCull(RenderFace renderFace)
+        {
+            switch (renderFace)
+            {
+                case RenderFace.Back:
+                    return Cull.Front;
+                case RenderFace.Front:
+                    return Cull.Back;
+                case RenderFace.Both:
+                    return Cull.Off;
+            }
+            return Cull.Back;
+        }
+
+        public static ZWrite ZWriteControlToZWrite(ZWriteControl zWriteControl, SurfaceType surfaceType)
+        {
+            if (zWriteControl == ZWriteControl.ForceEnabled)
+                return ZWrite.On;
+            else if (zWriteControl == ZWriteControl.ForceDisabled)
+                return ZWrite.Off;
+            else // ZWriteControl.Auto
+            {
+                if (surfaceType == SurfaceType.Opaque)
+                    return ZWrite.On;
+                else
+                    return ZWrite.Off;
+            }
+        }
+
+        public static void AddUberSwitchedZTest(BuiltInTarget target, RenderStateCollection renderStates)
+        {
+            if (target.allowMaterialOverride)
+                renderStates.Add(RenderState.ZTest(Uniforms.zTest));
+            else
+                renderStates.Add(RenderState.ZTest(target.zTestMode.ToString()));
+        }
+
+        public static void AddUberSwitchedZWrite(BuiltInTarget target, RenderStateCollection renderStates)
+        {
+            if (target.allowMaterialOverride)
+                renderStates.Add(RenderState.ZWrite(Uniforms.zWrite));
+            else
+                renderStates.Add(RenderState.ZWrite(ZWriteControlToZWrite(target.zWriteControl, target.surfaceType)));
+        }
+
+        public static void AddUberSwitchedCull(BuiltInTarget target, RenderStateCollection renderStates)
+        {
+            if (target.allowMaterialOverride)
+                renderStates.Add(RenderState.Cull(Uniforms.cullMode));
+            else
+                renderStates.Add(RenderState.Cull(RenderFaceToCull(target.renderFace)));
+        }
+
+        public static void AddUberSwitchedBlend(BuiltInTarget target, RenderStateCollection renderStates)
+        {
+            if (target.allowMaterialOverride)
+            {
+                renderStates.Add(RenderState.Blend(Uniforms.srcBlend, Uniforms.dstBlend));
+            }
+            else
+            {
+                if (target.surfaceType == SurfaceType.Opaque)
+                {
+                    renderStates.Add(RenderState.Blend(Blend.One, Blend.Zero));
+                }
+                else
+                {
+                    if (target.alphaMode == AlphaMode.Alpha)
+                        renderStates.Add(RenderState.Blend(Blend.SrcAlpha, Blend.OneMinusSrcAlpha, Blend.One, Blend.OneMinusSrcAlpha));
+                    else if (target.alphaMode == AlphaMode.Premultiply)
+                        renderStates.Add(RenderState.Blend(Blend.One, Blend.OneMinusSrcAlpha, Blend.One, Blend.OneMinusSrcAlpha));
+                    else if (target.alphaMode == AlphaMode.Additive)
+                        renderStates.Add(RenderState.Blend(Blend.SrcAlpha, Blend.One, Blend.One, Blend.One));
+                    else if (target.alphaMode == AlphaMode.Multiply)
+                        renderStates.Add(RenderState.Blend(Blend.DstColor, Blend.Zero));
+                }
+            }
+        }
+
+        public static readonly RenderStateCollection MaterialControlledDefault = new RenderStateCollection
         {
             { RenderState.ZTest(Uniforms.zTest) },
             { RenderState.ZWrite(Uniforms.zWrite) },
@@ -620,14 +843,21 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             { RenderState.ColorMask("ColorMask RGB"), new FieldCondition(BuiltInFields.SurfaceOpaque, false) },
         };
 
-        public static readonly RenderStateCollection Forward = new RenderStateCollection
+        public static RenderStateCollection Default(BuiltInTarget target)
         {
-            { RenderState.ZTest(Uniforms.zTest) },
-            { RenderState.ZWrite(Uniforms.zWrite) },
-            { RenderState.Cull(Uniforms.cullMode) },
-            { RenderState.Blend(Uniforms.srcBlend, Uniforms.dstBlend) },
-            { RenderState.ColorMask("ColorMask RGB"), new FieldCondition(BuiltInFields.SurfaceOpaque, false) },
-        };
+            if (target.allowMaterialOverride)
+                return MaterialControlledDefault;
+            else
+            {
+                var result = new RenderStateCollection();
+                AddUberSwitchedZTest(target, result);
+                AddUberSwitchedZWrite(target, result);
+                AddUberSwitchedCull(target, result);
+                AddUberSwitchedBlend(target, result);
+                result.Add(RenderState.ColorMask("ColorMask RGB"), new FieldCondition(BuiltInFields.SurfaceOpaque, false));
+                return result;
+            }
+        }
 
         public static readonly RenderStateCollection ForwardAdd = new RenderStateCollection
         {
@@ -644,33 +874,43 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             { RenderState.Cull(Cull.Off) },
         };
 
-        public static readonly RenderStateCollection ShadowCaster = new RenderStateCollection
+        public static RenderStateCollection ShadowCaster(BuiltInTarget target)
         {
-            { RenderState.ZTest(ZTest.LEqual) },
-            { RenderState.ZWrite(ZWrite.On) },
-            { RenderState.Cull(Uniforms.cullMode) },
-            { RenderState.Blend(Uniforms.srcBlend, Uniforms.dstBlend) },
-            { RenderState.ColorMask("ColorMask 0") },
-        };
+            var result = new RenderStateCollection();
+            result.Add(RenderState.ZTest(ZTest.LEqual));
+            result.Add(RenderState.ZWrite(ZWrite.On));
+            AddUberSwitchedCull(target, result);
+            AddUberSwitchedBlend(target, result);
+            result.Add(RenderState.ColorMask("ColorMask 0"));
+            return result;
+        }
 
-        public static readonly RenderStateCollection DepthOnly = new RenderStateCollection
+        public static RenderStateCollection DepthOnly(BuiltInTarget target)
         {
-            { RenderState.ZTest(ZTest.LEqual) },
-            { RenderState.ZWrite(ZWrite.On) },
-            { RenderState.Cull(Uniforms.cullMode) },
-            { RenderState.Blend(Uniforms.srcBlend, Uniforms.dstBlend) },
-            { RenderState.ColorMask("ColorMask 0") },
-        };
+            var result = new RenderStateCollection();
+            result.Add(RenderState.ZTest(ZTest.LEqual));
+            result.Add(RenderState.ZWrite(ZWrite.On));
+            AddUberSwitchedCull(target, result);
+            AddUberSwitchedBlend(target, result);
+            result.Add(RenderState.ColorMask("ColorMask 0"));
+            return result;
+        }   
 
-        public static readonly RenderStateCollection SceneSelection = new RenderStateCollection
+        public static RenderStateCollection SceneSelection(BuiltInTarget target)
         {
-            { RenderState.Cull(Cull.Off) },
-        };
+            var result = new RenderStateCollection()
+            {
+                { RenderState.Cull(Cull.Off) }
+            };
+            return result;
+        }
 
-        public static readonly RenderStateCollection ScenePicking = new RenderStateCollection
+        public static RenderStateCollection ScenePicking(BuiltInTarget target)
         {
-            { RenderState.Cull(Uniforms.cullMode) },
-        };
+            var result = new RenderStateCollection();
+            AddUberSwitchedCull(target, result);
+            return result;
+        }
     }
     #endregion
 
@@ -1075,16 +1315,8 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
     #region Keywords
     static class CoreKeywords
     {
-        public static readonly KeywordCollection Common = new KeywordCollection
-        {
-            CoreKeywordDescriptors.AlphaClip,
-            CoreKeywordDescriptors.AlphaTestOn,
-            CoreKeywordDescriptors.SurfaceTypeTransparent,
-        };
-
         public static readonly KeywordCollection ShadowCaster = new KeywordCollection
         {
-            CoreKeywords.Common,
             { CoreKeywordDescriptors.CastingPunctualLightShadow },
         };
     }

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
@@ -478,14 +478,13 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
     #region Passes
     static class CorePasses
     {
-
         internal static void AddSurfaceTypeControlToPass(ref PassDescriptor pass, BuiltInTarget target)
         {
             if (target.allowMaterialOverride)
             {
                 pass.keywords.Add(CoreKeywordDescriptors.SurfaceTypeTransparent);
             }
-            else if(target.surfaceType == SurfaceType.Transparent)
+            else if (target.surfaceType == SurfaceType.Transparent)
             {
                 pass.defines.Add(CoreKeywordDescriptors.SurfaceTypeTransparent, 1);
             }
@@ -502,6 +501,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                 pass.defines.Add(CoreKeywordDescriptors.AlphaPremultiplyOn, 1);
             }
         }
+
         internal static void AddAlphaClipControlToPass(ref PassDescriptor pass, BuiltInTarget target)
         {
             if (target.allowMaterialOverride)
@@ -630,7 +630,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                 // Conditional State
                 renderStates = CoreRenderStates.SceneSelection(target),
                 pragmas = CorePragmas.Instanced,
-                defines = new DefineCollection{ CoreDefines.SceneSelection },
+                defines = new DefineCollection { CoreDefines.SceneSelection },
                 keywords = new KeywordCollection(),
                 includes = CoreIncludes.SceneSelection,
 
@@ -668,7 +668,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                 // Conditional State
                 renderStates = CoreRenderStates.ScenePicking(target),
                 pragmas = CorePragmas.Instanced,
-                defines = new DefineCollection{ CoreDefines.ScenePicking },
+                defines = new DefineCollection { CoreDefines.ScenePicking },
                 keywords = new KeywordCollection(),
                 includes = CoreIncludes.ScenePicking,
 
@@ -853,7 +853,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                 AddUberSwitchedZWrite(target, result);
                 AddUberSwitchedCull(target, result);
                 AddUberSwitchedBlend(target, result);
-                if(target.surfaceType != SurfaceType.Opaque)
+                if (target.surfaceType != SurfaceType.Opaque)
                     result.Add(RenderState.ColorMask("ColorMask RGB"));
                 return result;
             }
@@ -901,7 +901,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             AddUberSwitchedBlend(target, result);
             result.Add(RenderState.ColorMask("ColorMask 0"));
             return result;
-        }   
+        }
 
         public static RenderStateCollection SceneSelection(BuiltInTarget target)
         {

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
@@ -39,7 +39,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
 
     enum ZTestMode  // the values here match UnityEngine.Rendering.CompareFunction
     {
-        Disabled = 0,
+        // Disabled = 0, "Disabled" option is invalid for actual use in shaders
         Never = 1,
         Less = 2,
         Equal = 3,

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
@@ -840,7 +840,6 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             { RenderState.ZWrite(Uniforms.zWrite) },
             { RenderState.Cull(Uniforms.cullMode) },
             { RenderState.Blend(Uniforms.srcBlend, Uniforms.dstBlend) },
-            { RenderState.ColorMask("ColorMask RGB"), new FieldCondition(BuiltInFields.SurfaceOpaque, false) },
         };
 
         public static RenderStateCollection Default(BuiltInTarget target)
@@ -854,20 +853,28 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                 AddUberSwitchedZWrite(target, result);
                 AddUberSwitchedCull(target, result);
                 AddUberSwitchedBlend(target, result);
-                result.Add(RenderState.ColorMask("ColorMask RGB"), new FieldCondition(BuiltInFields.SurfaceOpaque, false));
+                if(target.surfaceType != SurfaceType.Opaque)
+                    result.Add(RenderState.ColorMask("ColorMask RGB"));
                 return result;
             }
         }
 
-        public static readonly RenderStateCollection ForwardAdd = new RenderStateCollection
+        public static RenderStateCollection ForwardAdd(BuiltInTarget target)
         {
-            { RenderState.ZWrite(ZWrite.Off) },
-            { RenderState.ColorMask("ColorMask RGB"), new FieldCondition(BuiltInFields.SurfaceOpaque, false) },
-            { RenderState.Blend(Blend.One, Blend.One) },
+            var result = new RenderStateCollection();
 
-            { RenderState.Blend(Blend.SrcAlpha, Blend.One, Blend.One, Blend.One), new FieldCondition(BuiltInFields.SurfaceOpaque, true) },
-            { RenderState.Blend(Blend.SrcAlpha, Blend.One), new FieldCondition(BuiltInFields.SurfaceOpaque, false) },
-        };
+            result.Add(RenderState.ZWrite(ZWrite.Off));
+            if (target.surfaceType != SurfaceType.Opaque)
+            {
+                result.Add(RenderState.Blend(Blend.SrcAlpha, Blend.One));
+                result.Add(RenderState.ColorMask("ColorMask RGB"));
+            }
+            else
+            {
+                result.Add(RenderState.Blend(Blend.SrcAlpha, Blend.One, Blend.One, Blend.One));
+            }
+            return result;
+        }
 
         public static readonly RenderStateCollection Meta = new RenderStateCollection
         {

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
@@ -630,7 +630,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                 // Conditional State
                 renderStates = CoreRenderStates.SceneSelection(target),
                 pragmas = CorePragmas.Instanced,
-                defines = CoreDefines.SceneSelection,
+                defines = new DefineCollection{ CoreDefines.SceneSelection },
                 keywords = new KeywordCollection(),
                 includes = CoreIncludes.SceneSelection,
 
@@ -668,7 +668,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                 // Conditional State
                 renderStates = CoreRenderStates.ScenePicking(target),
                 pragmas = CorePragmas.Instanced,
-                defines = CoreDefines.ScenePicking,
+                defines = new DefineCollection{ CoreDefines.ScenePicking },
                 keywords = new KeywordCollection(),
                 includes = CoreIncludes.ScenePicking,
 

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInTarget.cs
@@ -66,7 +66,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
 
     sealed class BuiltInTarget : Target, IHasMetadata
     {
-        public override int latestVersion => 1;
+        public override int latestVersion => 2;
 
         // Constants
         static readonly GUID kSourceCodeGuid = new GUID("d0f59811de3924b6ab62802eb365ef6b"); // BuiltInTarget.cs
@@ -444,7 +444,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
             if (this.sgVersion < latestVersion)
             {
                 // Version 0 didn't have m_AllowMaterialOverride but acted as if it was true
-                if (this.sgVersion == 0)
+                if (this.sgVersion <= 1)
                 {
                     this.m_AllowMaterialOverride = true;
                 }

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInUnlitSubTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInUnlitSubTarget.cs
@@ -66,7 +66,7 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
 
         public override void CollectShaderProperties(PropertyCollector collector, GenerationMode generationMode)
         {
-            if(target.allowMaterialOverride)
+            if (target.allowMaterialOverride)
             {
                 base.CollectShaderProperties(collector, generationMode);
 

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInUnlitSubTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInUnlitSubTarget.cs
@@ -7,10 +7,11 @@ using UnityEngine.Rendering;
 using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 using UnityEditor.ShaderGraph.Legacy;
+using static UnityEditor.Rendering.BuiltIn.ShaderUtils;
 
 namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
 {
-    sealed class BuiltInUnlitSubTarget : SubTarget<BuiltInTarget>
+    sealed class BuiltInUnlitSubTarget : BuiltInSubTarget
     {
         static readonly GUID kSourceCodeGuid = new GUID("3af09b75886c549dbad6eaaaaf342387"); // BuiltInUnlitSubTarget.cs
 
@@ -18,6 +19,8 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
         {
             displayName = "Unlit";
         }
+
+        protected override ShaderID shaderID => ShaderID.SG_Unlit;
 
         public override bool IsActive() => true;
 

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInUnlitSubTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInUnlitSubTarget.cs
@@ -28,30 +28,24 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
                 context.customEditorForRenderPipelines.Add((typeof(BuiltInUnlitGUI).FullName, ""));
 
             // Process SubShaders
-            SubShaderDescriptor[] subShaders = { SubShaders.Unlit };
-            for (int i = 0; i < subShaders.Length; i++)
-            {
-                // Update Render State
-                subShaders[i].renderType = target.renderType;
-                subShaders[i].renderQueue = target.renderQueue;
-
-                // Add
-                context.AddSubShader(subShaders[i]);
-            }
+            context.AddSubShader(SubShaders.Unlit(target, target.renderType, target.renderQueue));
         }
 
         public override void ProcessPreviewMaterial(Material material)
         {
-            // copy our target's default settings into the material
-            // (technically not necessary since we are always recreating the material from the shader each time,
-            // which will pull over the defaults from the shader definition)
-            // but if that ever changes, this will ensure the defaults are set
-            material.SetFloat(Property.Surface(), (float)target.surfaceType);
-            material.SetFloat(Property.Blend(), (float)target.alphaMode);
-            material.SetFloat(Property.AlphaClip(), target.alphaClip ? 1.0f : 0.0f);
-            material.SetFloat(Property.Cull(), (int)target.renderFace);
-            material.SetFloat(Property.ZWriteControl(), (float)target.zWriteControl);
-            material.SetFloat(Property.ZTest(), (float)target.zTestMode);
+            if (target.allowMaterialOverride)
+            {
+                // copy our target's default settings into the material
+                // (technically not necessary since we are always recreating the material from the shader each time,
+                // which will pull over the defaults from the shader definition)
+                // but if that ever changes, this will ensure the defaults are set
+                material.SetFloat(Property.Surface(), (float)target.surfaceType);
+                material.SetFloat(Property.Blend(), (float)target.alphaMode);
+                material.SetFloat(Property.AlphaClip(), target.alphaClip ? 1.0f : 0.0f);
+                material.SetFloat(Property.Cull(), (int)target.renderFace);
+                material.SetFloat(Property.ZWriteControl(), (float)target.zWriteControl);
+                material.SetFloat(Property.ZTest(), (float)target.zTestMode);
+            }
 
             // call the full unlit material setup function
             BuiltInUnlitGUI.UpdateMaterial(material);
@@ -71,104 +65,122 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
 
         public override void GetActiveBlocks(ref TargetActiveBlockContext context)
         {
-            // Always add the alpha and alpha clip blocks. These may or may not be active depending on the material controls so we have to always add them.
-            context.AddBlock(BlockFields.SurfaceDescription.Alpha);
-            context.AddBlock(BlockFields.SurfaceDescription.AlphaClipThreshold);
+            context.AddBlock(BlockFields.SurfaceDescription.Alpha, (target.surfaceType == SurfaceType.Transparent || target.alphaClip) || target.allowMaterialOverride);
+            context.AddBlock(BlockFields.SurfaceDescription.AlphaClipThreshold, target.alphaClip || target.allowMaterialOverride);
         }
 
         public override void CollectShaderProperties(PropertyCollector collector, GenerationMode generationMode)
         {
-            base.CollectShaderProperties(collector, generationMode);
+            if(target.allowMaterialOverride)
+            {
+                base.CollectShaderProperties(collector, generationMode);
 
-            // setup properties using the defaults
-            collector.AddFloatProperty(Property.Surface(), (float)target.surfaceType);
-            collector.AddFloatProperty(Property.Blend(), (float)target.alphaMode);
-            collector.AddFloatProperty(Property.AlphaClip(), target.alphaClip ? 1.0f : 0.0f);
-            collector.AddFloatProperty(Property.SrcBlend(), 1.0f);    // always set by material inspector (TODO : get src/dst blend and set here?)
-            collector.AddFloatProperty(Property.DstBlend(), 0.0f);    // always set by material inspector
-            collector.AddFloatProperty(Property.ZWrite(), (target.surfaceType == SurfaceType.Opaque) ? 1.0f : 0.0f);
-            collector.AddFloatProperty(Property.ZWriteControl(), (float)target.zWriteControl);
-            collector.AddFloatProperty(Property.ZTest(), (float)target.zTestMode);    // ztest mode is designed to directly pass as ztest
-            collector.AddFloatProperty(Property.Cull(), (float)target.renderFace);    // render face enum is designed to directly pass as a cull mode
-            collector.AddFloatProperty(Property.QueueOffset(), 0.0f);
+                // setup properties using the defaults
+                collector.AddFloatProperty(Property.Surface(), (float)target.surfaceType);
+                collector.AddFloatProperty(Property.Blend(), (float)target.alphaMode);
+                collector.AddFloatProperty(Property.AlphaClip(), target.alphaClip ? 1.0f : 0.0f);
+                collector.AddFloatProperty(Property.SrcBlend(), 1.0f);    // always set by material inspector (TODO : get src/dst blend and set here?)
+                collector.AddFloatProperty(Property.DstBlend(), 0.0f);    // always set by material inspector
+                collector.AddFloatProperty(Property.ZWrite(), (target.surfaceType == SurfaceType.Opaque) ? 1.0f : 0.0f);
+                collector.AddFloatProperty(Property.ZWriteControl(), (float)target.zWriteControl);
+                collector.AddFloatProperty(Property.ZTest(), (float)target.zTestMode);    // ztest mode is designed to directly pass as ztest
+                collector.AddFloatProperty(Property.Cull(), (float)target.renderFace);    // render face enum is designed to directly pass as a cull mode
+                collector.AddFloatProperty(Property.QueueOffset(), 0.0f);
+            }
         }
 
         public override void GetPropertiesGUI(ref TargetPropertyGUIContext context, Action onChange, Action<String> registerUndo)
         {
             // show the target default surface properties
             var builtInTarget = (target as BuiltInTarget);
+            builtInTarget?.AddDefaultMaterialOverrideGUI(ref context, onChange, registerUndo);
             builtInTarget?.GetDefaultSurfacePropertiesGUI(ref context, onChange, registerUndo);
         }
 
         #region SubShader
         static class SubShaders
         {
-            public static SubShaderDescriptor Unlit = new SubShaderDescriptor()
+            public static SubShaderDescriptor Unlit(BuiltInTarget target, string renderType, string renderQueue)
             {
-                //pipelineTag = BuiltInTarget.kPipelineTag,
-                customTags = BuiltInTarget.kUnlitMaterialTypeTag,
-                generatesPreview = true,
-                passes = new PassCollection
+                var result = new SubShaderDescriptor()
                 {
-                    { UnlitPasses.Unlit },
-                    { CorePasses.ShadowCaster },
-                    { CorePasses.DepthOnly },
-                    { CorePasses.SceneSelection },
-                    { CorePasses.ScenePicking },
-                },
-            };
+                    //pipelineTag = UniversalTarget.kPipelineTag,
+                    customTags = BuiltInTarget.kUnlitMaterialTypeTag,
+                    renderType = renderType,
+                    renderQueue = renderQueue,
+                    generatesPreview = true,
+                    passes = new PassCollection()
+                };
+
+                result.passes.Add(UnlitPasses.Unlit(target));
+
+                if (target.mayWriteDepth)
+                    result.passes.Add(CorePasses.DepthOnly(target));
+
+                result.passes.Add(CorePasses.ShadowCaster(target));
+                result.passes.Add(CorePasses.SceneSelection(target));
+                result.passes.Add(CorePasses.ScenePicking(target));
+
+                return result;
+            }
         }
         #endregion
 
         #region Pass
         static class UnlitPasses
         {
-            public static PassDescriptor Unlit = new PassDescriptor
+            public static PassDescriptor Unlit(BuiltInTarget target)
             {
-                // Definition
-                displayName = "Pass",
-                referenceName = "SHADERPASS_UNLIT",
-                lightMode = "ForwardBase",
-                useInPreview = true,
+                var result = new PassDescriptor
+                {
+                    // Definition
+                    displayName = "Pass",
+                    referenceName = "SHADERPASS_UNLIT",
+                    lightMode = "ForwardBase",
+                    useInPreview = true,
 
-                // Template
-                passTemplatePath = BuiltInTarget.kTemplatePath,
-                sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
+                    // Template
+                    passTemplatePath = BuiltInTarget.kTemplatePath,
+                    sharedTemplateDirectories = BuiltInTarget.kSharedTemplateDirectories,
 
-                // Port Mask
-                validVertexBlocks = CoreBlockMasks.Vertex,
-                validPixelBlocks = CoreBlockMasks.FragmentColorAlpha,
+                    // Port Mask
+                    validVertexBlocks = CoreBlockMasks.Vertex,
+                    validPixelBlocks = CoreBlockMasks.FragmentColorAlpha,
 
-                // Fields
-                structs = CoreStructCollections.Default,
-                fieldDependencies = CoreFieldDependencies.Default,
+                    // Fields
+                    structs = CoreStructCollections.Default,
+                    fieldDependencies = CoreFieldDependencies.Default,
 
-                // Conditional State
-                renderStates = CoreRenderStates.Default,
-                pragmas = CorePragmas.Forward,
-                defines = CoreDefines.BuiltInTargetAPI,
-                keywords = UnlitKeywords.Unlit,
-                includes = UnlitIncludes.Unlit,
+                    // Conditional State
+                    renderStates = CoreRenderStates.Default(target),
+                    pragmas = CorePragmas.Forward,
+                    defines = new DefineCollection() { CoreDefines.BuiltInTargetAPI },
+                    keywords = new KeywordCollection(),
+                    includes = UnlitIncludes.Unlit,
 
-                // Custom Interpolator Support
-                customInterpolators = CoreCustomInterpDescriptors.Common
-            };
+                    // Custom Interpolator Support
+                    customInterpolators = CoreCustomInterpDescriptors.Common
+                };
+                CorePasses.AddTargetSurfaceControlsToPass(ref result, target);
+                return result;
+            }
         }
         #endregion
 
         #region Keywords
         static class UnlitKeywords
         {
-            public static KeywordCollection Unlit = new KeywordCollection
+            public static KeywordCollection Unlit(BuiltInTarget target)
             {
-                { CoreKeywordDescriptors.Lightmap },
-                { CoreKeywordDescriptors.DirectionalLightmapCombined },
-                { CoreKeywordDescriptors.SampleGI },
-                CoreKeywordDescriptors.AlphaClip,
-                CoreKeywordDescriptors.AlphaTestOn,
-                CoreKeywordDescriptors.SurfaceTypeTransparent,
-                CoreKeywordDescriptors.AlphaPremultiplyOn,
-            };
+                var result = new KeywordCollection
+                {
+                    { CoreKeywordDescriptors.Lightmap },
+                    { CoreKeywordDescriptors.DirectionalLightmapCombined },
+                    { CoreKeywordDescriptors.SampleGI },
+                };
+
+                return result;
+            }
         }
         #endregion
 

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInUnlitSubTarget.cs
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/Editor/ShaderGraph/Targets/BuiltInUnlitSubTarget.cs
@@ -53,14 +53,6 @@ namespace UnityEditor.Rendering.BuiltIn.ShaderGraph
 
         public override void GetFields(ref TargetFieldContext context)
         {
-            // Surface Type & Blend Mode
-            // These must be set per SubTarget as Sprite SubTargets override them
-            context.AddField(BuiltInFields.SurfaceOpaque,       target.surfaceType == SurfaceType.Opaque);
-            context.AddField(BuiltInFields.SurfaceTransparent,  target.surfaceType != SurfaceType.Opaque);
-            context.AddField(BuiltInFields.BlendAdd,            target.surfaceType != SurfaceType.Opaque && target.alphaMode == AlphaMode.Additive);
-            context.AddField(Fields.BlendAlpha,                 target.surfaceType != SurfaceType.Opaque && target.alphaMode == AlphaMode.Alpha);
-            context.AddField(BuiltInFields.BlendMultiply,       target.surfaceType != SurfaceType.Opaque && target.alphaMode == AlphaMode.Multiply);
-            context.AddField(BuiltInFields.BlendPremultiply,    target.surfaceType != SurfaceType.Opaque && target.alphaMode == AlphaMode.Premultiply);
         }
 
         public override void GetActiveBlocks(ref TargetActiveBlockContext context)


### PR DESCRIPTION
# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
The BuiltIn target was implemented with material override, but this was always true and couldn't be controlled via the shader graph. This PR is making the built-in target match URP by adding an option to shader graph to specify if the surface options should be controlled by the material or by the target on the shader graph.

---
### Testing status
- [x] For Material Override true (for both lit and unlit):
    - [x] Tested that assigning a new Shader to a Material will reset keywords properly
    - [x] Tested that newly created Materials have their keywords set up properly even if the inspector is not visible or run.
    - [x] Tested combinations of different Target settings, to see that they modify the default properties in the generated shader, and will populate newly created Materials with those defaults.
    - [x] Tested all cull mode settings (front/back/both) on Material
    - [x] Tested setting Opaque/Transparent, and all blend modes on Material
    - [x] Tested enabling/disabling alpha clipping on Material
    - [x] Tested Depth Write and Depth Test settings on Material
- [x] For Material Override false (for both lit and unlit):
    - [x] Tested that assigning a new Shader to a Material will reset keywords properly
    - [x] Tested that newly created Materials have their keywords set up properly even if the inspector is not visible or run.
    - [x] Tested combinations of different Target settings, to see that they modify the default properties in the generated shader, and will populate newly created Materials with those defaults.
    - [x] Tested all cull mode settings (front/back/both) on Target
    - [x] Tested setting Opaque/Transparent, and all blend modes on Target
    - [x] Tested enabling/disabling alpha clipping on Target
    - [x] Tested Depth Write and Depth Test settings on Target
- [x] Test swapping material's shader graph to another shader graph:
    - [x] Swap from material override false to material override true
    - [x] Swap from material override true  to material override false
- [x] Tested pre-existing BuiltIn graphs get upgraded correctly (as material override true)
- [x] Verified that shadergraph master previews show up correctly with BuiltIn Lit/Unlit subtarget, and selecting various combinations of default surface settings on them

Additional tests for extra bugs found:
- [x] Set an unlit shader to transparent. Set the alpha mode to "premultiply". Set the target back to opaque. This should properly compile and draw (used to be a shader error).
- [x] The "Disabled" mode for ZTest is now gone
  - [x] Setting all of the ZTest modes in the target still produce the correct value in the shader
  - [x] Setting all of the ZTest modes on the material when in "Allow Material Override" produce the correct values (verified both from rendering and inspecting the material with the inspector's debug mode).

---
### Comments to reviewers
In the added test project, a duplicate shader graph has to be added due to an existing bug not related to the built-in target: https://fogbugz.unity3d.com/f/cases/1328077/
A few addition bugs found:
 - Additive blend mode for material override got broken but the graphics tests weren't sensitive enough to catch it before. Updated the sensitivity on the tests
 - A shader compiler could happen in unlit if the material was opaque but the alpha mode was pre-multiply (depending on the last state it was set to).
 - The ZTest mode exposed "Disabled" which isn't valid inside a shader.
 - BuiltInUnlitSubtarget didn't inherit from the proper base class. This fixes a case where changing shaders on a material when "Allow Material Override" was true wasn't working. This is because no metadata was saved so the inspector didn't know what the inspector to use to update material keywords.