### PR TITLE
[ShaderGraph] [2020.3] Only ShaderGraph keywords count towards variant limit

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -16,6 +16,9 @@ The version number for this package has increased due to a version update of a r
 - Fixed GPU instancing support in Shadergraph [1319655] (https://issuetracker.unity3d.com/issues/shader-graph-errors-are-thrown-when-a-propertys-shader-declaration-is-set-to-hybrid-per-instance-and-exposed-is-disabled).
 - Fixed Procedural Virtual Texture compatibility with SRP Batcher [1329336] (https://issuetracker.unity3d.com/issues/procedural-virtual-texture-node-will-make-a-shadergraph-incompatible-with-srp-batcher)
 
+### Changed
+- Only ShaderGraph keywords count towards the shader permutation variant limit, SubGraph keywords do not.
+
 ## [10.5.0] - 2021-04-19
 
 ### Added
@@ -45,6 +48,7 @@ The version number for this package has increased due to a version update of a r
 - Fixed an issue where the shader variant limit exceeded message was not getting passed [1304168] (https://issuetracker.unity3d.com/product/unity/issues/guid/1304168)
 - Fixed an issue where generated `BuildVertexDescriptionInputs()` produced an HLSL warning, "implicit truncation of vector type" [1299179](https://issuetracker.unity3d.com/product/unity/issues/guid/1299179/)
 - Fixed a bug in master node preview generation that failed compilation when a block was deleted [1319066] (https://issuetracker.unity3d.com/issues/shadergraph-deleting-stack-blocks-of-universal-rp-targeted-shadergraph-causes-the-main-preview-to-fail-to-compile)
+- Fixed an issue where SubGraph keywords would not deduplicate before counting towards the permutation limit [1343528] (https://issuetracker.unity3d.com/issues/shader-graph-graph-is-generating-too-many-variants-error-is-thrown-when-using-subgraphs-with-keywords)
 
 ## [10.3.1] - 2021-01-26
 

--- a/com.unity.shadergraph/Editor/Data/Util/KeywordUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/KeywordUtil.cs
@@ -97,34 +97,6 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public static int GetKeywordPermutationCount(this GraphData graph)
-        {
-            // Gather all unique keywords from the Graph including Sub Graphs
-            IEnumerable<ShaderKeyword> allKeywords = graph.keywords;
-            var subGraphNodes = graph.GetNodes<SubGraphNode>();
-            foreach(SubGraphNode subGraphNode in subGraphNodes)
-            {
-                if (subGraphNode.asset == null)
-                {
-                    continue;
-                }
-                allKeywords = allKeywords.Union(subGraphNode.asset.keywords);
-            }
-            allKeywords = allKeywords.Distinct();
-
-            // Get permutation count for all Keywords
-            int permutationCount = 1;
-            foreach(ShaderKeyword keyword in allKeywords)
-            {
-                if(keyword.keywordType == KeywordType.Boolean)
-                    permutationCount *= 2;
-                else
-                    permutationCount *= keyword.entries.Count;
-            }
-
-            return permutationCount;
-        }
-
         public static string GetKeywordPermutationSetConditional(List<int> permutationSet)
         {
             StringBuilder sb = new StringBuilder();

--- a/com.unity.shadergraph/Editor/Generation/Processors/Generator.cs
+++ b/com.unity.shadergraph/Editor/Generation/Processors/Generator.cs
@@ -112,7 +112,7 @@ namespace UnityEditor.ShaderGraph
             m_GraphData.CollectShaderProperties(shaderProperties, m_Mode);
             m_GraphData.CollectShaderKeywords(shaderKeywords, m_Mode);
 
-            if(m_GraphData.GetKeywordPermutationCount() > ShaderGraphPreferences.variantLimit)
+            if (shaderKeywords.permutations.Count > ShaderGraphPreferences.variantLimit)
             {
                 string graphName = "";
                 if(m_GraphData.owner != null)


### PR DESCRIPTION
### Purpose of this PR
Fix for https://fogbugz.unity3d.com/f/cases/1343528/

This PR makes it so that only ShaderGraph keywords count towards the shader variant limit.

SubGraph keywords would never cause variant expansion (which is the thing we are trying to keep from getting too expensive with the variant limit), but they counted against the variant limit.  There was also a bug where the SubGraph keywords would not deduplicate properly, so they could potentially count multiple times against the limit..

This change gets rid of all of that code, and uses the actual permutation expansion count when comparing against the limit.

Note that the actual permutation expansion count will always be less than or equal to the original count we were comparing against the variant limit.

2021.2: https://github.com/Unity-Technologies/Graphics/pull/5017
2021.1: https://github.com/Unity-Technologies/Graphics/pull/5031
2020.3: https://github.com/Unity-Technologies/Graphics/pull/5032

---
### Testing status
Describe what manual/automated tests were performed for this PR

- [x] Tested against repro case -- 4 keywords in shader, 4 keywords in subgraph.
- [x] Tested multiple subgraphs with 4 identical keywords each -- they merge.
- [x] Tested multiple subgraphs with 4 unique keywords each -- they do not merge, no errors (all keywords work).
- [x] Tested multiple subgraphs with 3 unique and 4 identical keywords -- works properly.
- [x] Stepped through the code to verify it is doign the right thing, and verified the generated shader code is correct.
- [x] Verified it still displays the error if you have 8 or more bool keywords in your ShaderGraph

Yamato:

ShaderGraph PR Job: 🟢 
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/10.x.x%252Fsg%252Ffix%252F1343528/.yamato%252Fall-shadergraph.yml%2523PR_ShaderGraph_2020.3/7498121/job/full-pipeline

---
### Comments to reviewers
Notes for the reviewers you have assigned.
