### PR TITLE
Fixed SubGraph node stage limitation checks to be per slot instead of per node

### DIFF
--- a/TestProjects/ShaderGraph/Assets/CommonAssets/Editor/ShaderStageCapabilityTests.cs
+++ b/TestProjects/ShaderGraph/Assets/CommonAssets/Editor/ShaderStageCapabilityTests.cs
@@ -55,11 +55,11 @@ namespace UnityEditor.ShaderGraph.UnitTests
             GraphData graphData = new GraphData() { assetGuid = graphGuid, messageManager = messageManager };
             MultiJson.Deserialize(graphData, fileContents);
             graphData.OnEnable();
-            graphData.ValidateGraph();            
+            graphData.ValidateGraph();
 
             var subGraphnodeName = "ShaderStageCapability_SubGraph";
             var subGraphNode = FindFirstNodeOfType<SubGraphNode>(graphData, subGraphnodeName);
-            if(subGraphNode == null)
+            if (subGraphNode == null)
             {
                 Assert.Fail("Failed to find sub graph node for {0}", subGraphnodeName);
                 return;
@@ -125,7 +125,7 @@ namespace UnityEditor.ShaderGraph.UnitTests
                 Assert.IsNotNull(slotA, "Expected slotA to not be null");
                 Assert.IsNotNull(slotB, "Expected slotB to not be null");
                 var edge = graphData.Connect(slotA.slotReference, slotB.slotReference);
-                
+
                 bool foundNode = false;
                 foreach (var message in graphData.messageManager.GetNodeMessages())
                 {
@@ -134,7 +134,6 @@ namespace UnityEditor.ShaderGraph.UnitTests
                         foundNode = true;
                         break;
                     }
-                    
                 }
                 Assert.IsTrue(foundNode, $"Expected node {nodeWithError.name} didn't have an error");
 
@@ -142,7 +141,7 @@ namespace UnityEditor.ShaderGraph.UnitTests
                 graphData.messageManager.ClearAll();
                 graphData.RemoveEdge(edge);
             }
-            
+
             var subGraphNode = FindFirstNodeOfType<SubGraphNode>(graphData, "SubShaderInvalidCapabilities_SubGraph");
             var vertexIdNode = FindFirstNodeOfType<VertexIDNode>(graphData);
             var sampleTextureNode = FindFirstNodeOfType<SampleTexture2DNode>(graphData);

--- a/TestProjects/ShaderGraph/Assets/CommonAssets/Editor/ShaderStageCapabilityTests.cs
+++ b/TestProjects/ShaderGraph/Assets/CommonAssets/Editor/ShaderStageCapabilityTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using UnityEditor.Graphing;
+using UnityEditor.Graphing.Util;
+using UnityEditor.ShaderGraph.Serialization;
+
+
+namespace UnityEditor.ShaderGraph.UnitTests
+{
+    [TestFixture]
+    internal class ShaderStageCapabilityTests
+    {
+        static string targetUnityDirectoryPath => "Assets/Testing/ShaderStageCapabilityGraphs";
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+        }
+
+        SubGraphNode FindSubgraphNode(GraphData graphData, string subGraphNodeName)
+        {
+            var subGraphNodes = graphData.GetNodes<SubGraphNode>();
+            foreach (var subGraphNode in subGraphNodes)
+            {
+                if (subGraphNode.name == subGraphNodeName)
+                    return subGraphNode;
+            }
+            return null;
+        }
+
+        [Test]
+        public void SubGraphDescendentsTests()
+        {
+            var graphPath = targetUnityDirectoryPath + "/ShaderStageCapability_Graph.shadergraph";
+
+            string fileContents = File.ReadAllText(graphPath);
+            var graphGuid = AssetDatabase.AssetPathToGUID(graphPath);
+            var messageManager = new MessageManager();
+            GraphData graphData = new GraphData() { assetGuid = graphGuid, messageManager = messageManager };
+            MultiJson.Deserialize(graphData, fileContents);
+            graphData.OnEnable();
+            graphData.ValidateGraph();            
+
+            var subGraphnodeName = "ShaderStageCapability_SubGraph";
+            var subGraphNode = FindSubgraphNode(graphData, subGraphnodeName);
+            if(subGraphNode == null)
+            {
+                Assert.Fail("Failed to find sub graph node for {0}", subGraphnodeName);
+                return;
+            }
+
+            var expectedSlotCapabilities = new Dictionary<string, ShaderStageCapability>
+            {
+                { "NotConnectedOut", ShaderStageCapability.All },
+                { "NotConnectedInput", ShaderStageCapability.All },
+                { "InternalVertexLockedOut", ShaderStageCapability.Vertex },
+                { "InternalFragmentLockedOut", ShaderStageCapability.Fragment },
+                { "InternalBothLockedOut", ShaderStageCapability.None },
+                { "InternalVertexLockedInput", ShaderStageCapability.Vertex },
+                { "InternalFragmentLockedInput", ShaderStageCapability.Fragment },
+                { "InternalBothLockedInput", ShaderStageCapability.None },
+                // Output A is connected to InputA which is attached to a vertex locked node in the parent graph
+                { "OutputA", ShaderStageCapability.Vertex },
+                // Output B is connected to InputB which is attached to a fragment locked node in the parent graph
+                { "OutputB", ShaderStageCapability.Fragment },
+                // OutputAB is connected to InputA and InputB
+                { "OutputAB", ShaderStageCapability.None },
+                // InputC is connected to OutputC which is hooked up to the vertex output in the parent graph
+                { "InputC", ShaderStageCapability.Vertex },
+                // InputD is connected to OutputD which is hooked up to the fragment output in the parent graph
+                { "InputD", ShaderStageCapability.Fragment },
+                // InputEF is split into OutputE and OutputF which are hooked up to vertex and fragment outputs in the parent graph
+                { "InputEF", ShaderStageCapability.None },
+            };
+
+            var slotNameToId = new Dictionary<string, MaterialSlot>();
+            var slots = subGraphNode.GetSlots<MaterialSlot>();
+            foreach (var slot in slots)
+                slotNameToId[slot.RawDisplayName()] = slot;
+
+            foreach (var expectedSlotResult in expectedSlotCapabilities)
+            {
+                var slotName = expectedSlotResult.Key;
+                var expectedSlotValue = expectedSlotResult.Value;
+                if (slotNameToId.TryGetValue(slotName, out var slot))
+                {
+                    var capabilities = NodeUtils.GetEffectiveShaderStageCapability(slot, true) & NodeUtils.GetEffectiveShaderStageCapability(slot, false);
+                    Assert.AreEqual(capabilities, expectedSlotValue, "Slot {0} expected shader capability {1} but was {2}", slotName, expectedSlotValue, capabilities);
+                }
+                else
+                    Assert.Fail("Expected slot {0} wasn't found", slotName);
+            }
+        }
+    }
+}

