### PR TITLE
[ShaderGraph][2021.1] Throttling animated preview framerate

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added subshadergraphs for SpeedTree 8 shadergraph support: SpeedTree8Wind, SpeedTree8ColorAlpha, SpeedTree8Billboard.
 - Added an HLSL file implementing a version of the Unity core LODDitheringTransition function which can be used in a Shader Graph\
 - Added View Vector Node doc
+- Added a ShaderGraph animated preview framerate throttle.
 
 ### Changed
 - Only ShaderGraph keywords count towards the shader permutation variant limit, SubGraph keywords do not.

--- a/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
+++ b/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
@@ -37,6 +37,8 @@ namespace UnityEditor.ShaderGraph.Drawing
         HashSet<PreviewRenderData> m_PreviewsToDraw = new HashSet<PreviewRenderData>();                     // previews to re-render the texture (either because shader compile changed or property changed)
         HashSet<PreviewRenderData> m_TimedPreviews = new HashSet<PreviewRenderData>();                      // previews that are dependent on a time node -- i.e. animated / need to redraw every frame
 
+        double m_LastTimedUpdateTime = 0.0f;
+
         bool m_TopologyDirty;                                                                               // indicates topology changed, used to rebuild timed node list and preview type (2D/3D) inheritance.
 
         HashSet<BlockNode> m_MasterNodeTempBlocks = new HashSet<BlockNode>();                               // temp blocks used by the most recent master node preview generation.
@@ -420,8 +422,36 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
+        bool TimedNodesShouldUpdate(EditorWindow editorWindow)
+        {
+            // get current screen FPS, clamp to what we consider a valid range
+            // this is probably not accurate for multi-monitor.. but should be relevant to at least one of the monitors
+            double monitorFPS = Screen.currentResolution.refreshRate + 1.0;  // +1 to round up, since it is an integer and rounded down
+            if (Double.IsInfinity(monitorFPS) || Double.IsNaN(monitorFPS))
+                monitorFPS = 60.0f;
+            monitorFPS = Math.Min(monitorFPS, 144.0);
+            monitorFPS = Math.Max(monitorFPS, 30.0);
+
+            var curTime = EditorApplication.timeSinceStartup;
+            var deltaTime = curTime - m_LastTimedUpdateTime;
+            bool isFocusedWindow = (EditorWindow.focusedWindow == editorWindow);
+
+            // we throttle the update rate, based on whether the window is focused and if unity is active
+            const double k_AnimatedFPS_WhenNotFocused = 10.0;
+            const double k_AnimatedFPS_WhenInactive = 2.0;
+            double maxAnimatedFPS =
+                (UnityEditorInternal.InternalEditorUtility.isApplicationActive ?
+                    (isFocusedWindow ? monitorFPS : k_AnimatedFPS_WhenNotFocused) :
+                    k_AnimatedFPS_WhenInactive);
+
+            bool update = (deltaTime > (1.0 / maxAnimatedFPS));
+            if (update)
+                m_LastTimedUpdateTime = curTime;
+            return update;
+        }
+
         private static readonly ProfilerMarker RenderPreviewsMarker = new ProfilerMarker("RenderPreviews");
