### PR TITLE
[2021.2][ShaderGraph] Fix wrapping and scrolling due to VFX graph target warning

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -111,6 +111,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed ShaderGraph BuiltIn target not to apply emission in the ForwardAdd pass to match surface shader results [1345574]. (https://issuetracker.unity3d.com/product/unity/issues/guid/1345574/)
 - Fixed Procedural Virtual Texture compatibility with SRP Batcher [1329336] (https://issuetracker.unity3d.com/issues/procedural-virtual-texture-node-will-make-a-shadergraph-incompatible-with-srp-batcher)
 - Fixed an issue where SubGraph keywords would not deduplicate before counting towards the permutation limit [1343528] (https://issuetracker.unity3d.com/issues/shader-graph-graph-is-generating-too-many-variants-error-is-thrown-when-using-subgraphs-with-keywords)
+- Fixed an issue where an informational message could cause some UI controls on the graph inspector to be pushed outside the window [1343124] (https://issuetracker.unity3d.com/product/unity/issues/guid/1343124/)
 
 ## [11.0.0] - 2020-10-21
 

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/InspectorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/InspectorView.cs
@@ -82,6 +82,9 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector
             m_NodeSettingsContainer = m_GraphInspectorView.Q<VisualElement>("NodeSettingsContainer");
             m_MaxItemsMessageLabel = m_GraphInspectorView.Q<Label>("maxItemsMessageLabel");
             m_ContentContainer.Add(m_GraphInspectorView);
+            m_ScrollView = this.Q<ScrollView>();
+            m_GraphInspectorView.Q<TabButton>("GraphSettingsButton").OnSelect += SetScrollModeHorizontal;
+            m_GraphInspectorView.Q<TabButton>("NodeSettingsButton").OnSelect += SetScrollModeHorizontalVertical;
 
             isWindowScrollable = true;
             isWindowResizable = true;
@@ -95,6 +98,16 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector
 
             // By default at startup, show graph settings
             m_GraphInspectorView.Activate(m_GraphInspectorView.Q<TabButton>("GraphSettingsButton"));
+        }
+
+        void SetScrollModeHorizontal(TabButton button)
+        {
+            m_ScrollView.mode = ScrollViewMode.Vertical;
+        }
+
+        void SetScrollModeHorizontalVertical(TabButton button)
+        {
+            m_ScrollView.mode = ScrollViewMode.VerticalAndHorizontal;
         }
 
         public void InitializeGraphSettings()

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GraphDataPropertyDrawer.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/PropertyDrawers/GraphDataPropertyDrawer.cs
@@ -121,6 +121,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector.PropertyDrawers
                     "Add a Universal or HDRP target instead, and enable 'Support VFX Graph' in the Graph Inspector.");
 
                 vfxWarningLabel.style.color = new StyleColor(Color.white);
+                vfxWarningLabel.style.whiteSpace = WhiteSpace.Normal;
 
                 vfxWarning.Add(vfxWarningLabel);
                 element.Add(vfxWarning);

--- a/com.unity.shadergraph/Editor/Resources/UXML/GraphInspector.uxml
+++ b/com.unity.shadergraph/Editor/Resources/UXML/GraphInspector.uxml
@@ -6,7 +6,7 @@
                 <ui:Label name="subTitleLabel" text="" />
             </ui:VisualElement>
         </ui:VisualElement>
-        <ui:ScrollView class="unity-scroll-view unity-scroll-view--scroll unity-scroll-view--vertical-horizontal" name ="scrollView"/>
+        <ui:ScrollView class="unity-scroll-view unity-scroll-view--scroll unity-scroll-view--vertical" name ="scrollView"/>
         <ui:VisualElement name="contentContainer" picking-mode="Ignore" />
             <TabbedView name="GraphInspectorView" >
                 <TabButton name="NodeSettingsButton" text="Node Settings" target="NodeSettingsContainer" />


### PR DESCRIPTION
### Purpose of this PR

Fix for https://fogbugz.unity3d.com/f/cases/1343124/

#3467 introduced a warning about a change in the way VFXgraph would be configured by the user.  This warning tickled an interaction between the Shader Graph graph inspector's scroll view, and the default wrap mode of the actual message in the UI.  This PR does the following:

- Default the GraphInpsector to vertical scrolling only (for graph settings inspector view).
- Enable horizontal + vertical scrolling for node settings inspector view.
- Switch between those scroll view modes as appropriate.
- Enable wrapping on the VFXgraph target warning message.

As this the VFXgraph refactor was done during 2021.2, this should not need a backport.

Here is what the original situation looked like (N.b., there are no +/- controls on the target list and no dropdown indicators on the Precision and Material controls as they are well off the right side of the view and would need to be scrolled to.  Also, the warning message is not fully visible.):
![graph-inspector-nowrap](https://user-images.githubusercontent.com/6652495/124820496-6b7a6e80-df22-11eb-8133-a04e9709bc99.png)

And here is what it looks like with the fix (N.b., the previously missing controls are there, and the message is nicely wrapped and fully visible):
![graph-inspector-wrap](https://user-images.githubusercontent.com/6652495/124820678-a54b7500-df22-11eb-99c8-c5e270739727.png)

And one of the node settings to show that it still has a horizontal scroll:
![Screen Shot 2021-07-07 at 1 06 09 PM](https://user-images.githubusercontent.com/6652495/124821946-28b99600-df24-11eb-9bf4-ce03c7643a74.png)

---
### Testing status
Manual testing according to the repro case in the bug.
Additional manual testing to exercise the scroll view toggling (i.e., switching between graph settings and node settings), as well as resizing the graph inspector to engage/disengage the scroll bars.  Confirmed that these behave as expected.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