--- a/TestProjects/ShaderGraph/Assets/CommonAssets/Editor/ShaderStageCapabilityTests.cs.meta
+++ b/TestProjects/ShaderGraph/Assets/CommonAssets/Editor/ShaderStageCapabilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b68d66b1af548ef4fb74a0b9302889b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs.meta
+++ b/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b70cbca08ff4e5848961702d7e920219
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/ShaderStageCapability_Graph.shadergraph
+++ b/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/ShaderStageCapability_Graph.shadergraph
@@ -1,0 +1,1403 @@
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.GraphData",
+    "m_ObjectId": "773957c0203a47f498fae588bad0451c",
+    "m_Properties": [],
+    "m_Keywords": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "361ac9b1cc944afd945def17fd2a8beb"
+        }
+    ],
+    "m_Nodes": [
+        {
+            "m_Id": "7aa495f024ee4018819134b462d2d464"
+        },
+        {
+            "m_Id": "d80aa604c2c049228a5162576eeaa42d"
+        },
+        {
+            "m_Id": "e2cf546b0aed4b4d913eacf515d26342"
+        },
+        {
+            "m_Id": "9b582168aa6f421e9b6ed54be34d8014"
+        },
+        {
+            "m_Id": "172fdf52f86946efb2c9d0bd3e60e713"
+        },
+        {
+            "m_Id": "47341c838f1640e194fd327a9f91d329"
+        },
+        {
+            "m_Id": "9295ba0240cb44d0911dec11abf889b4"
+        },
+        {
+            "m_Id": "8d4c00bf486a4b5095e912df6094e4bf"
+        },
+        {
+            "m_Id": "48adb8d0ceec49bba3bcf6e0b1b123c9"
+        },
+        {
+            "m_Id": "0068e1e9950a4f90a6a0092c7879eb11"
+        },
+        {
+            "m_Id": "4705fcadba8740e4ae2e862822685257"
+        },
+        {
+            "m_Id": "d1093cc7976e4483aa9e259e641786c6"
+        }
+    ],
+    "m_GroupDatas": [],
+    "m_StickyNoteDatas": [],
+    "m_Edges": [
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "9b582168aa6f421e9b6ed54be34d8014"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d80aa604c2c049228a5162576eeaa42d"
+                },
+                "m_SlotId": 962626296
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "d80aa604c2c049228a5162576eeaa42d"
+                },
+                "m_SlotId": 7
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "172fdf52f86946efb2c9d0bd3e60e713"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "d80aa604c2c049228a5162576eeaa42d"
+                },
+                "m_SlotId": 9
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "7aa495f024ee4018819134b462d2d464"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "d80aa604c2c049228a5162576eeaa42d"
+                },
+                "m_SlotId": 10
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "9295ba0240cb44d0911dec11abf889b4"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "d80aa604c2c049228a5162576eeaa42d"
+                },
+                "m_SlotId": 11
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "8d4c00bf486a4b5095e912df6094e4bf"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e2cf546b0aed4b4d913eacf515d26342"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d80aa604c2c049228a5162576eeaa42d"
+                },
+                "m_SlotId": 537775618
+            }
+        }
+    ],
+    "m_VertexContext": {
+        "m_Position": {
+            "x": -0.000033020973205566406,
+            "y": -102.00001525878906
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "172fdf52f86946efb2c9d0bd3e60e713"
+            },
+            {
+                "m_Id": "47341c838f1640e194fd327a9f91d329"
+            },
+            {
+                "m_Id": "9295ba0240cb44d0911dec11abf889b4"
+            }
+        ]
+    },
+    "m_FragmentContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 200.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "7aa495f024ee4018819134b462d2d464"
+            },
+            {
+                "m_Id": "8d4c00bf486a4b5095e912df6094e4bf"
+            },
+            {
+                "m_Id": "48adb8d0ceec49bba3bcf6e0b1b123c9"
+            },
+            {
+                "m_Id": "0068e1e9950a4f90a6a0092c7879eb11"
+            },
+            {
+                "m_Id": "4705fcadba8740e4ae2e862822685257"
+            },
+            {
+                "m_Id": "d1093cc7976e4483aa9e259e641786c6"
+            }
+        ]
+    },
+    "m_PreviewData": {
+        "serializedMesh": {
+            "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
+            "m_Guid": ""
+        }
+    },
+    "m_Path": "Shader Graphs",
+    "m_GraphPrecision": 1,
+    "m_PreviewMode": 2,
+    "m_OutputNode": {
+        "m_Id": ""
+    },
+    "m_ActiveTargets": [
+        {
+            "m_Id": "2ab033def39840339fba260a640f3339"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "0068e1e9950a4f90a6a0092c7879eb11",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Emission",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d60452b6af464068a827d698f52af86a"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Emission"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "07925495277d41fbb69b4224848f8403",
+    "m_Id": 6,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "0d115f8fddbd40f78e78f1706bb8a9d5",
+    "m_Id": 2,
+    "m_DisplayName": "InternalFragmentLockedOut",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "InternalFragmentLockedOut",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "172fdf52f86946efb2c9d0bd3e60e713",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Position",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "1968842482e242818f501acd39b25ab4"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Position"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "1968842482e242818f501acd39b25ab4",
+    "m_Id": 0,
+    "m_DisplayName": "Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "2250a2bee874478580cad573a2a07715",
+    "m_Id": 0,
+    "m_DisplayName": "Ambient Occlusion",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Occlusion",
+    "m_StageCapability": 2,
+    "m_Value": 1.0,
+    "m_DefaultValue": 1.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "27163dcbfc664aa48d0c5d328fd8c642",
+    "m_Id": -59620834,
+    "m_DisplayName": "InputEF",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_InputEF",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "272689e67f76494e80262eb176441acd",
+    "m_Id": 0,
+    "m_DisplayName": "Smoothness",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Smoothness",
+    "m_StageCapability": 2,
+    "m_Value": 0.5,
+    "m_DefaultValue": 0.5,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
+    "m_ObjectId": "2ab033def39840339fba260a640f3339",
+    "m_ActiveSubTarget": {
+        "m_Id": "9379d59f4f99463fba8365849add845d"
+    },
+    "m_AllowMaterialOverride": false,
+    "m_SurfaceType": 0,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
+    "m_AlphaMode": 0,
+    "m_RenderFace": 2,
+    "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
+    "m_CustomEditorGUI": ""
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "2c6192757259414d9e0e1286b9583a29",
+    "m_Id": 1,
+    "m_DisplayName": "InternalVertexLockedOut",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "InternalVertexLockedOut",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "2ee4cdd9f1bf44568e878d0928ac0452",
+    "m_Id": 5,
+    "m_DisplayName": "OutputB",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputB",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "2f814b3f909d4998b3d69d99e92aa66a",
+    "m_Id": 0,
+    "m_DisplayName": "Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "361ac9b1cc944afd945def17fd2a8beb",
+    "m_Name": "",
+    "m_ChildObjectList": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "4705fcadba8740e4ae2e862822685257",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Occlusion",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "2250a2bee874478580cad573a2a07715"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "47341c838f1640e194fd327a9f91d329",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Normal",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "78569004a47246bdb9d8a6cdfd1aaf3d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Normal"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "48adb8d0ceec49bba3bcf6e0b1b123c9",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.NormalTS",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "92c06c4e8f9b412a98b7a7066411b470"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.NormalTS"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "4afec263bb1640d182e50d4febd046a6",
+    "m_Id": 7,
+    "m_DisplayName": "OutputC",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputC",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "5312792a2e174e53bd12e80c3ef5870d",
+    "m_Id": 1,
+    "m_DisplayName": "Texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Texture",
+    "m_StageCapability": 3,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "573ee1fd2c754e5ea4daede18b66191c",
+    "m_Id": 537775618,
+    "m_DisplayName": "InputA",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_InputA",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "57dc7319bceb4c41b21d1c82ef4547b2",
+    "m_Id": 530577236,
+    "m_DisplayName": "InternalFragmentLockedInput",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_InternalFragmentLockedInput",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "64185b9ad9c440d4b50d7bdae02723ef",
+    "m_Id": 5,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "64ef97f9abf546b9a873751baa74a719",
+    "m_Id": 10,
+    "m_DisplayName": "OutputE",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputE",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "6d64e7ea1a934db4bd76f24ad00b3947",
+    "m_Id": 0,
+    "m_DisplayName": "RGBA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "RGBA",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
+    "m_ObjectId": "6e9315015ec74d58bd3f124f27799ec6",
+    "m_Id": 2,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": [],
+    "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "7240ed712184493aa194ea67b13d63d8",
+    "m_Id": 962626296,
+    "m_DisplayName": "InputB",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "InputB",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "762c93120c2340688c6a59c3812b34b7",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 1,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "78569004a47246bdb9d8a6cdfd1aaf3d",
+    "m_Id": 0,
+    "m_DisplayName": "Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "7a75d793055f4d74a0c23ff6ead48133",
+    "m_Id": -1194186957,
+    "m_DisplayName": "NotConnectedInput",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_NotConnectedInput",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "7aa495f024ee4018819134b462d2d464",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.BaseColor",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c3409fcf316941c4b9fa53bdf4063eec"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.BaseColor"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "7bdc6ca15a3a4ff3bc25bd10ec6d24a4",
+    "m_Id": 1485052623,
+    "m_DisplayName": "InternalVertexLockedInput",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_InternalVertexLockedInput",
+    "m_StageCapability": 1,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "8d4c00bf486a4b5095e912df6094e4bf",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Smoothness",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "272689e67f76494e80262eb176441acd"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Smoothness"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "8e26d2d09cd74d37abdc43d43fa3a00a",
+    "m_Id": 8,
+    "m_DisplayName": "NotConnectedOut",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "NotConnectedOut",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "90b2e2404bc142a58b7e7b82707b45ab",
+    "m_Id": -1993558779,
+    "m_DisplayName": "InputD",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "InputD",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "9295ba0240cb44d0911dec11abf889b4",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Tangent",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "2f814b3f909d4998b3d69d99e92aa66a"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Tangent"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "92c06c4e8f9b412a98b7a7066411b470",
+    "m_Id": 0,
+    "m_DisplayName": "Normal (Tangent Space)",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "NormalTS",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 3
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
+    "m_ObjectId": "9379d59f4f99463fba8365849add845d",
+    "m_WorkflowMode": 1,
+    "m_NormalDropOffSpace": 0,
+    "m_ClearCoat": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
+    "m_ObjectId": "9b582168aa6f421e9b6ed54be34d8014",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Sample Texture 2D",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1011.0,
+            "y": -18.000015258789064,
+            "width": 208.0,
+            "height": 435.00006103515627
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "6d64e7ea1a934db4bd76f24ad00b3947"
+        },
+        {
+            "m_Id": "c1301efd0a42489db48fa22304406dfb"
+        },
+        {
+            "m_Id": "64185b9ad9c440d4b50d7bdae02723ef"
+        },
+        {
+            "m_Id": "07925495277d41fbb69b4224848f8403"
+        },
+        {
+            "m_Id": "9d615b30f8f2493a9ee7930a6f8eb29f"
+        },
+        {
+            "m_Id": "5312792a2e174e53bd12e80c3ef5870d"
+        },
+        {
+            "m_Id": "6e9315015ec74d58bd3f124f27799ec6"
+        },
+        {
+            "m_Id": "ff90eec143e44f6199326af40b190d53"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_TextureType": 0,
+    "m_NormalMapSpace": 0,
+    "m_EnableGlobalMipBias": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "9d615b30f8f2493a9ee7930a6f8eb29f",
+    "m_Id": 7,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a6e4be5df8f441499787407e4389d7d2",
+    "m_Id": 4,
+    "m_DisplayName": "OutputA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputA",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b07750ae6ada4fceb0c428a9ce69a85c",
+    "m_Id": 0,
+    "m_DisplayName": "Metallic",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Metallic",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b43fda856ac84e0d8c2b15556519971f",
+    "m_Id": 774947594,
+    "m_DisplayName": "InternalBothLockedInput",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_InternalBothLockedInput",
+    "m_StageCapability": 0,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c1301efd0a42489db48fa22304406dfb",
+    "m_Id": 4,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c233221d0018474bbaf62081478c90cb",
+    "m_Id": 1882476797,
+    "m_DisplayName": "InputC",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "InputC",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "c3409fcf316941c4b9fa53bdf4063eec",
+    "m_Id": 0,
+    "m_DisplayName": "Base Color",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "BaseColor",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.5,
+        "y": 0.5,
+        "z": 0.5
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 0,
+    "m_DefaultColor": {
+        "r": 0.5,
+        "g": 0.5,
+        "b": 0.5,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "ce89a538a290430c8668b7d8e6faaafe",
+    "m_Id": 6,
+    "m_DisplayName": "OutputAB",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputAB",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "d1093cc7976e4483aa9e259e641786c6",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Metallic",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "b07750ae6ada4fceb0c428a9ce69a85c"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d529a214915740ca9714fa3fcc32c45d",
+    "m_Id": 9,
+    "m_DisplayName": "OutputD",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputD",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "d60452b6af464068a827d698f52af86a",
+    "m_Id": 0,
+    "m_DisplayName": "Emission",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Emission",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 1,
+    "m_DefaultColor": {
+        "r": 0.0,
+        "g": 0.0,
+        "b": 0.0,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
+    "m_ObjectId": "d80aa604c2c049228a5162576eeaa42d",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "ShaderStageCapability_SubGraph",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -645.9999389648438,
+            "y": -53.0,
+            "width": 399.0000305175781,
+            "height": 470.0000305175781
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "573ee1fd2c754e5ea4daede18b66191c"
+        },
+        {
+            "m_Id": "7240ed712184493aa194ea67b13d63d8"
+        },
+        {
+            "m_Id": "c233221d0018474bbaf62081478c90cb"
+        },
+        {
+            "m_Id": "90b2e2404bc142a58b7e7b82707b45ab"
+        },
+        {
+            "m_Id": "7bdc6ca15a3a4ff3bc25bd10ec6d24a4"
+        },
+        {
+            "m_Id": "57dc7319bceb4c41b21d1c82ef4547b2"
+        },
+        {
+            "m_Id": "7a75d793055f4d74a0c23ff6ead48133"
+        },
+        {
+            "m_Id": "b43fda856ac84e0d8c2b15556519971f"
+        },
+        {
+            "m_Id": "27163dcbfc664aa48d0c5d328fd8c642"
+        },
+        {
+            "m_Id": "8e26d2d09cd74d37abdc43d43fa3a00a"
+        },
+        {
+            "m_Id": "2c6192757259414d9e0e1286b9583a29"
+        },
+        {
+            "m_Id": "0d115f8fddbd40f78e78f1706bb8a9d5"
+        },
+        {
+            "m_Id": "db6c1387efe4451c9d7ca5a1b1b86b71"
+        },
+        {
+            "m_Id": "a6e4be5df8f441499787407e4389d7d2"
+        },
+        {
+            "m_Id": "2ee4cdd9f1bf44568e878d0928ac0452"
+        },
+        {
+            "m_Id": "ce89a538a290430c8668b7d8e6faaafe"
+        },
+        {
+            "m_Id": "4afec263bb1640d182e50d4febd046a6"
+        },
+        {
+            "m_Id": "d529a214915740ca9714fa3fcc32c45d"
+        },
+        {
+            "m_Id": "64ef97f9abf546b9a873751baa74a719"
+        },
+        {
+            "m_Id": "edb5342b9f1d4fe3b4bd33f01dbecf6a"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"5028f2d6d26bdfd4493983323990e966\",\n        \"type\": 3\n    }\n}",
+    "m_PropertyGuids": [
+        "91f510fa-0f32-4880-84e2-fb70046213f7",
+        "62ec8fcf-c8ad-4fdc-9cce-2235994548aa",
+        "f15f54e6-6d27-4dfe-ae56-2d196da18185",
+        "7598d424-4a2e-442f-9acb-8a2968d75d21",
+        "601e9a42-e533-426a-bc81-78e530ae38b7",
+        "6ab6a6df-d701-490b-9eab-eeb1456f7f1b",
+        "da4ec2c8-8755-4c8a-ae32-0575fc6d45bb",
+        "71044941-9e99-428f-95a0-be941980aab8",
+        "9541ef1e-22a4-40f9-b6a6-7e393f4c1454",
+        "d41fcbd0-be91-41d7-9f98-73c3d42e8b78",
+        "51aeac0a-a648-4138-be4f-1888e207fc64"
+    ],
+    "m_PropertyIds": [
+        1587388232,
+        -1302672281,
+        537775618,
+        962626296,
+        1882476797,
+        -1993558779,
+        1485052623,
+        530577236,
+        -1194186957,
+        774947594,
+        -59620834
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "db6c1387efe4451c9d7ca5a1b1b86b71",
+    "m_Id": 3,
+    "m_DisplayName": "InternalBothLockedOut",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "InternalBothLockedOut",
+    "m_StageCapability": 0,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.VertexIDNode",
+    "m_ObjectId": "e2cf546b0aed4b4d913eacf515d26342",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Vertex ID",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -946.0,
+            "y": -148.00001525878907,
+            "width": 99.0,
+            "height": 77.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "762c93120c2340688c6a59c3812b34b7"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "edb5342b9f1d4fe3b4bd33f01dbecf6a",
+    "m_Id": 11,
+    "m_DisplayName": "OutputF",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputF",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
+    "m_ObjectId": "ff90eec143e44f6199326af40b190d53",
+    "m_Id": 3,
+    "m_DisplayName": "Sampler",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sampler",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+

--- a/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/ShaderStageCapability_Graph.shadergraph.meta
+++ b/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/ShaderStageCapability_Graph.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 604b1843f2f5bd14b8fa4831eefe9915
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/ShaderStageCapability_SubGraph.shadersubgraph
+++ b/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/ShaderStageCapability_SubGraph.shadersubgraph
@@ -1,0 +1,3163 @@
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.GraphData",
+    "m_ObjectId": "fffb59722d844a3da391d6d3e7e12f30",
+    "m_Properties": [
+        {
+            "m_Id": "cc957df9767f444eacb0f3da12af5199"
+        },
+        {
+            "m_Id": "e34ba3b5e1ec4d09b2bae29d7066080b"
+        },
+        {
+            "m_Id": "11bbc38c72f24a7fb8086180603aa947"
+        },
+        {
+            "m_Id": "56c424333b064b938d07fa53b36f65ad"
+        },
+        {
+            "m_Id": "da095aab13e64f7a80c5835718925b99"
+        },
+        {
+            "m_Id": "e58954ac6984492bb7e24d45fe1ec951"
+        },
+        {
+            "m_Id": "d73f6d530b7c4294b80da5a60167284f"
+        },
+        {
+            "m_Id": "9812c8289f0447a4ae27691d90e6a1bb"
+        },
+        {
+            "m_Id": "1892767b8c7540f7a0f15006fae7f98a"
+        }
+    ],
+    "m_Keywords": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "f18f6b68dcaf4c508e20f59080227472"
+        }
+    ],
+    "m_Nodes": [
+        {
+            "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+        },
+        {
+            "m_Id": "a945935963f646ee8928664b5c56ebfb"
+        },
+        {
+            "m_Id": "d73c40e867bd4e92986d174427eb4ffe"
+        },
+        {
+            "m_Id": "48883df884964911a284cf3739f01544"
+        },
+        {
+            "m_Id": "f0f0e498cdbb4d40b48cd1fa9096d552"
+        },
+        {
+            "m_Id": "3077e4c094ef4dfb8173da9216210b1d"
+        },
+        {
+            "m_Id": "554751c31ab94257a704a980f1396667"
+        },
+        {
+            "m_Id": "e0ff947666d34b45a0fa3458a8ec44e8"
+        },
+        {
+            "m_Id": "49d4b2483df84d48aea079a255983bbe"
+        },
+        {
+            "m_Id": "e9a425f04ebd44b2b2ccd6cb543b4282"
+        },
+        {
+            "m_Id": "53abbed15b96404c98065ed4860b7a38"
+        },
+        {
+            "m_Id": "c9d6944652ff4924ba7f61ad6cc7eb5f"
+        },
+        {
+            "m_Id": "587cf9b9b41642e58ff33b7c4346e144"
+        },
+        {
+            "m_Id": "3497d06473124674a205604fc7896565"
+        },
+        {
+            "m_Id": "208f9f45916e489da0a98829703f67bc"
+        },
+        {
+            "m_Id": "2028823a61204e6dbeb6e5b2587c2345"
+        },
+        {
+            "m_Id": "60c144d312184c79b848f24df18fe1b3"
+        },
+        {
+            "m_Id": "1923be3d225b46fb91550f98194d7776"
+        },
+        {
+            "m_Id": "630b42ff68d949d4ad0f8d6e545b5d18"
+        },
+        {
+            "m_Id": "ae677566dafa4ce7aab287c549db0480"
+        },
+        {
+            "m_Id": "e1b7ec7d37dd43538e31c305f755c426"
+        },
+        {
+            "m_Id": "30b5a98af81c464b96f88c501342ecd7"
+        },
+        {
+            "m_Id": "49751ab30e2347e8a463f6911e431255"
+        }
+    ],
+    "m_GroupDatas": [],
+    "m_StickyNoteDatas": [],
+    "m_Edges": [
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "1923be3d225b46fb91550f98194d7776"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "630b42ff68d949d4ad0f8d6e545b5d18"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "3077e4c094ef4dfb8173da9216210b1d"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "554751c31ab94257a704a980f1396667"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "3497d06473124674a205604fc7896565"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "208f9f45916e489da0a98829703f67bc"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "48883df884964911a284cf3739f01544"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 3
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "49d4b2483df84d48aea079a255983bbe"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 4
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "53abbed15b96404c98065ed4860b7a38"
+                },
+                "m_SlotId": 4
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "554751c31ab94257a704a980f1396667"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 6
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "587cf9b9b41642e58ff33b7c4346e144"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 9
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "60c144d312184c79b848f24df18fe1b3"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2028823a61204e6dbeb6e5b2587c2345"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "630b42ff68d949d4ad0f8d6e545b5d18"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "30b5a98af81c464b96f88c501342ecd7"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "630b42ff68d949d4ad0f8d6e545b5d18"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "49751ab30e2347e8a463f6911e431255"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "a945935963f646ee8928664b5c56ebfb"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "48883df884964911a284cf3739f01544"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "ae677566dafa4ce7aab287c549db0480"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e1b7ec7d37dd43538e31c305f755c426"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "c9d6944652ff4924ba7f61ad6cc7eb5f"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 7
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "d73c40e867bd4e92986d174427eb4ffe"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "48883df884964911a284cf3739f01544"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e0ff947666d34b45a0fa3458a8ec44e8"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 5
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e1b7ec7d37dd43538e31c305f755c426"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 10
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e1b7ec7d37dd43538e31c305f755c426"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 11
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e9a425f04ebd44b2b2ccd6cb543b4282"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "f0f0e498cdbb4d40b48cd1fa9096d552"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "554751c31ab94257a704a980f1396667"
+                },
+                "m_SlotId": 0
+            }
+        }
+    ],
+    "m_VertexContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 0.0
+        },
+        "m_Blocks": []
+    },
+    "m_FragmentContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 0.0
+        },
+        "m_Blocks": []
+    },
+    "m_PreviewData": {
+        "serializedMesh": {
+            "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
+            "m_Guid": ""
+        }
+    },
+    "m_Path": "Sub Graphs",
+    "m_GraphPrecision": 1,
+    "m_PreviewMode": 2,
+    "m_OutputNode": {
+        "m_Id": "6aace1a28e894a0d9116537ba9712cbd"
+    },
+    "m_ActiveTargets": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "00795a0707cf4b6c81c52d0929287d92",
+    "m_Id": 6,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
+    "m_ObjectId": "00eb679cddda4977be746d4ae0a32e5d",
+    "m_Id": 3,
+    "m_DisplayName": "Sampler",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sampler",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "03a3bdf740c64b39976d415a0267a93e",
+    "m_Id": 1,
+    "m_DisplayName": "Texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Texture",
+    "m_StageCapability": 3,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "03d5f318ac5b436ba385988a9ac0847c",
+    "m_Id": 11,
+    "m_DisplayName": "OutputF",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputF",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "04847932766c4a7e8640d460a49ae9b3",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "105ce9109417406d98816868ab241c82",
+    "m_Id": 5,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "11bbc38c72f24a7fb8086180603aa947",
+    "m_Guid": {
+        "m_GuidSerialized": "601e9a42-e533-426a-bc81-78e530ae38b7"
+    },
+    "m_Name": "InputC",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "InputC",
+    "m_DefaultReferenceName": "InputC",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "163e3f4f0371482fabf23420980c3482",
+    "m_Id": 2,
+    "m_DisplayName": "Vertex Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Vertex Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "17e2d828cde14b12bd393b2d5ae406ca",
+    "m_Id": 1,
+    "m_DisplayName": "InternalVertexLockedOut",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "InternalVertexLockedOut",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "1892767b8c7540f7a0f15006fae7f98a",
+    "m_Guid": {
+        "m_GuidSerialized": "51aeac0a-a648-4138-be4f-1888e207fc64"
+    },
+    "m_Name": "InputEF",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "InputEF",
+    "m_DefaultReferenceName": "_InputEF",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "1923be3d225b46fb91550f98194d7776",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1455.0,
+            "y": 1171.0,
+            "width": 203.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "fb8b614e808448899a55c9c431546499"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "9812c8289f0447a4ae27691d90e6a1bb"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "1b079d20e3664d31b71242a23513fc3f",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.LinearBlendSkinningNode",
+    "m_ObjectId": "2028823a61204e6dbeb6e5b2587c2345",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Linear Blend Skinning",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -889.9999389648438,
+            "y": 746.0,
+            "width": 273.0,
+            "height": 125.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "cfd19a46e84144e899e2c54d0e781f99"
+        },
+        {
+            "m_Id": "9b269c257c2443f5acc66dca15210a31"
+        },
+        {
+            "m_Id": "163e3f4f0371482fabf23420980c3482"
+        },
+        {
+            "m_Id": "4b67f91ba27e4e288b915bb22bb83d54"
+        },
+        {
+            "m_Id": "f5bfa5f45ff841ce83337e759220b5d5"
+        },
+        {
+            "m_Id": "f7e5272bdc974a89a25d9124edc8f263"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
+    "m_ObjectId": "208f9f45916e489da0a98829703f67bc",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Sample Texture 2D",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -853.0000610351563,
+            "y": 244.0,
+            "width": 208.0,
+            "height": 435.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "9cf4d5fb657944f391fb8a3b65745671"
+        },
+        {
+            "m_Id": "d6cc76543ad2421ba10dbcc9bef30929"
+        },
+        {
+            "m_Id": "5d719fd9c407488eaf087de8b332b7eb"
+        },
+        {
+            "m_Id": "e469454a725f4a13bfc5339e628ea6ec"
+        },
+        {
+            "m_Id": "2d3317fd470d47fb947565b846a5adcb"
+        },
+        {
+            "m_Id": "2587f86fb66b4680b7ec55f0298dcc42"
+        },
+        {
+            "m_Id": "b7d8b7eec79d4ddbb2bd622861a15a43"
+        },
+        {
+            "m_Id": "c62ccf1ded594d33acf000bb2390f01d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_TextureType": 0,
+    "m_NormalMapSpace": 0,
+    "m_EnableGlobalMipBias": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "21f0d86ad0f34aa0a8609f8d08ef5138",
+    "m_Id": 4,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "21fb90d5645b4ecaab08e75ad9b3e7c8",
+    "m_Id": 2,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "2587f86fb66b4680b7ec55f0298dcc42",
+    "m_Id": 1,
+    "m_DisplayName": "Texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Texture",
+    "m_StageCapability": 3,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "2d3317fd470d47fb947565b846a5adcb",
+    "m_Id": 7,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "2e8a8893ef3f4e35b9a2372e18f2076f",
+    "m_Id": 4,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "2f3ac807721b45fd9ca6a26ad7e1e820",
+    "m_Id": 4,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "3077e4c094ef4dfb8173da9216210b1d",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -511.0,
+            "y": 303.9999694824219,
+            "width": 109.0,
+            "height": 34.000030517578128
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "564d3b3c9356486c8b9efa7bfe7d420e"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "e34ba3b5e1ec4d09b2bae29d7066080b"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
+    "m_ObjectId": "30b5a98af81c464b96f88c501342ecd7",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Sample Texture 2D",
+    "m_DrawState": {
+        "m_Expanded": false,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1045.0,
+            "y": 1067.0,
+            "width": 155.0,
+            "height": 155.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "4874084b74da4c4cb5a5eae994fa33f1"
+        },
+        {
+            "m_Id": "2f3ac807721b45fd9ca6a26ad7e1e820"
+        },
+        {
+            "m_Id": "46449f3700fe42dca5df919f8774a790"
+        },
+        {
+            "m_Id": "666934202945455493ac20281f8fbeb3"
+        },
+        {
+            "m_Id": "aa6a794ef1d94496b93566b371f6a145"
+        },
+        {
+            "m_Id": "82e3a104d25941dcb7f50faa59d9e122"
+        },
+        {
+            "m_Id": "40f911ba4dcc442591d0fdbca01415fa"
+        },
+        {
+            "m_Id": "f8a6ce07c060442ba6a81ee0dcc3e5ef"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_TextureType": 0,
+    "m_NormalMapSpace": 0,
+    "m_EnableGlobalMipBias": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "3497d06473124674a205604fc7896565",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1166.0001220703125,
+            "y": 310.0000305175781,
+            "width": 190.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "a2c693d8876c4182ba1694040c260b06"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "e58954ac6984492bb7e24d45fe1ec951"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "362adea50be44b98b3cc372467a77c32",
+    "m_Id": 7,
+    "m_DisplayName": "OutputC",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputC",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "3734046427c743f793f9599163d98f7d",
+    "m_Id": 1,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "3ad6e9c48e1644b985d1c2dd0a9b088b",
+    "m_Id": 4,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "3d1b92486c564eb991593d4f681a3463",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "3e7e219a3ec1434ab1758da8235da635",
+    "m_Id": 8,
+    "m_DisplayName": "NotConnectedOut",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "NotConnectedOut",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
+    "m_ObjectId": "40f911ba4dcc442591d0fdbca01415fa",
+    "m_Id": 2,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": [],
+    "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "4412faf8eedd47d58d4bd1d02ce3a0bf",
+    "m_Id": 0,
+    "m_DisplayName": "RGBA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "RGBA",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "46449f3700fe42dca5df919f8774a790",
+    "m_Id": 5,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "4874084b74da4c4cb5a5eae994fa33f1",
+    "m_Id": 0,
+    "m_DisplayName": "RGBA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "RGBA",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "48883df884964911a284cf3739f01544",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -290.00006103515627,
+            "y": -24.00002098083496,
+            "width": 130.00003051757813,
+            "height": 118.00000762939453
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "64aacddd14c345e69e83061b0689faea"
+        },
+        {
+            "m_Id": "f62770de4aa14165adba2716e0bdcc90"
+        },
+        {
+            "m_Id": "1b079d20e3664d31b71242a23513fc3f"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.LinearBlendSkinningNode",
+    "m_ObjectId": "49751ab30e2347e8a463f6911e431255",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Linear Blend Skinning",
+    "m_DrawState": {
+        "m_Expanded": false,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1036.0,
+            "y": 1245.0,
+            "width": 167.99993896484376,
+            "height": 77.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "847fec565c464f19bd05dfe4378e6a58"
+        },
+        {
+            "m_Id": "6b929ca83a7f4db196b7859aeb1618ca"
+        },
+        {
+            "m_Id": "f0419e4afd17443993c316e8ea7591cf"
+        },
+        {
+            "m_Id": "e0a9e4dcd1a845da9f8867270707af09"
+        },
+        {
+            "m_Id": "6e8c48d8ffd546429a8f1ed88200ddf0"
+        },
+        {
+            "m_Id": "8f8ef76a5ef147daa77991831235c750"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "49d4b2483df84d48aea079a255983bbe",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -160.0000457763672,
+            "y": 94.00003051757813,
+            "width": 108.99998474121094,
+            "height": 33.999969482421878
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "aae7a65b4d814f3cb406c7cece265fdb"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "cc957df9767f444eacb0f3da12af5199"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "4b67f91ba27e4e288b915bb22bb83d54",
+    "m_Id": 3,
+    "m_DisplayName": "Skinned Position",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Skinned Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
+    "m_ObjectId": "53abbed15b96404c98065ed4860b7a38",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Sample Texture 2D",
+    "m_DrawState": {
+        "m_Expanded": false,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -296.0,
+            "y": -182.0,
+            "width": 155.0,
+            "height": 155.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e2d3bbdc6dd34b1a9e8f75148a3d7bb7"
+        },
+        {
+            "m_Id": "2e8a8893ef3f4e35b9a2372e18f2076f"
+        },
+        {
+            "m_Id": "105ce9109417406d98816868ab241c82"
+        },
+        {
+            "m_Id": "00795a0707cf4b6c81c52d0929287d92"
+        },
+        {
+            "m_Id": "ba2536eae676433aa519d478a75e4456"
+        },
+        {
+            "m_Id": "a27095a76f294a51bc6a489f2d573818"
+        },
+        {
+            "m_Id": "58493f073ef64199992c4dda012c6064"
+        },
+        {
+            "m_Id": "00eb679cddda4977be746d4ae0a32e5d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_TextureType": 0,
+    "m_NormalMapSpace": 0,
+    "m_EnableGlobalMipBias": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "554751c31ab94257a704a980f1396667",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -319.0,
+            "y": 189.0,
+            "width": 125.99996948242188,
+            "height": 118.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "da008a510d3f4ba7a01a3b137c7a26bf"
+        },
+        {
+            "m_Id": "d4731006a827472eb4b0d74cae56b400"
+        },
+        {
+            "m_Id": "3d1b92486c564eb991593d4f681a3463"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "564d3b3c9356486c8b9efa7bfe7d420e",
+    "m_Id": 0,
+    "m_DisplayName": "InputB",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "56c424333b064b938d07fa53b36f65ad",
+    "m_Guid": {
+        "m_GuidSerialized": "6ab6a6df-d701-490b-9eab-eeb1456f7f1b"
+    },
+    "m_Name": "InputD",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "InputD",
+    "m_DefaultReferenceName": "InputD",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
+    "m_ObjectId": "58493f073ef64199992c4dda012c6064",
+    "m_Id": 2,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": [],
+    "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "587cf9b9b41642e58ff33b7c4346e144",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -160.0000457763672,
+            "y": 321.0000305175781,
+            "width": 110.00001525878906,
+            "height": 33.999969482421878
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c7877e809f944db3b42b7d14ecbe135c"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "56c424333b064b938d07fa53b36f65ad"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "5d719fd9c407488eaf087de8b332b7eb",
+    "m_Id": 5,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "60c144d312184c79b848f24df18fe1b3",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1216.0,
+            "y": 793.0,
+            "width": 213.99993896484376,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "68ddd1c8f30145abaa18acf9fc68805b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "da095aab13e64f7a80c5835718925b99"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SplitNode",
+    "m_ObjectId": "630b42ff68d949d4ad0f8d6e545b5d18",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Split",
+    "m_DrawState": {
+        "m_Expanded": false,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1200.0,
+            "y": 1144.0,
+            "width": 118.0,
+            "height": 149.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "04847932766c4a7e8640d460a49ae9b3"
+        },
+        {
+            "m_Id": "3734046427c743f793f9599163d98f7d"
+        },
+        {
+            "m_Id": "db71b7da20e34163872557da6332282d"
+        },
+        {
+            "m_Id": "c946ef8ff57146e68b12a83657fb71f8"
+        },
+        {
+            "m_Id": "21f0d86ad0f34aa0a8609f8d08ef5138"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "6381c73cda744ccfae238e9582582311",
+    "m_Id": 0,
+    "m_DisplayName": "InputEF",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "645d0b61e3df49e98ea1d8f5b42d7945",
+    "m_Id": 3,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "64aacddd14c345e69e83061b0689faea",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "666934202945455493ac20281f8fbeb3",
+    "m_Id": 6,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "68ddd1c8f30145abaa18acf9fc68805b",
+    "m_Id": 0,
+    "m_DisplayName": "InternalVertexLockedInput",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "697870033bf044f7a4fb830e302091d5",
+    "m_Id": 4,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphOutputNode",
+    "m_ObjectId": "6aace1a28e894a0d9116537ba9712cbd",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Output",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 183.00003051757813,
+            "y": -62.00002670288086,
+            "width": 199.0,
+            "height": 269.0000305175781
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "3e7e219a3ec1434ab1758da8235da635"
+        },
+        {
+            "m_Id": "17e2d828cde14b12bd393b2d5ae406ca"
+        },
+        {
+            "m_Id": "d81782ff1afd4c748ed019217591a463"
+        },
+        {
+            "m_Id": "75112e47bbd8410f8327c0ad58a87465"
+        },
+        {
+            "m_Id": "6c75820a81764edbbff5a0288bda1e95"
+        },
+        {
+            "m_Id": "edcaf1860b9f41e6927090d5631f42a0"
+        },
+        {
+            "m_Id": "b27d395e5fdd42b69f910d69430e8673"
+        },
+        {
+            "m_Id": "362adea50be44b98b3cc372467a77c32"
+        },
+        {
+            "m_Id": "b35a47568e58444eafacb53b2e51c974"
+        },
+        {
+            "m_Id": "c9e87d8c84b147f6b5793d3db64d9012"
+        },
+        {
+            "m_Id": "03d5f318ac5b436ba385988a9ac0847c"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "IsFirstSlotValid": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "6b929ca83a7f4db196b7859aeb1618ca",
+    "m_Id": 1,
+    "m_DisplayName": "Vertex Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Vertex Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "6c75820a81764edbbff5a0288bda1e95",
+    "m_Id": 4,
+    "m_DisplayName": "OutputA",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputA",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "6e8c48d8ffd546429a8f1ed88200ddf0",
+    "m_Id": 4,
+    "m_DisplayName": "Skinned Normal",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Skinned Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "700a887cdba44b61a92f4ae18758ebb3",
+    "m_Id": 6,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "75112e47bbd8410f8327c0ad58a87465",
+    "m_Id": 3,
+    "m_DisplayName": "InternalBothLockedOut",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "InternalBothLockedOut",
+    "m_StageCapability": 0,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
+    "m_ObjectId": "7cdf937093e94d979ae747f25a6953de",
+    "m_Id": 3,
+    "m_DisplayName": "Sampler",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sampler",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "82e3a104d25941dcb7f50faa59d9e122",
+    "m_Id": 1,
+    "m_DisplayName": "Texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Texture",
+    "m_StageCapability": 3,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "847fec565c464f19bd05dfe4378e6a58",
+    "m_Id": 0,
+    "m_DisplayName": "Vertex Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Vertex Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "8d2b7ab79354447f9320f3a5edcca66c",
+    "m_Id": 5,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "8f7a40a79009455292142082c9dd64a8",
+    "m_Id": 7,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "8f8ef76a5ef147daa77991831235c750",
+    "m_Id": 5,
+    "m_DisplayName": "Skinned Tangent",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Skinned Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "9812c8289f0447a4ae27691d90e6a1bb",
+    "m_Guid": {
+        "m_GuidSerialized": "d41fcbd0-be91-41d7-9f98-73c3d42e8b78"
+    },
+    "m_Name": "InternalBothLockedInput",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "InternalBothLockedInput",
+    "m_DefaultReferenceName": "_InternalBothLockedInput",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "99a18f6df1b94dcbb7de074beb9617b5",
+    "m_Id": 1,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "9b269c257c2443f5acc66dca15210a31",
+    "m_Id": 1,
+    "m_DisplayName": "Vertex Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Vertex Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "9cf4d5fb657944f391fb8a3b65745671",
+    "m_Id": 0,
+    "m_DisplayName": "RGBA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "RGBA",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a19c1e39c10545ebbe4d24b332e9a581",
+    "m_Id": 0,
+    "m_DisplayName": "InputC",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "a27095a76f294a51bc6a489f2d573818",
+    "m_Id": 1,
+    "m_DisplayName": "Texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Texture",
+    "m_StageCapability": 3,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a2c693d8876c4182ba1694040c260b06",
+    "m_Id": 0,
+    "m_DisplayName": "InternalFragmentLockedInput",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.VertexIDNode",
+    "m_ObjectId": "a945935963f646ee8928664b5c56ebfb",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Vertex ID",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -472.0000305175781,
+            "y": -101.00000762939453,
+            "width": 99.0,
+            "height": 76.99998474121094
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d517f0f447be4121966b5b092b18e164"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "aa6a794ef1d94496b93566b371f6a145",
+    "m_Id": 7,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "aae7a65b4d814f3cb406c7cece265fdb",
+    "m_Id": 0,
+    "m_DisplayName": "InputA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "ae677566dafa4ce7aab287c549db0480",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -153.41001892089845,
+            "y": 390.13751220703127,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "6381c73cda744ccfae238e9582582311"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "1892767b8c7540f7a0f15006fae7f98a"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b27d395e5fdd42b69f910d69430e8673",
+    "m_Id": 6,
+    "m_DisplayName": "OutputAB",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputAB",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b35a47568e58444eafacb53b2e51c974",
+    "m_Id": 9,
+    "m_DisplayName": "OutputD",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputD",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
+    "m_ObjectId": "b7d8b7eec79d4ddbb2bd622861a15a43",
+    "m_Id": 2,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": [],
+    "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "ba2536eae676433aa519d478a75e4456",
+    "m_Id": 7,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "bd21fc340928490399f977d384513ee0",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 1,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c076c4bd814142628ddaa32e6b53809b",
+    "m_Id": 0,
+    "m_DisplayName": "InputB",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
+    "m_ObjectId": "c62ccf1ded594d33acf000bb2390f01d",
+    "m_Id": 3,
+    "m_DisplayName": "Sampler",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sampler",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c7877e809f944db3b42b7d14ecbe135c",
+    "m_Id": 0,
+    "m_DisplayName": "InputD",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c946ef8ff57146e68b12a83657fb71f8",
+    "m_Id": 3,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "c9d6944652ff4924ba7f61ad6cc7eb5f",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -159.99996948242188,
+            "y": 260.9999694824219,
+            "width": 110.00000762939453,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "a19c1e39c10545ebbe4d24b332e9a581"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "11bbc38c72f24a7fb8086180603aa947"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c9e87d8c84b147f6b5793d3db64d9012",
+    "m_Id": 10,
+    "m_DisplayName": "OutputE",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputE",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "cc957df9767f444eacb0f3da12af5199",
+    "m_Guid": {
+        "m_GuidSerialized": "f15f54e6-6d27-4dfe-ae56-2d196da18185"
+    },
+    "m_Name": "InputA",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "InputA",
+    "m_DefaultReferenceName": "_InputA",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "cfd19a46e84144e899e2c54d0e781f99",
+    "m_Id": 0,
+    "m_DisplayName": "Vertex Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Vertex Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "d4731006a827472eb4b0d74cae56b400",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d517f0f447be4121966b5b092b18e164",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 1,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d6cc76543ad2421ba10dbcc9bef30929",
+    "m_Id": 4,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
+    "m_ObjectId": "d73c40e867bd4e92986d174427eb4ffe",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Sample Texture 2D",
+    "m_DrawState": {
+        "m_Expanded": false,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -520.0,
+            "y": -24.00002098083496,
+            "width": 155.0,
+            "height": 155.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "4412faf8eedd47d58d4bd1d02ce3a0bf"
+        },
+        {
+            "m_Id": "3ad6e9c48e1644b985d1c2dd0a9b088b"
+        },
+        {
+            "m_Id": "8d2b7ab79354447f9320f3a5edcca66c"
+        },
+        {
+            "m_Id": "700a887cdba44b61a92f4ae18758ebb3"
+        },
+        {
+            "m_Id": "8f7a40a79009455292142082c9dd64a8"
+        },
+        {
+            "m_Id": "03a3bdf740c64b39976d415a0267a93e"
+        },
+        {
+            "m_Id": "f0aee82257204042916919a644bb5042"
+        },
+        {
+            "m_Id": "7cdf937093e94d979ae747f25a6953de"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_TextureType": 0,
+    "m_NormalMapSpace": 0,
+    "m_EnableGlobalMipBias": true
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "d73f6d530b7c4294b80da5a60167284f",
+    "m_Guid": {
+        "m_GuidSerialized": "9541ef1e-22a4-40f9-b6a6-7e393f4c1454"
+    },
+    "m_Name": "NotConnectedInput",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "NotConnectedInput",
+    "m_DefaultReferenceName": "_NotConnectedInput",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d81782ff1afd4c748ed019217591a463",
+    "m_Id": 2,
+    "m_DisplayName": "InternalFragmentLockedOut",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "InternalFragmentLockedOut",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "da008a510d3f4ba7a01a3b137c7a26bf",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "da095aab13e64f7a80c5835718925b99",
+    "m_Guid": {
+        "m_GuidSerialized": "da4ec2c8-8755-4c8a-ae32-0575fc6d45bb"
+    },
+    "m_Name": "InternalVertexLockedInput",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "InternalVertexLockedInput",
+    "m_DefaultReferenceName": "_InternalVertexLockedInput",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "db71b7da20e34163872557da6332282d",
+    "m_Id": 2,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "dea45617ded841cab6740442bc1b234e",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "e0a9e4dcd1a845da9f8867270707af09",
+    "m_Id": 3,
+    "m_DisplayName": "Skinned Position",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Skinned Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "e0ff947666d34b45a0fa3458a8ec44e8",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -136.48204040527345,
+            "y": 145.4750213623047,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c076c4bd814142628ddaa32e6b53809b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "e34ba3b5e1ec4d09b2bae29d7066080b"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SplitNode",
+    "m_ObjectId": "e1b7ec7d37dd43538e31c305f755c426",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Split",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.9999610185623169,
+            "y": 338.0,
+            "width": 117.99998474121094,
+            "height": 149.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "dea45617ded841cab6740442bc1b234e"
+        },
+        {
+            "m_Id": "99a18f6df1b94dcbb7de074beb9617b5"
+        },
+        {
+            "m_Id": "21fb90d5645b4ecaab08e75ad9b3e7c8"
+        },
+        {
+            "m_Id": "645d0b61e3df49e98ea1d8f5b42d7945"
+        },
+        {
+            "m_Id": "697870033bf044f7a4fb830e302091d5"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "e2d3bbdc6dd34b1a9e8f75148a3d7bb7",
+    "m_Id": 0,
+    "m_DisplayName": "RGBA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "RGBA",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "e34ba3b5e1ec4d09b2bae29d7066080b",
+    "m_Guid": {
+        "m_GuidSerialized": "7598d424-4a2e-442f-9acb-8a2968d75d21"
+    },
+    "m_Name": "InputB",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "InputB",
+    "m_DefaultReferenceName": "InputB",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "e469454a725f4a13bfc5339e628ea6ec",
+    "m_Id": 6,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "e58954ac6984492bb7e24d45fe1ec951",
+    "m_Guid": {
+        "m_GuidSerialized": "71044941-9e99-428f-95a0-be941980aab8"
+    },
+    "m_Name": "InternalFragmentLockedInput",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "InternalFragmentLockedInput",
+    "m_DefaultReferenceName": "_InternalFragmentLockedInput",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.VertexIDNode",
+    "m_ObjectId": "e9a425f04ebd44b2b2ccd6cb543b4282",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Vertex ID",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -126.0000228881836,
+            "y": -209.9999542236328,
+            "width": 99.0,
+            "height": 76.99998474121094
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "bd21fc340928490399f977d384513ee0"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "edcaf1860b9f41e6927090d5631f42a0",
+    "m_Id": 5,
+    "m_DisplayName": "OutputB",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputB",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "f0419e4afd17443993c316e8ea7591cf",
+    "m_Id": 2,
+    "m_DisplayName": "Vertex Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Vertex Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
+    "m_ObjectId": "f0aee82257204042916919a644bb5042",
+    "m_Id": 2,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": [],
+    "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "f0f0e498cdbb4d40b48cd1fa9096d552",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -532.0,
+            "y": 244.0,
+            "width": 109.00003051757813,
+            "height": 33.99993896484375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "fd533ca7ba844690abd6d07ddbf8187d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "cc957df9767f444eacb0f3da12af5199"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "f18f6b68dcaf4c508e20f59080227472",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "d73f6d530b7c4294b80da5a60167284f"
+        },
+        {
+            "m_Id": "da095aab13e64f7a80c5835718925b99"
+        },
+        {
+            "m_Id": "e58954ac6984492bb7e24d45fe1ec951"
+        },
+        {
+            "m_Id": "cc957df9767f444eacb0f3da12af5199"
+        },
+        {
+            "m_Id": "e34ba3b5e1ec4d09b2bae29d7066080b"
+        },
+        {
+            "m_Id": "11bbc38c72f24a7fb8086180603aa947"
+        },
+        {
+            "m_Id": "56c424333b064b938d07fa53b36f65ad"
+        },
+        {
+            "m_Id": "9812c8289f0447a4ae27691d90e6a1bb"
+        },
+        {
+            "m_Id": "1892767b8c7540f7a0f15006fae7f98a"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "f5bfa5f45ff841ce83337e759220b5d5",
+    "m_Id": 4,
+    "m_DisplayName": "Skinned Normal",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Skinned Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "f62770de4aa14165adba2716e0bdcc90",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "f7e5272bdc974a89a25d9124edc8f263",
+    "m_Id": 5,
+    "m_DisplayName": "Skinned Tangent",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Skinned Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
+    "m_ObjectId": "f8a6ce07c060442ba6a81ee0dcc3e5ef",
+    "m_Id": 3,
+    "m_DisplayName": "Sampler",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sampler",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "fb8b614e808448899a55c9c431546499",
+    "m_Id": 0,
+    "m_DisplayName": "InternalBothLockedInput",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "fd533ca7ba844690abd6d07ddbf8187d",
+    "m_Id": 0,
+    "m_DisplayName": "InputA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+

--- a/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/ShaderStageCapability_SubGraph.shadersubgraph.meta
+++ b/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/ShaderStageCapability_SubGraph.shadersubgraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5028f2d6d26bdfd4493983323990e966
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 60072b568d64c40a485e0fc55012dc9f, type: 3}

--- a/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/SubShaderInvalidCapabilities_Graph.shadergraph
+++ b/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/SubShaderInvalidCapabilities_Graph.shadergraph
@@ -1,0 +1,1156 @@
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.GraphData",
+    "m_ObjectId": "b0ac10afa44a4f58b79a62825ed81b9b",
+    "m_Properties": [],
+    "m_Keywords": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "582bf4b4b1344ade99f4b84b7db9d3aa"
+        }
+    ],
+    "m_Nodes": [
+        {
+            "m_Id": "161d993258944c5dbaa25f70d0b0dec1"
+        },
+        {
+            "m_Id": "fb2a8be30d5d4917872e7ccd81d14cb7"
+        },
+        {
+            "m_Id": "abd45e3d6e8e44a79ff4cd03edb4b616"
+        },
+        {
+            "m_Id": "af8359ee297d42bfa9d6ef5cebec6ab4"
+        },
+        {
+            "m_Id": "9118d98f636d4fb29bc1484cc2b1dfba"
+        },
+        {
+            "m_Id": "1e63631659264cdea1c9efd5e79a7475"
+        },
+        {
+            "m_Id": "f446436e195b414da535b2b00ed976df"
+        },
+        {
+            "m_Id": "3f8e1e511d8e46d0b9b501c7afeac244"
+        },
+        {
+            "m_Id": "33e76ff763f846698fbeb9521c33cf17"
+        },
+        {
+            "m_Id": "d7f8649846af44648b584b3fb336bdb8"
+        },
+        {
+            "m_Id": "35386a2e03984755b353cb655d4ef6fb"
+        },
+        {
+            "m_Id": "95463ddebbf94067b8465e4d81533edd"
+        },
+        {
+            "m_Id": "d376745648a8494e9c76080e4b5204a2"
+        }
+    ],
+    "m_GroupDatas": [],
+    "m_StickyNoteDatas": [],
+    "m_Edges": [
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "35386a2e03984755b353cb655d4ef6fb"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d376745648a8494e9c76080e4b5204a2"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "95463ddebbf94067b8465e4d81533edd"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d376745648a8494e9c76080e4b5204a2"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "d376745648a8494e9c76080e4b5204a2"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d7f8649846af44648b584b3fb336bdb8"
+                },
+                "m_SlotId": -1633206446
+            }
+        }
+    ],
+    "m_VertexContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 0.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "161d993258944c5dbaa25f70d0b0dec1"
+            },
+            {
+                "m_Id": "fb2a8be30d5d4917872e7ccd81d14cb7"
+            },
+            {
+                "m_Id": "abd45e3d6e8e44a79ff4cd03edb4b616"
+            }
+        ]
+    },
+    "m_FragmentContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 200.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "af8359ee297d42bfa9d6ef5cebec6ab4"
+            },
+            {
+                "m_Id": "9118d98f636d4fb29bc1484cc2b1dfba"
+            },
+            {
+                "m_Id": "1e63631659264cdea1c9efd5e79a7475"
+            },
+            {
+                "m_Id": "f446436e195b414da535b2b00ed976df"
+            },
+            {
+                "m_Id": "3f8e1e511d8e46d0b9b501c7afeac244"
+            },
+            {
+                "m_Id": "33e76ff763f846698fbeb9521c33cf17"
+            }
+        ]
+    },
+    "m_PreviewData": {
+        "serializedMesh": {
+            "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
+            "m_Guid": ""
+        }
+    },
+    "m_Path": "Shader Graphs",
+    "m_GraphPrecision": 1,
+    "m_PreviewMode": 2,
+    "m_OutputNode": {
+        "m_Id": ""
+    },
+    "m_ActiveTargets": [
+        {
+            "m_Id": "57edfb40245c406d814f370268901a8d"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "0907d12f81304eea8efc378a42425d06",
+    "m_Id": 5,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "0926fd0c3d0a47a99101a04e628062b7",
+    "m_Id": 0,
+    "m_DisplayName": "Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "11c69d344c774b2a8a0b44b40fd20ffa",
+    "m_Id": 0,
+    "m_DisplayName": "Metallic",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Metallic",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "157f14dcbcc444a38f232c29b7a9c3f4",
+    "m_Id": 0,
+    "m_DisplayName": "Smoothness",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Smoothness",
+    "m_StageCapability": 2,
+    "m_Value": 0.5,
+    "m_DefaultValue": 0.5,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "161d993258944c5dbaa25f70d0b0dec1",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Position",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "0926fd0c3d0a47a99101a04e628062b7"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Position"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "1e63631659264cdea1c9efd5e79a7475",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Metallic",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "11c69d344c774b2a8a0b44b40fd20ffa"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "31e61d07c5d94b60a1d9b6cb8d63d85b",
+    "m_Id": 0,
+    "m_DisplayName": "Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
+    "m_ObjectId": "3283f48e5a304c39ab75afb74d578f60",
+    "m_WorkflowMode": 1,
+    "m_NormalDropOffSpace": 0,
+    "m_ClearCoat": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "3323602f06024f6d9d516741d53c1af7",
+    "m_Id": 1,
+    "m_DisplayName": "Texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Texture",
+    "m_StageCapability": 3,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "33e76ff763f846698fbeb9521c33cf17",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Occlusion",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "42bbc261f28844ddaf3dc8ebbc37e086"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.VertexIDNode",
+    "m_ObjectId": "35386a2e03984755b353cb655d4ef6fb",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Vertex ID",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1023.2057495117188,
+            "y": 130.25059509277345,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "65283415b03644ec8269ae3ac7e5213a"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
+    "m_ObjectId": "37826d13664448bca7e7cf688fcd0e04",
+    "m_Id": 3,
+    "m_DisplayName": "Sampler",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sampler",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "3f8e1e511d8e46d0b9b501c7afeac244",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Emission",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "773ba675a96d427f9184efe2d74c30b5"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Emission"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "42bbc261f28844ddaf3dc8ebbc37e086",
+    "m_Id": 0,
+    "m_DisplayName": "Ambient Occlusion",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Occlusion",
+    "m_StageCapability": 2,
+    "m_Value": 1.0,
+    "m_DefaultValue": 1.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "5458a44fcce14e0586122765d0064a16",
+    "m_Id": 2,
+    "m_DisplayName": "FragmentLocked_Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "FragmentLocked_Out",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
+    "m_ObjectId": "57edfb40245c406d814f370268901a8d",
+    "m_ActiveSubTarget": {
+        "m_Id": "3283f48e5a304c39ab75afb74d578f60"
+    },
+    "m_AllowMaterialOverride": false,
+    "m_SurfaceType": 0,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
+    "m_AlphaMode": 0,
+    "m_RenderFace": 2,
+    "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
+    "m_CustomEditorGUI": ""
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "582bf4b4b1344ade99f4b84b7db9d3aa",
+    "m_Name": "",
+    "m_ChildObjectList": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "5d7c05224a15407ab3b77bdb8536db11",
+    "m_Id": 1,
+    "m_DisplayName": "VertexLocked_Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "VertexLocked_Out",
+    "m_StageCapability": 1,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "624e8949e8c94786ba7e485f6d5fc775",
+    "m_Id": 0,
+    "m_DisplayName": "RGBA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "RGBA",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "65283415b03644ec8269ae3ac7e5213a",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 1,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "773ba675a96d427f9184efe2d74c30b5",
+    "m_Id": 0,
+    "m_DisplayName": "Emission",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Emission",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 1,
+    "m_DefaultColor": {
+        "r": 0.0,
+        "g": 0.0,
+        "b": 0.0,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "89476942cde74a74ad3dea4cdb7eae99",
+    "m_Id": 0,
+    "m_DisplayName": "Base Color",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "BaseColor",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.5,
+        "y": 0.5,
+        "z": 0.5
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 0,
+    "m_DefaultColor": {
+        "r": 0.5,
+        "g": 0.5,
+        "b": 0.5,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "9118d98f636d4fb29bc1484cc2b1dfba",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.NormalTS",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e6ad3e6b7ff64b06b411409672055a30"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.NormalTS"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
+    "m_ObjectId": "945c1c489b6c4cff90715031b34bd435",
+    "m_Id": 2,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": [],
+    "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
+    "m_ObjectId": "95463ddebbf94067b8465e4d81533edd",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Sample Texture 2D",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1086.0001220703125,
+            "y": 248.00001525878907,
+            "width": 183.00006103515626,
+            "height": 250.99998474121095
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "624e8949e8c94786ba7e485f6d5fc775"
+        },
+        {
+            "m_Id": "a52f187f10844aa1ab962d47a24bdf55"
+        },
+        {
+            "m_Id": "0907d12f81304eea8efc378a42425d06"
+        },
+        {
+            "m_Id": "f8a45bff83924e8b97634a234466bc7a"
+        },
+        {
+            "m_Id": "cdc7864031c1495cb5e106015850a050"
+        },
+        {
+            "m_Id": "3323602f06024f6d9d516741d53c1af7"
+        },
+        {
+            "m_Id": "945c1c489b6c4cff90715031b34bd435"
+        },
+        {
+            "m_Id": "37826d13664448bca7e7cf688fcd0e04"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_TextureType": 0,
+    "m_NormalMapSpace": 0,
+    "m_EnableGlobalMipBias": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "9c9b3106fe1c4e218c6f676551ab4413",
+    "m_Id": -1633206446,
+    "m_DisplayName": "InputA",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_InputA",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "9ec06fde5b874bb0968904ca8df5bfc8",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "a0a6b09cd92e462596878f85f9a1dfbd",
+    "m_Id": 0,
+    "m_DisplayName": "Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a52f187f10844aa1ab962d47a24bdf55",
+    "m_Id": 4,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "abd45e3d6e8e44a79ff4cd03edb4b616",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Tangent",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "31e61d07c5d94b60a1d9b6cb8d63d85b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Tangent"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "af8359ee297d42bfa9d6ef5cebec6ab4",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.BaseColor",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "89476942cde74a74ad3dea4cdb7eae99"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.BaseColor"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "c5051f7f716a460d93e8148261bbb54c",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c55e75bfc51843b98d5d11c30f434ad9",
+    "m_Id": 3,
+    "m_DisplayName": "OutputA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputA",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "cdc7864031c1495cb5e106015850a050",
+    "m_Id": 7,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "d376745648a8494e9c76080e4b5204a2",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -864.0000610351563,
+            "y": 130.0,
+            "width": 208.0,
+            "height": 302.0000305175781
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c5051f7f716a460d93e8148261bbb54c"
+        },
+        {
+            "m_Id": "9ec06fde5b874bb0968904ca8df5bfc8"
+        },
+        {
+            "m_Id": "db6f04d00ab9468fa74a8754789305a5"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
+    "m_ObjectId": "d7f8649846af44648b584b3fb336bdb8",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SubShaderInvalidCapabilities_SubGraph",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -598.8842163085938,
+            "y": 100.709228515625,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "9c9b3106fe1c4e218c6f676551ab4413"
+        },
+        {
+            "m_Id": "5d7c05224a15407ab3b77bdb8536db11"
+        },
+        {
+            "m_Id": "5458a44fcce14e0586122765d0064a16"
+        },
+        {
+            "m_Id": "c55e75bfc51843b98d5d11c30f434ad9"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"b55c39fbfe50d164fa4676d8e3bd5cc7\",\n        \"type\": 3\n    }\n}",
+    "m_PropertyGuids": [
+        "38879cba-bede-42e4-843e-4120b22385c4"
+    ],
+    "m_PropertyIds": [
+        -1633206446
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "db6f04d00ab9468fa74a8754789305a5",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "e6ad3e6b7ff64b06b411409672055a30",
+    "m_Id": 0,
+    "m_DisplayName": "Normal (Tangent Space)",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "NormalTS",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 3
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "f446436e195b414da535b2b00ed976df",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Smoothness",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "157f14dcbcc444a38f232c29b7a9c3f4"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Smoothness"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "f8a45bff83924e8b97634a234466bc7a",
+    "m_Id": 6,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "fb2a8be30d5d4917872e7ccd81d14cb7",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Normal",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "a0a6b09cd92e462596878f85f9a1dfbd"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Normal"
+}
+

--- a/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/SubShaderInvalidCapabilities_Graph.shadergraph.meta
+++ b/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/SubShaderInvalidCapabilities_Graph.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: ba28bf1beee2e4442b5f678d9f8be41b
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/SubShaderInvalidCapabilities_SubGraph.shadersubgraph
+++ b/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/SubShaderInvalidCapabilities_SubGraph.shadersubgraph
@@ -1,0 +1,519 @@
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.GraphData",
+    "m_ObjectId": "ec2cb23c27ca48d196112080902cb861",
+    "m_Properties": [
+        {
+            "m_Id": "945f3d50e2b44a29adeb151e6bf09338"
+        }
+    ],
+    "m_Keywords": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "36cb9ff5a09c45e8b37c0def4e4476d3"
+        }
+    ],
+    "m_Nodes": [
+        {
+            "m_Id": "1f336b39b12d4f21ab51be1afc1f6526"
+        },
+        {
+            "m_Id": "6237d895a8154946b88e9efd758078bd"
+        },
+        {
+            "m_Id": "01629c22b73846b897c88ba15f20db16"
+        },
+        {
+            "m_Id": "9a7f50fadff94d34ab1c3459f4ce5b2b"
+        }
+    ],
+    "m_GroupDatas": [],
+    "m_StickyNoteDatas": [],
+    "m_Edges": [
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "01629c22b73846b897c88ba15f20db16"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "1f336b39b12d4f21ab51be1afc1f6526"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "6237d895a8154946b88e9efd758078bd"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "1f336b39b12d4f21ab51be1afc1f6526"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "9a7f50fadff94d34ab1c3459f4ce5b2b"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "1f336b39b12d4f21ab51be1afc1f6526"
+                },
+                "m_SlotId": 3
+            }
+        }
+    ],
+    "m_VertexContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 0.0
+        },
+        "m_Blocks": []
+    },
+    "m_FragmentContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 0.0
+        },
+        "m_Blocks": []
+    },
+    "m_PreviewData": {
+        "serializedMesh": {
+            "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
+            "m_Guid": ""
+        }
+    },
+    "m_Path": "Sub Graphs",
+    "m_GraphPrecision": 1,
+    "m_PreviewMode": 2,
+    "m_OutputNode": {
+        "m_Id": "1f336b39b12d4f21ab51be1afc1f6526"
+    },
+    "m_ActiveTargets": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
+    "m_ObjectId": "01629c22b73846b897c88ba15f20db16",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Sample Texture 2D",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -292.0,
+            "y": 66.0,
+            "width": 183.0,
+            "height": 251.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e6fc6283bfbe4d4b87b0893c397d7666"
+        },
+        {
+            "m_Id": "a5a61d9f73124f4b9a0bcc9dc1fc285c"
+        },
+        {
+            "m_Id": "023cbf0fc6d1470f91984fdf613848ef"
+        },
+        {
+            "m_Id": "f5c1483a3f404319b7b6cc80bcc7b770"
+        },
+        {
+            "m_Id": "672086bce8fb4f169a99fb9617e6903b"
+        },
+        {
+            "m_Id": "148ee6c20a03445db77871d1a75ace45"
+        },
+        {
+            "m_Id": "94976e98f50f460e8d03e01d8e6c9bc2"
+        },
+        {
+            "m_Id": "168bd95ee3eb47cea8b830e23cccccd0"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_TextureType": 0,
+    "m_NormalMapSpace": 0,
+    "m_EnableGlobalMipBias": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "023cbf0fc6d1470f91984fdf613848ef",
+    "m_Id": 5,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "148ee6c20a03445db77871d1a75ace45",
+    "m_Id": 1,
+    "m_DisplayName": "Texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Texture",
+    "m_StageCapability": 3,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
+    "m_ObjectId": "168bd95ee3eb47cea8b830e23cccccd0",
+    "m_Id": 3,
+    "m_DisplayName": "Sampler",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sampler",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphOutputNode",
+    "m_ObjectId": "1f336b39b12d4f21ab51be1afc1f6526",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Output",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 165.0,
+            "height": 101.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "dc538d0afb7944db9ed6ab27c16aca4e"
+        },
+        {
+            "m_Id": "a257b1904f5844e3ae215ad739c78831"
+        },
+        {
+            "m_Id": "9dee276dbf5a4620b182346d04596df8"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "IsFirstSlotValid": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "36cb9ff5a09c45e8b37c0def4e4476d3",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "945f3d50e2b44a29adeb151e6bf09338"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "3c0aab821ecd4c9f87f241ff983de986",
+    "m_Id": 0,
+    "m_DisplayName": "InputA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "4065ab1106be45c29525e90b32616f7d",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 1,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.VertexIDNode",
+    "m_ObjectId": "6237d895a8154946b88e9efd758078bd",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Vertex ID",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -230.0,
+            "y": -62.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "4065ab1106be45c29525e90b32616f7d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "672086bce8fb4f169a99fb9617e6903b",
+    "m_Id": 7,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "945f3d50e2b44a29adeb151e6bf09338",
+    "m_Guid": {
+        "m_GuidSerialized": "38879cba-bede-42e4-843e-4120b22385c4"
+    },
+    "m_Name": "InputA",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "InputA",
+    "m_DefaultReferenceName": "_InputA",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
+    "m_ObjectId": "94976e98f50f460e8d03e01d8e6c9bc2",
+    "m_Id": 2,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": [],
+    "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "9a7f50fadff94d34ab1c3459f4ce5b2b",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -109.0,
+            "y": 192.0,
+            "width": 109.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "3c0aab821ecd4c9f87f241ff983de986"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "945f3d50e2b44a29adeb151e6bf09338"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "9dee276dbf5a4620b182346d04596df8",
+    "m_Id": 3,
+    "m_DisplayName": "OutputA",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutputA",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a257b1904f5844e3ae215ad739c78831",
+    "m_Id": 2,
+    "m_DisplayName": "FragmentLocked_Out",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "FragmentLocked_Out",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a5a61d9f73124f4b9a0bcc9dc1fc285c",
+    "m_Id": 4,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "dc538d0afb7944db9ed6ab27c16aca4e",
+    "m_Id": 1,
+    "m_DisplayName": "VertexLocked_Out",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "VertexLocked_Out",
+    "m_StageCapability": 1,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "e6fc6283bfbe4d4b87b0893c397d7666",
+    "m_Id": 0,
+    "m_DisplayName": "RGBA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "RGBA",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "f5c1483a3f404319b7b6cc80bcc7b770",
+    "m_Id": 6,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+

--- a/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/SubShaderInvalidCapabilities_SubGraph.shadersubgraph.meta
+++ b/TestProjects/ShaderGraph/Assets/Testing/ShaderStageCapabilityGraphs/SubShaderInvalidCapabilities_SubGraph.shadersubgraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b55c39fbfe50d164fa4676d8e3bd5cc7
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 60072b568d64c40a485e0fc55012dc9f, type: 3}

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Added `Gather Texture 2D` node, for retrieving the four samples (red component only) that would be used for bilinear interpolation when sampling a Texture2D.
   - Added toggle "Disable Global Mip Bias" in Sample Texture 2D and Sample Texture 2D array node. This checkbox disables the runtimes automatic Mip Bias, which for instance can be activated during dynamic resolution scaling.
   - Added `Sprite` option to Main Preview, which is similar to `Quad` but does not allow rotation. `Sprite` is used as the default preview for URP Sprite shaders.
