### PR TITLE
Fixed Bug That Prevented Sclera Iris Blend node from being added

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/Node/ScleraIrisBlend.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/Node/ScleraIrisBlend.cs
@@ -10,7 +10,7 @@ namespace UnityEditor.ShaderGraph
     {
         public ScleraIrisBlend()
         {
-            name = "Sclera Limbal Ring (Preview)";
+            name = "Sclera Iris Blend (Preview)";
         }
 
         public override bool hasPreview


### PR DESCRIPTION
The Sclera Iris Blend node had the same name as the Sclera Limbal Ring node, so when you selected the Sclera Iris Blend node from the Create Node menu, the Sclera Limbal Ring node was added instead.  This made it impossible to add a Sclera Iris Blend node to the graph.

### Purpose of this PR
Fixed the name field of the Sclera Iris Blend node so that it can be added to a graph via the Create Node menu.

---
### Testing status
After making this change, I was able to add the node correctly in my local branch.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
