### PR TITLE
[ShaderGraph] [2021.2] Fix "view shader" commands to not block Unity from closing, use same editor instance

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -138,6 +138,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed the ordering of inputs on a SubGraph node to match the properties on the blackboard of the subgraph itself [1366052]
 - Fixed Parallax Occlusion Mapping node to handle non-uniformly scaled UVs such as HDRP/Lit POM [1347008].
 - Fixed ShaderGraph HDRP master preview disappearing for a few seconds when graph is modified  [1330289] (https://issuetracker.unity3d.com/issues/shadergraph-hdrp-main-preview-is-invisible-until-moved)
+- Fixed an issue where ShaderGraph "view shader" commands were opening in individual windows, and blocking Unity from closing [1367188]
 
 ## [11.0.0] - 2020-10-21
 

--- a/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
@@ -362,26 +362,6 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        static ProcessStartInfo CreateProcessStartInfo(string filePath)
-        {
-            string externalScriptEditor = ScriptEditorUtility.GetExternalScriptEditor();
-
-            ProcessStartInfo psi = new ProcessStartInfo();
-            psi.UseShellExecute = false;
-
-
-#if UNITY_EDITOR_OSX
-            string arg = string.Format("-a \"{0}\" -n --args \"{1}\"", externalScriptEditor, Path.GetFullPath(filePath));
-            psi.FileName = "open";
-            psi.Arguments = arg;
-#else
-            psi.Arguments = Path.GetFileName(filePath);
-            psi.WorkingDirectory = Path.GetDirectoryName(filePath);
-            psi.FileName = externalScriptEditor;
-#endif
-            return psi;
-        }
-
         public static void OpenFile(string path)
         {
             string filePath = Path.GetFullPath(path);
@@ -394,8 +374,7 @@ namespace UnityEditor.ShaderGraph
             string externalScriptEditor = ScriptEditorUtility.GetExternalScriptEditor();
             if (externalScriptEditor != "internal")
             {
-                ProcessStartInfo psi = CreateProcessStartInfo(filePath);
-                Process.Start(psi);
+                InternalEditorUtility.OpenFileAtLineExternal(filePath, 0);
             }
             else
             {


### PR DESCRIPTION
### Purpose of this PR
Backports:
2022.1: https://github.com/Unity-Technologies/Graphics/pull/5735
2021.2: https://github.com/Unity-Technologies/Graphics/pull/5736

Fix for https://fogbugz.unity3d.com/f/cases/1367188/

Previously, when viewing the generated shader output via the debug commands in ShaderGraph, a separate instance of the script editor would be invoked for each generated shader, instead of re-using the existing editor.

Worse, when the user tried to close Unity, it would block on an inscrutable dialog:
![image](https://user-images.githubusercontent.com/28871759/134061081-88cd23bb-95e5-422e-9138-0be99dab3e11.png)
Until the user closed all of the script editors that had been opened.

This PR fixes both issues by switching to use the script function:  "OpenFileAtLineExternal" to invoke the script editor, instead of directly creating editor processes.

---
### Testing status
- [x] Tested opening generated shaders via the ShaderGraph Inspector (both buttons)
- [x] When using Visual Studio, validated that they open in the existing VS instance
- [x] When VS is not running, it opens a new instance of VS.
- [x] Validated that changing the "script editor" preferences is reflected in what editor is opened.
- [x] Tested right click on node -> show generated code -- all of above works.
- [x]  Tested right click on node -> show preview code -- all of above works.

Yamato:

PR ShaderGraph: 🟢
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/2021.2%252Fsg%252Ffix%252F1367188/.yamato%252Fall-shadergraph.yml%2523PR_ShaderGraph_2021.2/8870350/job/pipeline

---
### Comments to reviewers
Notes for the reviewers you have assigned.
