### PR TITLE
Added synonyms to nodes for better searchability

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/ShaderGraph/Nodes/HDSceneColorNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/ShaderGraph/Nodes/HDSceneColorNode.cs
@@ -17,6 +17,7 @@ namespace UnityEditor.Rendering.HighDefinition
         public HDSceneColorNode()
         {
             name = "HD Scene Color";
+            synonyms = new string[] { "screen buffer" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Added Tessellation Option to PositionNode settings, to provide access to the pre-displaced tessellated position.
   - Added visible errors for invalid stage capability connections to shader graph.
   - Added a ShaderGraph animated preview framerate throttle.
+  - Added many node synonyms for the Create Node search so that it's easier to find nodes.
 
 ### Changed
 - Properties and Keywords are no longer separated by type on the blackboard. Categories allow for any combination of properties and keywords to be grouped together as the user defines.

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Blend/BlendNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Blend/BlendNode.cs
@@ -11,6 +11,7 @@ namespace UnityEditor.ShaderGraph
         public BlendNode()
         {
             name = "Blend";
+            synonyms = new string[] { "burn", "darken", "difference", "dodge", "divide", "exclusion", "hard light", "hard mix", "linear burn", "linear dodge", "linear light", "multiply", "negate", "overlay", "pin light", "screen", "soft light", "subtract", "vivid light", "overwrite" };
         }
 
         string GetCurrentBlendName()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Mask/ChannelMaskNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Mask/ChannelMaskNode.cs
@@ -19,6 +19,7 @@ namespace UnityEditor.ShaderGraph
         public ChannelMaskNode()
         {
             name = "Channel Mask";
+            synonyms = new string[] { "component mask" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalReconstructZNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalReconstructZNode.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.ShaderGraph
         public NormalReconstructZNode()
         {
             name = "Normal Reconstruct Z";
+            synonyms = new string[] { "derive z" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Channel/CombineNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Channel/CombineNode.cs
@@ -10,6 +10,7 @@ namespace UnityEditor.ShaderGraph
         public CombineNode()
         {
             name = "Combine";
+            synonyms = new string[] { "append" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Channel/SwizzleNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Channel/SwizzleNode.cs
@@ -13,6 +13,7 @@ namespace UnityEditor.ShaderGraph
         public SwizzleNode()
         {
             name = "Swizzle";
+            synonyms = new string[] { "swap", "reorder", "component mask" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ConstantNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ConstantNode.cs
@@ -50,6 +50,7 @@ namespace UnityEditor.ShaderGraph
         public ConstantNode()
         {
             name = "Constant";
+            synonyms = new string[] { "pi", "tau", "phi" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector1Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector1Node.cs
@@ -22,7 +22,7 @@ namespace UnityEditor.ShaderGraph
         public Vector1Node()
         {
             name = "Float";
-            synonyms = new string[] {"Vector 1"};
+            synonyms = new string[] { "Vector 1", "1", "v1", "vec1", "scalar" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector2Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector2Node.cs
@@ -25,6 +25,7 @@ namespace UnityEditor.ShaderGraph
         public Vector2Node()
         {
             name = "Vector 2";
+            synonyms = new string[] { "2", "v2", "vec2", "float2" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector3Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector3Node.cs
@@ -26,6 +26,7 @@ namespace UnityEditor.ShaderGraph
         public Vector3Node()
         {
             name = "Vector 3";
+            synonyms = new string[] { "3", "v3", "vec3", "float3" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector4Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector4Node.cs
@@ -28,6 +28,7 @@ namespace UnityEditor.ShaderGraph
         public Vector4Node()
         {
             name = "Vector 4";
+            synonyms = new string[] { "4", "v4", "vec4", "float4" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/BitangentVectorNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/BitangentVectorNode.cs
@@ -13,6 +13,7 @@ namespace UnityEditor.ShaderGraph
         public BitangentVectorNode()
         {
             name = "Bitangent Vector";
+            synonyms = new string[] { "binormal" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/UVNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/UVNode.cs
@@ -33,6 +33,7 @@ namespace UnityEditor.ShaderGraph
         public UVNode()
         {
             name = "UV";
+            synonyms = new string[] { "texcoords", "coords", "coordinates" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/ViewDirectionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/ViewDirectionNode.cs
@@ -18,6 +18,7 @@ namespace UnityEditor.ShaderGraph
         public ViewDirectionNode()
         {
             name = "View Direction";
+            synonyms = new string[] { "eye direction" };
             UpdateNodeAfterDeserialization();
             onAfterVersionChange += () => { if (sgVersion > 0) owner.ClearErrorsForNode(this); };
         }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/ViewVectorNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/ViewVectorNode.cs
@@ -16,6 +16,7 @@ namespace UnityEditor.ShaderGraph
         public ViewVectorNode()
         {
             name = "View Vector";
+            synonyms = new string[] { "eye vector" };
         }
 
         public virtual List<CoordinateSpace> validSpaces => new List<CoordinateSpace> { CoordinateSpace.Object, CoordinateSpace.View, CoordinateSpace.World, CoordinateSpace.Tangent };

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Scene/SceneColorNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Scene/SceneColorNode.cs
@@ -15,6 +15,7 @@ namespace UnityEditor.ShaderGraph
         public SceneColorNode()
         {
             name = "Scene Color";
+            synonyms = new string[] { "screen buffer" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Scene/SceneDepthNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Scene/SceneDepthNode.cs
@@ -41,6 +41,7 @@ namespace UnityEditor.ShaderGraph
         public SceneDepthNode()
         {
             name = "Scene Depth";
+            synonyms = new string[] { "zbuffer", "zdepth" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Advanced/ModuloNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Advanced/ModuloNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public ModuloNode()
         {
             name = "Modulo";
+            synonyms = new string[] { "fmod" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Advanced/NegateNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Advanced/NegateNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public NegateNode()
         {
             name = "Negate";
+            synonyms = new string[] { "invert", "opposite" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Advanced/ReciprocalNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Advanced/ReciprocalNode.cs
@@ -17,6 +17,7 @@ namespace UnityEditor.ShaderGraph
         public ReciprocalNode()
         {
             name = "Reciprocal";
+            synonyms = new string[] { "rcp" };
         }
 
         [SerializeField]

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Advanced/ReciprocalSquareRootNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Advanced/ReciprocalSquareRootNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public ReciprocalSquareRootNode()
         {
             name = "Reciprocal Square Root";
+            synonyms = new string[] { "rsqrt", "inversesqrt" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/AddNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/AddNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public AddNode()
         {
             name = "Add";
+            synonyms = new string[] { "addition", "sum", "plus" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/DivideNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/DivideNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public DivideNode()
         {
             name = "Divide";
+            synonyms = new string[] { "division", "divided by" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/MultiplyNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/MultiplyNode.cs
@@ -15,6 +15,7 @@ namespace UnityEditor.ShaderGraph
         public MultiplyNode()
         {
             name = "Multiply";
+            synonyms = new string[] { "multiplication", "times", "x" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/SquareRootNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/SquareRootNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public SquareRootNode()
         {
             name = "Square Root";
+            synonyms = new string[] { "sqrt" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/SubtractNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/SubtractNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public SubtractNode()
         {
             name = "Subtract";
+            synonyms = new string[] { "subtraction", "remove", "minus", "take away" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Interpolation/LerpNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Interpolation/LerpNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public LerpNode()
         {
             name = "Lerp";
+            synonyms = new string[] { "mix", "blend", "linear interpolate" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Range/ClampNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Range/ClampNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public ClampNode()
         {
             name = "Clamp";
+            synonyms = new string[] { "limit" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Range/OneMinusNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Range/OneMinusNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public OneMinusNode()
         {
             name = "One Minus";
+            synonyms = new string[] { "complement", "invert", "opposite" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Range/SaturateNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Range/SaturateNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public SaturateNode()
         {
             name = "Saturate";
+            synonyms = new string[] { "clamp" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/ArccosineNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/ArccosineNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public ArccosineNode()
         {
             name = "Arccosine";
+            synonyms = new string[] { "acos" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/ArcsineNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/ArcsineNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public ArcsineNode()
         {
             name = "Arcsine";
+            synonyms = new string[] { "asin" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/Arctangent2Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/Arctangent2Node.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public Arctangent2Node()
         {
             name = "Arctangent2";
+            synonyms = new string[] { "atan2" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/ArctangentNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/ArctangentNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public ArctangentNode()
         {
             name = "Arctangent";
+            synonyms = new string[] { "atan" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/DegreesToRadiansNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/DegreesToRadiansNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public DegreesToRadiansNode()
         {
             name = "Degrees To Radians";
+            synonyms = new string[] { "degtorad" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/HyperbolicCosineNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/HyperbolicCosineNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public HyperbolicCosineNode()
         {
             name = "Hyperbolic Cosine";
+            synonyms = new string[] { "cosh" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/HyperbolicSineNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/HyperbolicSineNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public HyperbolicSineNode()
         {
             name = "Hyperbolic Sine";
+            synonyms = new string[] { "sinh" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/HyperbolicTangentNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/HyperbolicTangentNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public HyperbolicTangentNode()
         {
             name = "Hyperbolic Tangent";
+            synonyms = new string[] { "tanh" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/RadiansToDegreesNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Trigonometry/RadiansToDegreesNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public RadiansToDegreesNode()
         {
             name = "Radians To Degrees";
+            synonyms = new string[] { "radtodeg" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Vector/DotProductNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Vector/DotProductNode.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.ShaderGraph
         public DotProductNode()
         {
             name = "Dot Product";
+            synonyms = new string[] { "scalar product" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Vector/TransformNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Vector/TransformNode.cs
@@ -50,6 +50,7 @@ namespace UnityEditor.ShaderGraph
         public TransformNode()
         {
             name = "Transform";
+            synonyms = new string[] { "world", "tangent", "object", "view" };
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Wave/SawtoothWaveNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Wave/SawtoothWaveNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public SawtoothWaveNode()
         {
             name = "Sawtooth Wave";
+            synonyms = new string[] { "triangle wave" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Wave/TriangleWaveNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Wave/TriangleWaveNode.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ShaderGraph
         public TriangleWaveNode()
         {
             name = "Triangle Wave";
+            synonyms = new string[] { "sawtooth wave" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Noise/GradientNoiseNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Noise/GradientNoiseNode.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.ShaderGraph
         public GradientNoiseNode()
         {
             name = "Gradient Noise";
+            synonyms = new string[] { "perlin noise" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Noise/SimpleNoiseNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Noise/SimpleNoiseNode.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.ShaderGraph
         public NoiseNode()
         {
             name = "Simple Noise";
+            synonyms = new string[] { "value noise" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Noise/VoronoiNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Noise/VoronoiNode.cs
@@ -10,6 +10,7 @@ namespace UnityEditor.ShaderGraph
         public VoronoiNode()
         {
             name = "Voronoi";
+            synonyms = new string[] { "worley noise" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/BranchNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/BranchNode.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.ShaderGraph
         public BranchNode()
         {
             name = "Branch";
+            synonyms = new string[] { "switch", "if", "else" };
         }
 
         protected override MethodInfo GetFunctionToConvert()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/ComparisonNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/ComparisonNode.cs
@@ -21,6 +21,7 @@ namespace UnityEditor.ShaderGraph
         public ComparisonNode()
         {
             name = "Comparison";
+            synonyms = new string[] { "equal", "greater than", "less than" };
         }
 
         [SerializeField]

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/IsFrontFaceNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/IsFrontFaceNode.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.ShaderGraph
         public IsFrontFaceNode()
         {
             name = "Is Front Face";
+            synonyms = new string[] { "face", "side" };
             UpdateNodeAfterDeserialization();
         }
 


### PR DESCRIPTION
This change adds synonyms to a set of nodes.  The synonyms are used for searches so that users don't have to know the exact name of the nodes to find what they are looking for.

### Purpose of this PR
Many of the nodes have slightly unexpected names or alternate names to the industry standard - so this allows users to enter search terms with names that are different and still come up with the correct results.  It makes searching more "intelligent"

---
### Testing status
For each of the synonyms, I have typed them in the Create Node search field to make sure that the proper nodes are displayed as search results.

---
### Comments to reviewers
A complete list of all of the synonyms I have added can be found in this document:
https://docs.google.com/document/d/1eYeCXM-Qre1O5tTrPglkSuuynLmLtS-t_b_9d7V3XUM
Note that the document also contains some symbols as synonyms such as +-/* etc - but symbols don't currently work as search terms, so I left those out of the code changes.