+  - Added visible errors for invalid stage capability connections to shader graph.
 
 ### Changed
 - Properties and Keywords are no longer separated by type on the blackboard. Categories allow for any combination of properties and keywords to be grouped together as the user defines.
@@ -115,6 +116,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a ShaderGraph issue where selecting a keyword property in the blackboard would invalidate all previews, causing them to recompile [1347666] (https://issuetracker.unity3d.com/product/unity/issues/guid/1347666/)
 - Fixed the incorrect value written to the VT feedback buffer when VT is not used.
 - Fixed ShaderGraph isNaN node, which was always returning false on Vulkan and Metal platforms.
+- Fixed ShaderGraph sub-graph stage limitations to be per slot instead of per sub-graph node [1337137].
 
 ## [11.0.0] - 2020-10-21
 

--- a/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
@@ -2833,7 +2833,7 @@ namespace UnityEditor.ShaderGraph
             {
                 if (contextData == null)
                     return;
-                
+
                 foreach (var block in contextData.blocks)
                 {
                     var slots = block.value.GetInputSlots<MaterialSlot>();
@@ -2894,12 +2894,12 @@ namespace UnityEditor.ShaderGraph
             bool IsEntireNodeStageLocked(AbstractMaterialNode node, ShaderStageCapability expectedNodeCapability)
             {
                 var slots = node.GetOutputSlots<MaterialSlot>();
-                foreach(var slot in slots)
+                foreach (var slot in slots)
                 {
                     if (expectedNodeCapability != slot.stageCapability)
                         return false;
                 }
-                return true; 
+                return true;
             };
 
             foreach (var errorSourceSlot in errorSourceSlots)
@@ -2909,7 +2909,7 @@ namespace UnityEditor.ShaderGraph
                 // Determine if only one slot or the entire node is at fault. Currently only slots are
                 // denoted with stage capabilities so deduce this by checking all outputs
                 string errorSource;
-                if(IsEntireNodeStageLocked(errorNode, errorSourceSlot.stageCapability))
+                if (IsEntireNodeStageLocked(errorNode, errorSourceSlot.stageCapability))
                     errorSource = $"Node {errorNode.name}";
                 else
                     errorSource = $"Slot {errorSourceSlot.RawDisplayName()}";

--- a/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
@@ -1876,6 +1876,7 @@ namespace UnityEditor.ShaderGraph
             }
 
             ValidateCustomBlockLimit();
+            ValidateContextBlocks();
         }
 
         public void AddValidationError(string id, string errorMessage,
@@ -2823,6 +2824,109 @@ namespace UnityEditor.ShaderGraph
                 {
                     AddValidationError(cib.objectId, $"{cib.customName} exceeds the interpolation channel warning threshold: {warnRange}. See ShaderGraph project settings.", ShaderCompilerMessageSeverity.Warning);
                 }
+            }
+        }
+
+        void ValidateContextBlocks()
+        {
+            void ValidateContext(ContextData contextData, ShaderStage expectedShaderStage)
+            {
+                if (contextData == null)
+                    return;
+                
+                foreach (var block in contextData.blocks)
+                {
+                    var slots = block.value.GetInputSlots<MaterialSlot>();
+                    foreach (var slot in slots)
+                        FindAndReportSlotErrors(slot, expectedShaderStage);
+                }
+            };
+
+            ValidateContext(vertexContext, ShaderStage.Vertex);
+            ValidateContext(fragmentContext, ShaderStage.Fragment);
+        }
+
+        void FindAndReportSlotErrors(MaterialSlot initialSlot, ShaderStage expectedShaderStage)
+        {
+            var expectedCapability = expectedShaderStage.GetShaderStageCapability();
+            var errorSourceSlots = new HashSet<MaterialSlot>();
+            var visitedNodes = new HashSet<AbstractMaterialNode>();
+
+            var graph = initialSlot.owner.owner;
+            var slotStack = new Stack<MaterialSlot>();
+            slotStack.Clear();
+            slotStack.Push(initialSlot);
+
+            // Trace back and find any edges that introduce an error
+            while (slotStack.Any())
+            {
+                var slot = slotStack.Pop();
+
+                // If the slot is an input, jump across the connected edge to the output it's connected to
+                if (slot.isInputSlot)
+                {
+                    foreach (var edge in graph.GetEdges(slot.slotReference))
+                    {
+                        var node = edge.outputSlot.node;
+
+                        var outputSlot = node.FindOutputSlot<MaterialSlot>(edge.outputSlot.slotId);
+                        // If the output slot this is connected to is invalid then this is a source of an error.
+                        // Mark the slot and stop iterating, otherwise continue the recursion
+                        if (!outputSlot.stageCapability.HasFlag(expectedCapability))
+                            errorSourceSlots.Add(outputSlot);
+                        else
+                            slotStack.Push(outputSlot);
+                    }
+                }
+                else
+                {
+                    // No need to double visit nodes
+                    if (visitedNodes.Contains(slot.owner))
+                        continue;
+                    visitedNodes.Add(slot.owner);
+
+                    var ownerSlots = slot.owner.GetInputSlots<MaterialSlot>(slot);
+                    foreach (var ownerSlot in ownerSlots)
+                        slotStack.Push(ownerSlot);
+                }
+            }
+
+            bool IsEntireNodeStageLocked(AbstractMaterialNode node, ShaderStageCapability expectedNodeCapability)
+            {
+                var slots = node.GetOutputSlots<MaterialSlot>();
+                foreach(var slot in slots)
+                {
+                    if (expectedNodeCapability != slot.stageCapability)
+                        return false;
+                }
+                return true; 
+            };
+
+            foreach (var errorSourceSlot in errorSourceSlots)
+            {
+                var errorNode = errorSourceSlot.owner;
+
+                // Determine if only one slot or the entire node is at fault. Currently only slots are
+                // denoted with stage capabilities so deduce this by checking all outputs
+                string errorSource;
+                if(IsEntireNodeStageLocked(errorNode, errorSourceSlot.stageCapability))
+                    errorSource = $"Node {errorNode.name}";
+                else
+                    errorSource = $"Slot {errorSourceSlot.RawDisplayName()}";
+
+                // Determine what action they can take. If the stage capability is None then this can't be connected to anything.
+                string actionToTake;
+                if (errorSourceSlot.stageCapability != ShaderStageCapability.None)
+                {
+                    var validStageName = errorSourceSlot.stageCapability.ToString().ToLower();
+                    actionToTake = $"reconnect to a {validStageName} block or delete invalid connection";
+                }
+                else
+                    actionToTake = "delete invalid connection";
+
+                var invalidStageName = expectedShaderStage.ToString().ToLower();
+                string message = $"{errorSource} is not compatible with {invalidStageName} block {initialSlot.RawDisplayName()}, {actionToTake}.";
+                AddValidationError(errorNode.objectId, message, ShaderCompilerMessageSeverity.Error);
             }
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/MaterialSlot.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/MaterialSlot.cs
@@ -292,7 +292,7 @@ namespace UnityEditor.ShaderGraph
         public bool IsCompatibleStageWith(MaterialSlot otherSlot)
         {
             var startStage = otherSlot.stageCapability;
-            if (startStage == ShaderStageCapability.All)
+            if (startStage == ShaderStageCapability.All || otherSlot.owner is SubGraphNode)
                 startStage = NodeUtils.GetEffectiveShaderStageCapability(otherSlot, true)
                     & NodeUtils.GetEffectiveShaderStageCapability(otherSlot, false);
             return startStage == ShaderStageCapability.All || stageCapability == ShaderStageCapability.All || stageCapability == startStage;

--- a/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
+++ b/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
@@ -466,9 +466,9 @@ namespace UnityEditor.Graphing
                 {
                     var ownerSlots = Enumerable.Empty<MaterialSlot>();
                     if (goingBackwards && slot.isOutputSlot)
-                        ownerSlots = slot.owner.GetInputSlots<MaterialSlot>();
+                        ownerSlots = slot.owner.GetInputSlots<MaterialSlot>(slot);
                     else if (!goingBackwards && slot.isInputSlot)
-                        ownerSlots = slot.owner.GetOutputSlots<MaterialSlot>();
+                        ownerSlots = slot.owner.GetOutputSlots<MaterialSlot>(slot);
                     foreach (var ownerSlot in ownerSlots)
                         s_SlotStack.Push(ownerSlot);
                 }
@@ -513,9 +513,9 @@ namespace UnityEditor.Graphing
                 {
                     var ownerSlots = Enumerable.Empty<MaterialSlot>();
                     if (goingBackwards && slot.isOutputSlot)
-                        ownerSlots = slot.owner.GetInputSlots<MaterialSlot>();
+                        ownerSlots = slot.owner.GetInputSlots<MaterialSlot>(slot);
                     else if (!goingBackwards && slot.isInputSlot)
-                        ownerSlots = slot.owner.GetOutputSlots<MaterialSlot>();
+                        ownerSlots = slot.owner.GetOutputSlots<MaterialSlot>(slot);
                     foreach (var ownerSlot in ownerSlots)
                         s_SlotStack.Push(ownerSlot);
                 }

--- a/com.unity.shadergraph/Editor/Data/Interfaces/Graph/INode.cs
+++ b/com.unity.shadergraph/Editor/Data/Interfaces/Graph/INode.cs
@@ -31,10 +31,24 @@ namespace UnityEditor.Graphing
             return slots;
         }
 
+        public static IEnumerable<T> GetInputSlots<T>(this AbstractMaterialNode node, MaterialSlot startingSlot) where T : MaterialSlot
+        {
+            var slots = new List<T>();
+            node.GetInputSlots(startingSlot, slots);
+            return slots;
+        }
+
         public static IEnumerable<T> GetOutputSlots<T>(this AbstractMaterialNode node) where T : MaterialSlot
         {
             var slots = new List<T>();
             node.GetOutputSlots(slots);
+            return slots;
+        }
+
+        public static IEnumerable<T> GetOutputSlots<T>(this AbstractMaterialNode node, MaterialSlot startingSlot) where T : MaterialSlot
+        {
+            var slots = new List<T>();
+            node.GetOutputSlots(startingSlot, slots);
             return slots;
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
@@ -341,6 +341,11 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
+        public virtual void GetInputSlots<T>(MaterialSlot startingSlot, List<T> foundSlots) where T : MaterialSlot
+        {
+            GetInputSlots(foundSlots);
+        }
+
         public void GetOutputSlots<T>(List<T> foundSlots) where T : MaterialSlot
         {
             foreach (var slot in m_Slots.SelectValue())
@@ -350,6 +355,11 @@ namespace UnityEditor.ShaderGraph
                     foundSlots.Add(materialSlot);
                 }
             }
+        }
+
+        public virtual void GetOutputSlots<T>(MaterialSlot startingSlot, List<T> foundSlots) where T : MaterialSlot
+        {
+            GetOutputSlots(foundSlots);
         }
 
         public void GetSlots<T>(List<T> foundSlots) where T : MaterialSlot

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
@@ -133,6 +133,7 @@ namespace UnityEditor.ShaderGraph
                     return;
                 }
                 m_SubGraph.LoadGraphData();
