### PR TITLE
[ShaderGraph] [2021.1] Fix for PVT compatibility with SRP Batcher

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a ShaderGraph issue where unused blocks get removed on edge replacement [1336832].
 - Fixed GPU instancing support in Shadergraph [1319655] (https://issuetracker.unity3d.com/issues/shader-graph-errors-are-thrown-when-a-propertys-shader-declaration-is-set-to-hybrid-per-instance-and-exposed-is-disabled).
 - Fixed rounded rectangle shape not rendering correctly on Nintendo Switch.
+- Fixed Procedural Virtual Texture compatibility with SRP Batcher [1329336] (https://issuetracker.unity3d.com/issues/procedural-virtual-texture-node-will-make-a-shadergraph-incompatible-with-srp-batcher)
 
 ## [10.3.0] - 2020-11-03
 

--- a/com.unity.shadergraph/Editor/Data/Graphs/VirtualTextureShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/VirtualTextureShaderProperty.cs
@@ -75,7 +75,11 @@ namespace UnityEditor.ShaderGraph
             int numLayers = value.layers.Count;
             if (numLayers > 0)
             {
-                action(new HLSLProperty(HLSLType._CUSTOM, referenceName + "_CBDecl", HLSLDeclaration.UnityPerMaterial, concretePrecision)
+                HLSLDeclaration decl = HLSLDeclaration.UnityPerMaterial;
+                if (value.procedural)
+                    decl = GetDefaultHLSLDeclaration();
+
+                action(new HLSLProperty(HLSLType._CUSTOM, referenceName + "_CBDecl", decl, concretePrecision)
                 {
                     customDeclaration = (ssb) =>
                     {


### PR DESCRIPTION
### Purpose of this PR
Fix for https://fogbugz.unity3d.com/f/cases/1329336/

2021.2: https://github.com/Unity-Technologies/Graphics/pull/4958
2021.1: https://github.com/Unity-Technologies/Graphics/pull/4962
2020.3: https://github.com/Unity-Technologies/Graphics/pull/4956

---
### Testing status

Tested on Windows PC in HDRP (VT not supported in URP):

- [x] ShaderGraph using PVT is detected as SRP Batcher compatible
- [x] Rendering with Globally-Bound PVT works
- [x] and uses SRP Batcher path
- [x] Rendering with Material-Bound PVT works
- [x] and uses SRP Batcher path
- [x] ShaderGraph using streaming VT is detected as SRP Batcher compatible
- [x] Rendering with streaming VT works
- [x] and uses SRP Batcher path

![image](https://user-images.githubusercontent.com/28871759/123846580-66864100-d8ca-11eb-8c76-c571efd3ae65.png)

Yamato:

ShaderGraph PR Job: 🟢
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/2021.1%252Fsg%252Ffix%252F1329336/.yamato%252Fall-shadergraph.yml%2523PR_ShaderGraph_2021.1/7454312/job/pipeline

HDRP PR Job: 🟢 
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/2021.1%252Fsg%252Ffix%252F1329336/.yamato%252Fall-hdrp.yml%2523PR_HDRP_2021.1/7454335/job/pipeline

---
### Comments to reviewers
Notes for the reviewers you have assigned.
