### PR TITLE
Update light2d properties and expose settor for sprite light

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/2D/Light2D.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Light2D.cs
@@ -254,7 +254,21 @@ namespace UnityEngine.Rendering.Universal
         /// <summary>
         /// The Sprite that's used by the Sprite Light type to control the shape light
         /// </summary>
-        public Sprite lightCookieSprite { get { return m_LightType != LightType.Point ? m_LightCookieSprite : m_DeprecatedPointLightCookieSprite; } }
+        public Sprite lightCookieSprite
+        {
+            get
+            {
+                return m_LightType != LightType.Point ? m_LightCookieSprite : m_DeprecatedPointLightCookieSprite;
+            }
+
+            set
+            {
+                if (m_LightType != LightType.Point)
+                    m_LightCookieSprite = value;
+                else
+                    m_DeprecatedPointLightCookieSprite = value;
+            }
+        }
         /// <summary>
         /// Controls the brightness and distance of the fall off (edge) of the light
         /// </summary>

--- a/com.unity.render-pipelines.universal/Runtime/2D/Light2D.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Light2D.cs
@@ -254,21 +254,7 @@ namespace UnityEngine.Rendering.Universal
         /// <summary>
         /// The Sprite that's used by the Sprite Light type to control the shape light
         /// </summary>
-        public Sprite lightCookieSprite
-        {
-            get
-            {
-                return m_LightType != LightType.Point ? m_LightCookieSprite : m_DeprecatedPointLightCookieSprite;
-            }
-
-            set
-            {
-                if (m_LightType != LightType.Point)
-                    m_LightCookieSprite = value;
-                else
-                    m_DeprecatedPointLightCookieSprite = value;
-            }
-        }
+        public Sprite lightCookieSprite { get => m_LightCookieSprite; set => m_LightCookieSprite = value; }
         /// <summary>
         /// Controls the brightness and distance of the fall off (edge) of the light
         /// </summary>

--- a/com.unity.render-pipelines.universal/Runtime/2D/Light2DShape.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Light2DShape.cs
@@ -60,7 +60,6 @@ namespace UnityEngine.Rendering.Universal
         public void SetShapePath(Vector3[] path)
         {
             m_ShapePath = path;
-            UpdateMesh(true);
         }
     }
 }

--- a/com.unity.render-pipelines.universal/Tests/Runtime/Light2DTests.cs
+++ b/com.unity.render-pipelines.universal/Tests/Runtime/Light2DTests.cs
@@ -110,6 +110,7 @@ namespace UnityEngine.Rendering.Universal.Tests
             light.lightType = Light2D.LightType.Freeform;
 
             light.SetShapePath(shapePath);
+            light.UpdateMesh(true);
 
             Assert.AreEqual(true, light.hasCachedMesh);
         }
@@ -121,6 +122,7 @@ namespace UnityEngine.Rendering.Universal.Tests
             var light = m_TestObjectCached.AddComponent<Light2D>();
             light.lightType = Light2D.LightType.Freeform;
             light.SetShapePath(shapePath);
+            light.UpdateMesh(true);
 
             int vertexCount = 0, triangleCount = 0;
 
@@ -132,6 +134,7 @@ namespace UnityEngine.Rendering.Universal.Tests
             // Simulate Runtime Behavior.
             var shapePathChanged = new Vector3[5] { new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 1, 0), new Vector3(0.5f, 1.5f, 0), new Vector3(0, 1, 0) };
             light.SetShapePath(shapePathChanged);
+            light.UpdateMesh(true);
 
             // Check if Cached Data and the actual data are no longer the same. (We don't save cache on Runtime)
             Assert.AreNotEqual(vertexCount, light.lightMesh.triangles.Length);


### PR DESCRIPTION
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Users are able to set/change sprite mesh in sprite lights using scripting api

https://forum.unity.com/threads/setting-lightcookiesprite-for-light2d-experimental.1117513/#post-7209010

---
### Testing status
Describe what manual/automated tests were performed for this PR

Add a Light2D of Sprite type to the scene.
Create a new script with the following code to test.

> public Sprite spriteMesh;
> // Start is called before the first frame update
> void Start()
> {
>     GetComponent<Light2D>().lightCookieSprite = spriteMesh;
> }

---
### Comments to reviewers
Notes for the reviewers you have assigned.