+                m_SubGraph.LoadDependencyData();
 
                 name = m_SubGraph.name;
             }
@@ -189,6 +190,49 @@ namespace UnityEditor.ShaderGraph
         public override bool canSetPrecision
         {
             get { return asset?.subGraphGraphPrecision == GraphPrecision.Graph;  }
+        }
+
+        public override void GetInputSlots<T>(MaterialSlot startingSlot, List<T> foundSlots)
+        {
+            var allSlots = new List<T>();
+            GetInputSlots<T>(allSlots);
+            var info = asset?.GetOutputDependencies(startingSlot.RawDisplayName());
+            if (info != null)
+            {
+                foreach (var slot in allSlots)
+                {
+                    if (info.ContainsSlot(slot))
+                        foundSlots.Add(slot);
+                }
+            }
+        }
+
+        public override void GetOutputSlots<T>(MaterialSlot startingSlot, List<T> foundSlots)
+        {
+            var allSlots = new List<T>();
+            GetOutputSlots<T>(allSlots);
+            var info = asset?.GetInputDependencies(startingSlot.RawDisplayName());
+            if (info != null)
+            {
+                foreach (var slot in allSlots)
+                {
+                    if (info.ContainsSlot(slot))
+                        foundSlots.Add(slot);
+                }
+            }
+        }
+
+        ShaderStageCapability GetSlotCapability(MaterialSlot slot)
+        {
+            SlotDependencyInfo dependencyInfo;
+            if (slot.isInputSlot)
+                dependencyInfo = asset?.GetInputDependencies(slot.RawDisplayName());
+            else
+                dependencyInfo = asset?.GetOutputDependencies(slot.RawDisplayName());
+
+            if (dependencyInfo != null)
+                return dependencyInfo.capabilities;
+            return ShaderStageCapability.All;
         }
 
         public void GenerateNodeCode(ShaderStringBuilder sb, GenerationMode generationMode)