-        public void RenderPreviews(bool requestShaders = true)
+        public void RenderPreviews(EditorWindow editorWindow, bool requestShaders = true)
         {
             using (RenderPreviewsMarker.Auto())
             using (var renderList2D = PooledList<PreviewRenderData>.Get())
@@ -445,10 +475,11 @@ namespace UnityEditor.ShaderGraph.Drawing
                 CollectPreviewProperties(m_NodesPropertyChanged, perMaterialPreviewProperties);
                 m_NodesPropertyChanged.Clear();
 
-                // timed nodes change every frame, so must be drawn
+                // timed nodes are animated, so they should be updated regularly (but not necessarily on every update)
                 // (m_TimedPreviews has been pre-propagated downstream)
                 // HOWEVER they do not need to collect properties. (the only property changing is time..)
-                m_PreviewsToDraw.UnionWith(m_TimedPreviews);
+                if (TimedNodesShouldUpdate(editorWindow))
+                    m_PreviewsToDraw.UnionWith(m_TimedPreviews);
 
                 ForEachNodesPreview(nodesToDraw, p => m_PreviewsToDraw.Add(p));
 

--- a/com.unity.shadergraph/Editor/Drawing/PreviewRate.cs
+++ b/com.unity.shadergraph/Editor/Drawing/PreviewRate.cs
@@ -1,9 +1,0 @@
-namespace UnityEditor.ShaderGraph.Drawing
-{
-    enum PreviewRate
-    {
-        Full,
-        Throttled,
-        Off
-    }
-}

--- a/com.unity.shadergraph/Editor/Drawing/PreviewRate.cs.meta
+++ b/com.unity.shadergraph/Editor/Drawing/PreviewRate.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: fa070520993a4b839e705dcd7f22e4d6
-timeCreated: 1506421104

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -121,7 +121,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_Graph = graph;
             m_MessageManager = messageManager;
             previewManager = new PreviewManager(graph, messageManager);
-            previewManager.RenderPreviews(false);
+            previewManager.RenderPreviews(m_EditorWindow, false);
 
             styleSheets.Add(Resources.Load<StyleSheet>("Styles/GraphEditorView"));
 
@@ -648,7 +648,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_ColorManager.UpdateNodeViews(nodeList);
             }
 
-            previewManager.RenderPreviews();
+            previewManager.RenderPreviews(m_EditorWindow);
             m_BlackboardProvider.HandleGraphChanges(wasUndoRedoPerformed);
             if (wasUndoRedoPerformed || m_InspectorView.DoesInspectorNeedUpdate())
                 m_InspectorView.Update();


### PR DESCRIPTION
### Purpose of this PR

Addressing: https://fogbugz.unity3d.com/f/cases/1351801/

Backports:
2021.2: https://github.com/Unity-Technologies/Graphics/pull/5164
2021.1: https://github.com/Unity-Technologies/Graphics/pull/5574
2020.3: https://github.com/Unity-Technologies/Graphics/pull/5575

Fixing an issue where animated preview rendering can take huge amounts of GPU time.

Animated preview rendering is only throttled by the rate at which update is called, and this can be 300 fps or more, depending on your machine and setup, which can result in excessive GPU usage.  Some users were seeing very hefty GPUs burning 50% of their time rendering the animated previews at thousands of FPS.

This PR adds a throttle, limiting animated previews to render at your monitor refresh rate.
When the ShaderGraph window is not focused, it further reduces that to 10 fps max.
And when Unity is not active (i.e. another app has focus), it drops it down to 2 fps.

---
### Testing status
Describe what manual/automated tests were performed for this PR

- [x] Tested on Windows with debug logging enabled, to see that preview rendering is called at most 60 times/second.
- [x] Tested on Windows, with another Unity window focused, to see that preview rendering is called at most 10 times/second.
- [x] Tested on Windows, with another program active, to see that preview rendering is called at most 2 times/second.
- [x] Tested with two ShaderGraph editor windows open -- the focused one gets updated at 60 fps, the other at 10 fps.

Before with two animated graphs of 8 nodes: ~40% GPU usage
Same independent of which window focused, or if Unity app is focused.
![image](https://user-images.githubusercontent.com/28871759/126242765-3160026f-2860-460c-9324-99dab6e6e683.png)

After: ~30%
![image](https://user-images.githubusercontent.com/28871759/132593293-8e9d7b23-ef55-4387-a291-3e97065d4646.png)

When a non-ShaderGraph unity window selected: ~17%
![image](https://user-images.githubusercontent.com/28871759/132591106-e6c17772-8b3c-4c00-bec0-c5c249a96306.png)

When another app selected:  ~7%
![image](https://user-images.githubusercontent.com/28871759/132590389-9aab22f5-69e0-4063-becd-0a7025b969cc.png)

Yamato:

ShaderGraph PR job: 🟢 
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/2021.1%252Fsg%252Fthrottle-preview/.yamato%252Fall-shadergraph.yml%2523PR_ShaderGraph_2021.1/8613730/job/pipeline

---
### Comments to reviewers
Notes for the reviewers you have assigned.
