### PR TITLE
Fixed an l-value error when using CameraNode with sample reflected cube map

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -138,6 +138,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed ParallaxMapping node compile issue on GLES2
 - Fixed a selection bug with block nodes after changing tabs [1312222]
 - Fixed some shader graph compiler errors not being logged [1304162].
+- Fixed an error when using camera direction with sample reflected cube map [1340538].
 
 ## [10.3.0] - 2020-11-03
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Scene/CameraNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Scene/CameraNode.cs
@@ -48,7 +48,7 @@ namespace UnityEditor.ShaderGraph
             switch (slotId)
             {
                 case OutputSlot1Id:
-                    return "-1 * mul((float3x3)UNITY_MATRIX_M, transpose(mul(UNITY_MATRIX_I_M, UNITY_MATRIX_I_V)) [2].xyz)";
+                    return "(-1 * mul((float3x3)UNITY_MATRIX_M, transpose(mul(UNITY_MATRIX_I_M, UNITY_MATRIX_I_V)) [2].xyz))";
                 case OutputSlot2Id:
                     return "unity_OrthoParams.w";
                 case OutputSlot3Id:


### PR DESCRIPTION
# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
---
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1340538/
When hooking up CameraNode's direction value into the SampleReflectedCubeMap node there would be an error:
![image](https://user-images.githubusercontent.com/76977132/123874058-6008c100-d8ec-11eb-84e8-4e91ebe788d3.png)

Camera node was embedding an expression for one of it's outputs. SampleReflectedCubeMap was then negative this value, producing the code:
```
--1 * mul((float3x3)UNITY_MATRIX_M, transpose(mul(UNITY_MATRIX_I_M, UNITY_MATRIX_I_V)) [2].xyz
```
This is invalid because you can't use operator-- on an l-value.
This is supposed to actually be `-cameraDirection` but the minus signs merged together.

To fix this, the camera node's result was just wrapped in parenthesis:
```
-(-1 * mul((float3x3)UNITY_MATRIX_M, transpose(mul(UNITY_MATRIX_I_M, UNITY_MATRIX_I_V)) [2].xyz)
```
which fixes the error as shown here:
![image](https://user-images.githubusercontent.com/76977132/123874256-b70e9600-d8ec-11eb-922b-fd51c016c8e6.png)

---
### Testing status
Verified that the original bug no longer reproes.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