@@ -473,10 +517,9 @@ namespace UnityEditor.ShaderGraph
                 validNames.Add(id);
             }
 
-            var outputStage = asset.effectiveShaderStage;
-
             foreach (var slot in asset.outputs)
             {
+                var outputStage = GetSlotCapability(slot);
                 var newSlot = MaterialSlot.CreateMaterialSlot(slot.valueType, slot.id, slot.RawDisplayName(),
                     slot.shaderOutputName, SlotType.Output, Vector4.zero, outputStage, slot.hidden);
                 AddSlot(newSlot);
@@ -497,9 +540,8 @@ namespace UnityEditor.ShaderGraph
                 GetInputSlots(slots);
                 GetOutputSlots(slots);
 
-                var outputStage = asset.effectiveShaderStage;
                 foreach (MaterialSlot slot in slots)
-                    slot.stageCapability = outputStage;
+                    slot.stageCapability = GetSlotCapability(slot);
             }
         }
 

--- a/com.unity.shadergraph/Editor/Data/SubGraph/SubGraphOutputNode.cs
+++ b/com.unity.shadergraph/Editor/Data/SubGraph/SubGraphOutputNode.cs
@@ -40,22 +40,14 @@ namespace UnityEditor.ShaderGraph
             List<MaterialSlot> slots = new List<MaterialSlot>();
             GetInputSlots(slots);
 
