### PR TITLE
[ShaderGraph] [2021.1] Only ShaderGraph keywords count towards variant limit

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added an HLSL file implementing a version of the Unity core LODDitheringTransition function which can be used in a Shader Graph
 
 ### Changed
+- Only ShaderGraph keywords count towards the shader permutation variant limit, SubGraph keywords do not.
 
 ### Fixed
 - Fixed an issue where nodes with ports on one side would appear incorrectly on creation [1262050]
@@ -47,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed GPU instancing support in Shadergraph [1319655] (https://issuetracker.unity3d.com/issues/shader-graph-errors-are-thrown-when-a-propertys-shader-declaration-is-set-to-hybrid-per-instance-and-exposed-is-disabled).
 - Fixed rounded rectangle shape not rendering correctly on Nintendo Switch.
 - Fixed Procedural Virtual Texture compatibility with SRP Batcher [1329336] (https://issuetracker.unity3d.com/issues/procedural-virtual-texture-node-will-make-a-shadergraph-incompatible-with-srp-batcher)
+- Fixed an issue where SubGraph keywords would not deduplicate before counting towards the permutation limit [1343528] (https://issuetracker.unity3d.com/issues/shader-graph-graph-is-generating-too-many-variants-error-is-thrown-when-using-subgraphs-with-keywords)
 
 ## [10.3.0] - 2020-11-03
 

--- a/com.unity.shadergraph/Editor/Data/Util/KeywordUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/KeywordUtil.cs
@@ -97,34 +97,6 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public static int GetKeywordPermutationCount(this GraphData graph)
-        {
-            // Gather all unique keywords from the Graph including Sub Graphs
-            IEnumerable<ShaderKeyword> allKeywords = graph.keywords;
-            var subGraphNodes = graph.GetNodes<SubGraphNode>();
-            foreach (SubGraphNode subGraphNode in subGraphNodes)
-            {
-                if (subGraphNode.asset == null)
-                {
-                    continue;
-                }
-                allKeywords = allKeywords.Union(subGraphNode.asset.keywords);
-            }
-            allKeywords = allKeywords.Distinct();
-
-            // Get permutation count for all Keywords
-            int permutationCount = 1;
-            foreach (ShaderKeyword keyword in allKeywords)
-            {
-                if (keyword.keywordType == KeywordType.Boolean)
-                    permutationCount *= 2;
-                else
-                    permutationCount *= keyword.entries.Count;
-            }
-
-            return permutationCount;
-        }
-
         public static string GetKeywordPermutationSetConditional(List<int> permutationSet)
         {
             StringBuilder sb = new StringBuilder();

--- a/com.unity.shadergraph/Editor/Generation/Processors/Generator.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/Generator.cs
@@ -113,7 +113,7 @@ namespace UnityEditor.ShaderGraph
             m_GraphData.CollectShaderProperties(shaderProperties, m_Mode);
             m_GraphData.CollectShaderKeywords(shaderKeywords, m_Mode);
 
-            if (m_GraphData.GetKeywordPermutationCount() > ShaderGraphPreferences.variantLimit)
+            if (shaderKeywords.permutations.Count > ShaderGraphPreferences.variantLimit)
             {
                 m_GraphData.AddValidationError(m_OutputNode.objectId, ShaderKeyword.kVariantLimitWarning, Rendering.ShaderCompilerMessageSeverity.Error);
 

--- a/com.unity.shadergraph/Editor/Generation/Processors/Generator.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/Generator.cs
@@ -115,7 +115,10 @@ namespace UnityEditor.ShaderGraph
 
             if (shaderKeywords.permutations.Count > ShaderGraphPreferences.variantLimit)
             {
-                m_GraphData.AddValidationError(m_OutputNode.objectId, ShaderKeyword.kVariantLimitWarning, Rendering.ShaderCompilerMessageSeverity.Error);
+                if (m_OutputNode != null)
+                    m_GraphData.AddValidationError(m_OutputNode.objectId, ShaderKeyword.kVariantLimitWarning, Rendering.ShaderCompilerMessageSeverity.Error);
+                else
+                    Debug.LogError($"Error in Shader Graph:{ShaderKeyword.kVariantLimitWarning}");
 
                 m_ConfiguredTextures = shaderProperties.GetConfiguredTextures();
                 m_Builder.AppendLines(ShaderGraphImporter.k_ErrorShader);

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -24,9 +24,9 @@ namespace UnityEditor.ShaderGraph
     // sure that all shader graphs get re-imported. Re-importing is required,
     // because the shader graph codegen is different for V2.
     // This ifdef can be removed once V2 is the only option.
-    [ScriptedImporter(113, Extension, -902)]
+    [ScriptedImporter(114, Extension, -902)]
 #else
-    [ScriptedImporter(45, Extension, -902)]
+    [ScriptedImporter(46, Extension, -902)]
 #endif
 
     class ShaderGraphImporter : ScriptedImporter


### PR DESCRIPTION
### Purpose of this PR
Fix for https://fogbugz.unity3d.com/f/cases/1343528/

This PR makes it so that only ShaderGraph keywords count towards the shader variant limit.

SubGraph keywords would never cause variant expansion (which is the thing we are trying to keep from getting too expensive with the variant limit), but they counted against the variant limit.  There was also a bug where the SubGraph keywords would not deduplicate properly, so they could potentially count multiple times against the limit..

This change gets rid of all of that code, and uses the actual permutation expansion count when comparing against the limit.

Note that the actual permutation expansion count will always be less than or equal to the original count we were comparing against the variant limit.

2021.2: https://github.com/Unity-Technologies/Graphics/pull/5017
2021.1: https://github.com/Unity-Technologies/Graphics/pull/5031
2020.3: https://github.com/Unity-Technologies/Graphics/pull/5032

---
### Testing status
Describe what manual/automated tests were performed for this PR

- [x] Tested against repro case -- 4 keywords in shader, 4 keywords in subgraph.
- [x] Tested multiple subgraphs with 4 identical keywords each -- they merge.
- [x] Tested multiple subgraphs with 4 unique keywords each -- they do not merge, no errors (all keywords work).
- [x] Tested multiple subgraphs with 3 unique and 4 identical keywords -- works properly.
- [x] Stepped through the code to verify it is doign the right thing, and verified the generated shader code is correct.
- [x] Verified it still displays the error if you have 8 or more bool keywords in your ShaderGraph

Yamato:

ShaderGraph PR Job: 🟢
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/2021.1%252Fsg%252Ffix%252F1343528/.yamato%252Fall-shadergraph.yml%2523PR_ShaderGraph_2021.1/7548830/job/pipeline

---
### Comments to reviewers
Notes for the reviewers you have assigned.
