### PR TITLE
Mark anchor override as not supported for probes

### DIFF
--- a/com.unity.render-pipelines.high-definition/Documentation~/Feature-Comparison.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Feature-Comparison.md
@@ -116,6 +116,7 @@ The tables that follow provide an overview of the Features that the High Definit
 | **Realtime**            | Yes                                                          | yes                                                          |
 | **Baked**               | Yes                                                          | Yes                                                          |
 | ***Sampling***          |                                                              |                                                              |
+| **Anchor Override**     | Yes                                                          | Not supported                                                |
 | **Simple**              | Yes                                                          | See [Reflection Hierarchy](Reflection-in-HDRP.md). |
 | **Blend Probes**        | Yes                                                          | See [Reflection Hierarchy](Reflection-in-HDRP.md). |
 | **Blend Probes and Skybox** | Yes                                                          | See [Reflection Hierarchy](Reflection-in-HDRP.md). |


### PR DESCRIPTION
### Purpose of this PR

https://fogbugz.unity3d.com/f/cases/1360903/

anchor override is not used for reflectoin probes, only light probes in HDRP. Tooltip is already correct about that
Added a line in the feature comparison doc