+            // Reset all input slots back to All, otherwise they'll be incorrectly configured when traversing below
             foreach (MaterialSlot slot in slots)
                 slot.stageCapability = ShaderStageCapability.All;
 
-            var effectiveStage = ShaderStageCapability.All;
             foreach (var slot in slots)
             {
-                var stage = NodeUtils.GetEffectiveShaderStageCapability(slot, true);
-                if (stage != ShaderStageCapability.All)
-                {
-                    effectiveStage = stage;
-                    break;
-                }
+                slot.stageCapability = NodeUtils.GetEffectiveShaderStageCapability(slot, true);
             }
-
-            foreach (MaterialSlot slot in slots)
-                slot.stageCapability = effectiveStage;
         }
 
         void ValidateSlotName()

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -170,7 +170,8 @@ namespace UnityEditor.ShaderGraph.Drawing
                 return compatibleAnchors;
 
             var startStage = startSlot.stageCapability;
-            if (startStage == ShaderStageCapability.All)
+            // If this is a sub-graph node we always have to check the effective stage as we might have to trace back through the sub-graph
+            if (startStage == ShaderStageCapability.All || startSlot.owner is SubGraphNode)
                 startStage = NodeUtils.GetEffectiveShaderStageCapability(startSlot, true) & NodeUtils.GetEffectiveShaderStageCapability(startSlot, false);
 
             foreach (var candidateAnchor in ports.ToList())
