### PR TITLE
Fixed the fog node's density being 1 when fog was disabled in URP. Fi…

### DIFF
--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl
@@ -63,9 +63,14 @@ float3 shadergraph_LWReflectionProbe(float3 viewDir, float3 normalOS, float lod)
 void shadergraph_LWFog(float3 positionOS, out float4 color, out float density)
 {
     color = unity_FogColor;
+    #if defined(FOG_LINEAR) || defined(FOG_EXP) || defined(FOG_EXP2)
     float viewZ = -TransformWorldToView(TransformObjectToWorld(positionOS)).z;
     float nearZ0ToFarZ = max(viewZ - _ProjectionParams.y, 0);
+    // ComputeFogFactorZ0ToFar returns the fog "occlusion" (0 for full fog and 1 for no fog) so this has to be inverted for density.
     density = 1.0f - ComputeFogIntensity(ComputeFogFactorZ0ToFar(nearZ0ToFarZ));
+    #else
+    density = 0.0f;
+    #endif
 }
 
 // This function assumes the bitangent flip is encoded in tangentWS.w

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -144,6 +144,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a selection bug with block nodes after changing tabs [1312222]
 - Fixed some shader graph compiler errors not being logged [1304162].
 - Fixed an error when using camera direction with sample reflected cube map [1340538].
+- Fixed ShaderGraph's FogNode returning an incorrect density when the fog setting was disabled [1347235].
 
 ## [10.3.0] - 2020-11-03
 

--- a/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/ShaderLibrary/ShaderGraphFunctions.hlsl
+++ b/com.unity.shadergraph/Editor/Generation/Targets/BuiltIn/ShaderLibrary/ShaderGraphFunctions.hlsl
@@ -57,7 +57,12 @@ float3 shadergraph_LWReflectionProbe(float3 viewDir, float3 normalOS, float lod)
 void shadergraph_LWFog(float3 position, out float4 color, out float density)
 {
     color = unity_FogColor;
+    #if defined(FOG_LINEAR) || defined(FOG_EXP) || defined(FOG_EXP2)
+    // ComputeFogFactor returns the fog density (0 for no fog and 1 for full fog).
     density = ComputeFogFactor(TransformObjectToHClip(position).z);
+    #else
+    density = 0.0f;
+    #endif
 }
 
 // This function assumes the bitangent flip is encoded in tangentWS.w


### PR DESCRIPTION
…xes fogbugz 1347235

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1347235/

Previously you could create a fog node and use it to lerp between the color and fog color with something like:
```
color = lerp(originalColor, fogNode.color, fogNode.density);
```
And the same code would work when fog was enabled and disabled in URP. This looks to have been broken in this PR: https://github.com/Unity-Technologies/Graphics/pull/2428/commits/e6b9fb4faf45376efd23ac1d714349cb89bc5bb8
Now when fog is disabled in the render settings, the fog node is returning 1 for density instead of 0, causing the entire object to go gray.

---
### Testing status
Here's the results in URP with the bug
| - | Fog On | Fog Off |
| - | ------------- | ------------- |
| Near|  ![image](https://user-images.githubusercontent.com/76977132/124808082-59dd9a80-df13-11eb-8c6e-07fb3ca8da76.png) | ![image](https://user-images.githubusercontent.com/76977132/124808136-682bb680-df13-11eb-8ad0-e34b50552aeb.png) |
| Far | ![image](https://user-images.githubusercontent.com/76977132/124808187-7aa5f000-df13-11eb-8c93-590e7b89a479.png) | ![image](https://user-images.githubusercontent.com/76977132/124808231-8691b200-df13-11eb-83cd-9be879190509.png) |

Here's the results in URP with the bug fixed:
| - | Fog On | Fog Off |
| - | ------------- | ------------- |
| Near| ![image](https://user-images.githubusercontent.com/76977132/124808354-b17c0600-df13-11eb-8fc5-d114bbd5939c.png) | ![image](https://user-images.githubusercontent.com/76977132/124808394-bfca2200-df13-11eb-8ba8-b3798dc97988.png) |
| Far | ![image](https://user-images.githubusercontent.com/76977132/124808439-ce183e00-df13-11eb-84b6-4c2202b25be5.png) | ![image](https://user-images.githubusercontent.com/76977132/124808479-d83a3c80-df13-11eb-8f98-73611f80d019.png) |


Both current failures are also in master:
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/master/.yamato%252Furp_lighting-iphone-metal.yml%2523URP_Lighting_iPhone_Metal_Standalone_il2cpp_Linear_2021.2/7580613/job/artifacts
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/master/.yamato%252Furp_terrain-iphone-metal.yml%2523URP_Terrain_iPhone_Metal_Standalone_il2cpp_Linear_2021.2

---
### Comments to reviewers
This was done with an ifdef inside of the shader graph specific function so as to minimize any breaking changes. For consistency, the same ifdef was added to the built-in render pipeline, even though built-in didn't suffer from the bug.