### PR TITLE
[HDRP] Fixing UI instructions anchor to bottom left on lens flare sample scene

### DIFF
--- a/com.unity.render-pipelines.high-definition/Samples~/LensFlareSamples/LensFlareSamples.unity
+++ b/com.unity.render-pipelines.high-definition/Samples~/LensFlareSamples/LensFlareSamples.unity
@@ -1021,11 +1021,11 @@ RectTransform:
   m_Father: {fileID: 912585141}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 20, y: -1060}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 20, y: 20}
   m_SizeDelta: {x: 216.33, y: 0}
-  m_Pivot: {x: 0, y: 0.5}
+  m_Pivot: {x: 0, y: 0}
 --- !u!114 &1045076802
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Purpose of this PR
This PR fixes a really simple and cosmetic issue on the lens flare sample. 
On squared resolutions or portrait one, the lens flare sample instructions text wasn't staying on the bottom left because of how the anchor of the text was setup.
On classic landscape resolutions (like 1080p), the issue does not repro because it was setup using this ratio most probably. 
Here's 3 gifs with resolutions to show the problem. 

**Classic 1080p landscape**
![1080p_Landscape](https://user-images.githubusercontent.com/57442369/130973058-b593cbb3-96bf-40d9-ac5e-fc0328fd30e6.gif)

**Square 2048px**
![Squared](https://user-images.githubusercontent.com/57442369/130973075-b770f8ee-65c8-4d82-81e7-cf2520561f3b.gif)

**1080p Portrait**
![Portrait](https://user-images.githubusercontent.com/57442369/130973092-1d9ab9f9-a844-4ced-970f-a51c8dee6390.gif)

---
### Testing status
Tried reimporting the sample after and changed to multiple resolutions to verify that the instructions were staying on the bottom left. ✔️ 