@@ -183,7 +184,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 if (startStage != ShaderStageCapability.All)
                 {
                     var candidateStage = candidateSlot.stageCapability;
-                    if (candidateStage == ShaderStageCapability.All)
+                    if (candidateStage == ShaderStageCapability.All || candidateSlot.owner is SubGraphNode)
                         candidateStage = NodeUtils.GetEffectiveShaderStageCapability(candidateSlot, true)
                             & NodeUtils.GetEffectiveShaderStageCapability(candidateSlot, false);
                     if (candidateStage != ShaderStageCapability.All && candidateStage != startStage)

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -188,6 +188,10 @@ namespace UnityEditor.ShaderGraph.Drawing
                             & NodeUtils.GetEffectiveShaderStageCapability(candidateSlot, false);
                     if (candidateStage != ShaderStageCapability.All && candidateStage != startStage)
                         continue;
+
+                    // None stage can only connect to All stage, otherwise you can connect invalid connections
+                    if (startStage == ShaderStageCapability.None && candidateStage != ShaderStageCapability.All)
+                        continue;
                 }
 
                 compatibleAnchors.Add(candidateAnchor);

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
@@ -19,7 +19,7 @@ using UnityEngine.Pool;
 namespace UnityEditor.ShaderGraph
 {
     [ExcludeFromPreset]
-    [ScriptedImporter(27, Extension, -905)]
+    [ScriptedImporter(28, Extension, -905)]
     class ShaderSubGraphImporter : ScriptedImporter
     {
         public const string Extension = "shadersubgraph";
@@ -177,19 +177,35 @@ namespace UnityEditor.ShaderGraph
             List<AbstractMaterialNode> nodes = new List<AbstractMaterialNode>();
             NodeUtils.DepthFirstCollectNodesFromNode(nodes, outputNode);
 
-            asset.effectiveShaderStage = ShaderStageCapability.All;
+            ShaderStageCapability effectiveShaderStage = ShaderStageCapability.All;
             foreach (var slot in outputSlots)
             {
                 var stage = NodeUtils.GetEffectiveShaderStageCapability(slot, true);
-                if (stage != ShaderStageCapability.All)
+                if (effectiveShaderStage == ShaderStageCapability.All && stage != ShaderStageCapability.All)
+                    effectiveShaderStage = stage;
+
+                asset.outputCapabilities.Add(new SlotCapability { slotName = slot.RawDisplayName(), capabilities = stage });
+
+                // Find all unique property nodes used by this slot and record a dependency for this input/output pair
+                var inputPropertyNames = new HashSet<string>();
+                var nodeSet = new HashSet<AbstractMaterialNode>();
+                NodeUtils.CollectNodeSet(nodeSet, slot);
+                foreach (var node in nodeSet)
                 {
-                    asset.effectiveShaderStage = stage;
-                    break;
+                    if (node is PropertyNode propNode && !inputPropertyNames.Contains(propNode.property.displayName))
+                    {
+                        inputPropertyNames.Add(propNode.property.displayName);
+                        var slotDependency = new SlotDependencyPair();
+                        slotDependency.inputSlotName = propNode.property.displayName;
+                        slotDependency.outputSlotName = slot.RawDisplayName();
+                        asset.slotDependencies.Add(slotDependency);
+                    }
                 }
             }
+            CollectInputCapabilities(asset, graph);
 
             asset.vtFeedbackVariables = VirtualTexturingFeedbackUtils.GetFeedbackVariables(outputNode as SubGraphOutputNode);
-            asset.requirements = ShaderGraphRequirements.FromNodes(nodes, asset.effectiveShaderStage, false);
+            asset.requirements = ShaderGraphRequirements.FromNodes(nodes, effectiveShaderStage, false);
 
             // output precision is whatever the output node has as a graph precision, falling back to the graph default
             asset.outputGraphPrecision = outputNode.graphPrecision.GraphFallback(graph.graphDefaultPrecision);
@@ -422,6 +438,34 @@ namespace UnityEditor.ShaderGraph
             ancestors.RemoveAt(ancestors.Count - 1);
 
             return false;
+        }
+
+        static void CollectInputCapabilities(SubGraphAsset asset, GraphData graph)
+        {
+            // Collect each input's capabilities. There can be multiple property nodes
+            // contributing to the same input, so we cache these in a map while building
+            var inputCapabilities = new Dictionary<string, SlotCapability>();
+
+            // Walk all property node output slots, computing and caching the capabilities for that slot
+            var propertyNodes = graph.GetNodes<PropertyNode>();
+            foreach (var propertyNode in propertyNodes)
+            {
+                var outputSlots = PooledList<MaterialSlot>.Get();
+                propertyNode.GetOutputSlots(outputSlots);
+                foreach (var slot in outputSlots)
+                {
+                    var slotName = slot.RawDisplayName();
+                    SlotCapability capabilityInfo;
+                    if (!inputCapabilities.TryGetValue(slotName, out capabilityInfo))
+                    {
+                        capabilityInfo = new SlotCapability();
+                        capabilityInfo.slotName = slotName;
+                        inputCapabilities.Add(propertyNode.property.displayName, capabilityInfo);
+                    }
+                    capabilityInfo.capabilities &= NodeUtils.GetEffectiveShaderStageCapability(slot, false);
+                }
+            }
+            asset.inputCapabilities.AddRange(inputCapabilities.Values);
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
@@ -450,9 +450,7 @@ namespace UnityEditor.ShaderGraph
             var propertyNodes = graph.GetNodes<PropertyNode>();
             foreach (var propertyNode in propertyNodes)
             {
-                var outputSlots = PooledList<MaterialSlot>.Get();
-                propertyNode.GetOutputSlots(outputSlots);
-                foreach (var slot in outputSlots)
+                foreach (var slot in propertyNode.GetOutputSlots<MaterialSlot>())
                 {
                     var slotName = slot.RawDisplayName();
                     SlotCapability capabilityInfo;


### PR DESCRIPTION
# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1337137/

Sub graphs nodes became locked by whatever shader stage capabilities they encountered. A sub-graph node should be usable in multiple stages and the individual slots should actually be locked instead. This requires baking out input/output capabilities for a sub-graph node as well as input/output dependencies so that they can be traced through in a parent graph.

Fixing this made some error cases a bit easier, in particular it's easier now to make a connection that's valid in a parent graph and then change the sub-graph out from under it causing an error. To help with this, errors were added when these cases were encountered. The error should always be show on any source node that causes the error (e.g. the first node that is stage locked) and if this is a sub-graph then it tells the user which slot is causing the error.

Error when sub-graph node is internally fragment locked and connected to a vertex block output:
![image](https://user-images.githubusercontent.com/76977132/123827479-82331c80-d8b5-11eb-8339-6dda13664419.png)
Error when sub-graph node is internally vertex locked and connected to a fragment block output:
![image](https://user-images.githubusercontent.com/76977132/123827590-98d97380-d8b5-11eb-8ca5-efe16d84c566.png)
Error when sub-graph node is externally vertex locked and connected to a fragment block output:
![image](https://user-images.githubusercontent.com/76977132/123827670-ad1d7080-d8b5-11eb-8426-cf41d32c288b.png)
Error when sub-graph node is externally fragment locked and connected to a vertex block output:
![image](https://user-images.githubusercontent.com/76977132/123827776-c6262180-d8b5-11eb-9c23-abe0d26a0b0b.png)


---
### Testing status
Newly added unit tests:
- [x] Verified subgraph output that is not connected to anything
- [x] Verified subgraph input that is not connected to anything
- [x] Verified subgraph output that is vertex locked internally
- [x] Verified subgraph output that is fragment locked internally
- [x] Verified subgraph output that is vertex and fragment locked internally
- [x] Verified subgraph input that is vertex locked internally
- [x] Verified subgraph input that is fragment locked internally
- [x] Verified subgraph input that is vertex and fragment locked internally
- [x] Verified subgraph input/output connection where input is externally vertex locked: produces output that is vertex locked
- [x] Verified subgraph input/output connection where input is externally fragment locked: produces output that is fragment locked
- [x] Verified subgraph where inputs combine into output where one input is vertex locked and the other is fragment locked: produces output that is both locked
- [x] Verified subgraph input/output connection where output is externally vertex locked: produces input that is vertex locked
- [x] Verified subgraph input/output connection where output is externally fragment locked: produces input that is fragment locked
- [x] Verified subgraph where one input splits into two outputs, one output is vertex locked and one is fragment locked: input is both locked

Hand tested (these either require visual validation to changes or creating a partially invalid graph by modifying the sub-graph after connecting the parent graph)
- [x] Verified subgraph input/output connection where input is externally vertex and fragment locked
- [x] Verified subgraph input/output connection where output is externally vertex and fragment locked
- [x] Verified subgraph input/output connection where input is internally fragment locked and is externally vertex locked
- [x] Change internal lock state and saving immediately reflects changes in parent Graph
    - [x] Add locked state, check input/output
    - [x] Remove locked state, check input/output
- [x] Change external lock state and saving immediately reflects changes in parent Graph
- [x] Check nested sub-graph and verify state changes reflect immediately in parent graph and parent sub-graph

New Error Unit Tests:
- [x] Connect internally vertex locked sub-graph node to fragment block output. Error is displayed on the sub-graph node.
- [x] Connect internally fragment locked sub-graph node to vertex block output. Error is displayed on the sub-graph node.
- [x] Connect vertex locked node -> sub-graph -> fragment block output. Error is on vertex locked node.
- [x] Connect fragment locked node -> sub-graph -> vertex block output. Error is on fragment locked node.

---
### Comments to reviewers
Additionally noticed a weird case where you could connect a "None" shader capability stage to another "None" which was really odd as you can connect make a none output with (sampled + vertex id -> add) and a none input with (split -> position + base color) and connect them. This was updated by only allowing None to connect to All.

I additionally did a simple test with a hand-written shader to validate that you can indeed have one function where some inputs are partially stage locked and it compiles on all of our target platforms.