### PR TITLE
[ShaderGraph][21.2] Fix wrong searcher appearing when edge of stack is hovered

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed ShaderGraph sub-graph stage limitations to be per slot instead of per sub-graph node [1337137].
 - Fixed ShaderGraph exception when trying to set a texture to "main texture" [1350573].
 - Fixed a ShaderGraph issue where Float properties in Integer mode would not be cast properly in graph previews [1330302](https://fogbugz.unity3d.com/f/cases/1330302/)
+- Fixed a ShaderGraph issue where hovering over a context block but not its node stack would not bring up the incorrect add menu [1351733](https://fogbugz.unity3d.com/f/cases/1351733/)
 
 ## [11.0.0] - 2020-10-21
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -51,6 +51,7 @@ namespace UnityEditor.ShaderGraph.Drawing
         MessageManager m_MessageManager;
         SearchWindowProvider m_SearchWindowProvider;
         EdgeConnectorListener m_EdgeConnectorListener;
+        VisualElement m_HoveredContextView;
 
         BlackboardController m_BlackboardController;
 
@@ -301,6 +302,16 @@ namespace UnityEditor.ShaderGraph.Drawing
             {
                 //need to eventually remove this reference to editor window in context views
                 var contextView = new ContextView(name, contextData, m_EditorWindow);
+
+                // GraphView marks ContextViews' stacks, but not the actual root elements, as insertable. We want the
+                // contextual searcher menu to come up when *any* part of the ContextView is hovered. As a workaround,
+                // we keep track of the hovered ContextView and offer it if no targets are found.
+                contextView.RegisterCallback((MouseOverEvent _) => m_HoveredContextView = contextView);
+                contextView.RegisterCallback((MouseOutEvent _) =>
+                {
+                    if (m_HoveredContextView == contextView) m_HoveredContextView = null;
+                });
+
                 contextView.SetPosition(new Rect(contextData.position, Vector2.zero));
                 contextView.AddPort(portDirection);
                 m_GraphView.AddElement(contextView);
@@ -346,7 +357,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             if (EditorWindow.focusedWindow == m_EditorWindow) //only display the search window when current graph view is focused
             {
                 m_SearchWindowProvider.connectedPort = null;
-                m_SearchWindowProvider.target = c.target;
+                m_SearchWindowProvider.target = c.target ?? m_HoveredContextView;
                 SearcherWindow.Show(m_EditorWindow, (m_SearchWindowProvider as SearcherProvider).LoadSearchWindow(),
                     item => (m_SearchWindowProvider as SearcherProvider).OnSearcherSelectEntry(item, c.screenMousePosition - m_EditorWindow.position.position),
                     c.screenMousePosition - m_EditorWindow.position.position, null);


### PR DESCRIPTION
### Purpose of this PR

FogBugz case: https://fogbugz.unity3d.com/f/cases/1351733/. This PR fixes an issue where hovering over a context block but not its inner stack (i.e. mouse on the heading or edge of the block, see images below) would cause the global searcher instead of the block-specific one to appear.

This PR doesn't change the behavior of right-click menus.

---
### Testing status

Note that in this test graph, the fragment context searcher should start with "Alpha," the vertex one should start with "Normal," and the global one should start with "Artistic."

#### Before Fix
![image](https://user-images.githubusercontent.com/10332426/126209384-922c2b3a-34ca-4c79-91dd-638c4366c66c.png)
![image](https://user-images.githubusercontent.com/10332426/126209427-6afec405-24ac-4ed8-a79a-30153e09340b.png)
![image](https://user-images.githubusercontent.com/10332426/126209460-628a19b8-4fe8-40b0-aed9-c9353d9983fa.png)


#### After Fix
![image](https://user-images.githubusercontent.com/10332426/126208854-391ed87a-1842-47b8-bba6-0cc44486ac64.png)
![image](https://user-images.githubusercontent.com/10332426/126208880-b0495685-575f-4b78-8f5e-923517b2ecac.png)
![image](https://user-images.githubusercontent.com/10332426/126208962-1af711da-608b-486a-9535-f855a2af9379.png)

#### Mousing Over Stack Still Works

Before:
![image](https://user-images.githubusercontent.com/10332426/126214321-def6063c-416b-4a92-8c8c-6da7df2c9828.png)
After:
![image](https://user-images.githubusercontent.com/10332426/126214155-6d8f713f-1949-41f9-920d-01e61fb70d0a.png)

#### Undo/Redo Interaction

Moving a block, opening the searcher, undoing/redoing the move without moving the mouse, and re-opening the searcher correctly reflects the change beneath the cursor.

https://user-images.githubusercontent.com/10332426/126213516-1fda3249-1adb-4fee-99a6-75aee9c10a90.mp4

#### Overlaps

I confirmed that the correct searcher window appears when edges overlap with both nodes and other context blocks. This test was motivated by the fact that I worked with mouse over/out events.

https://user-images.githubusercontent.com/10332426/126213444-cfbe02a6-9c9b-436a-8041-e678135efb1b.mp4

https://user-images.githubusercontent.com/10332426/126213625-06cf8fb3-d215-4e9a-9059-af8a2e178bfe.mp4

#### Additional Cases

- Empty block works both inside and outside the "Spacebar to Add Node" frame
  ![image](https://user-images.githubusercontent.com/10332426/126213761-0c82aac1-4600-4d4b-8eae-7a055c7133f4.png)
  ![image](https://user-images.githubusercontent.com/10332426/126213783-0f1f05a6-5442-47ff-bf27-2aad3059d408.png)



