### PR TITLE
[ShaderGraph] [2022.1] [Ruby] Delay preview rendering until async pre-compilation is complete

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -15,6 +15,7 @@ The version number for this package has increased due to a version update of a r
 
 ### Fixed
  - Fixed an incorrect direction transform from view to world space [1362034] (https://issuetracker.unity3d.com/product/unity/issues/guid/1362034/)
+ - Fixed ShaderGraph HDRP master preview disappearing for a few seconds when graph is modified  [1330289] (https://issuetracker.unity3d.com/issues/shadergraph-hdrp-main-preview-is-invisible-until-moved)
 
 ## [12.0.0] - 2021-01-11
 

--- a/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
+++ b/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
@@ -563,6 +563,10 @@ namespace UnityEditor.ShaderGraph.Drawing
                         continue;
                     }
 
+                    // skip rendering while a preview shader is being compiled
+                    if (m_PreviewsCompiling.Contains(preview))
+                        continue;
+
                     // we want to render this thing, now categorize what kind of render it is
                     if (preview == m_MasterRenderData)
                         renderMasterPreview = true;


### PR DESCRIPTION
### Purpose of this PR

PR/Backports:
2022.1: https://github.com/Unity-Technologies/Graphics/pull/5659/
2021.2: https://github.com/Unity-Technologies/Graphics/pull/5676/


Addressing regression: https://fogbugz.unity3d.com/f/cases/edit/1330289/

Previously, modifying the graph to a novel configuration would cause the master preview to go blank for a few seconds, while the preview shader is compiled async, then render itself when compilation completes.

The reason it goes blank is complicated, but stems from the fact that a re-render is requested at the same time as a re-compile, and the render is performed before the shader has finished compiling.  This means it is rendered with the async fallback shader, which shows up blank in the preview.

This change causes pending async-compilations on a preview to pause the render requests for that preview until the async compilation is complete.

The net effect is that the preview render will gray out and not move, but will keep its old appearance while the async compile is happening.

Normal preview:
![image](https://user-images.githubusercontent.com/28871759/133347469-050fa2ef-bad1-49fe-b1c8-c046e0fb5f2d.png)

While async pre-compile is pending:
![image](https://user-images.githubusercontent.com/28871759/133347494-818254fd-cf3d-4d79-9840-36f89457e381.png)

---
### Testing status
- [x] Tested HDRP Lit preview behavior
- [x] Tested HDRP Unlit preview behavior
- [x] Tested URP Lit preview behavior
- [x] Tested URP Unlit preview behavior
- [x] Tested cached and uncached preview behavior for all of above

Yamato:

ShaderGraph PR Job: 🟢
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/sg%252Ffix%252F1330289/.yamato%252Fall-shadergraph.yml%2523PR_ShaderGraph_trunk/8744935/job/pipeline


---
### Comments to reviewers
Notes for the reviewers you have assigned.
