### PR TITLE
[Yamato] Fix extended reporting path

### DIFF
--- a/.yamato/script/log_scripts/log_parser.py
+++ b/.yamato/script/log_scripts/log_parser.py
@@ -118,7 +118,7 @@ def post_additional_results(cmd, local):
 
 def parse_args(argv):
     parser = argparse.ArgumentParser()
-    parser.add_argument("--execution-log", required=False, help='Path to execution log file. If not specified, ../../Execution-*.log is used.', default=None)
+    parser.add_argument("--execution-log", required=False, help='Path to execution log file. If not specified, ../../Execution-*.log is used.', default="")
     parser.add_argument("--local", action='store_true', help='If specified, API call to post additional results is skipped.', default=False)
     args = parser.parse_args(argv)
     return args


### PR DESCRIPTION

---
### Purpose of this PR
Fixes the default path to Execution logs for extended reporting, which was missed when testing specific logs locally. It's now been tested properly and finds execution logs at their default location.

