### PR TITLE
Floor values to handle rounding present elsewhere doesn't dirty.

### DIFF
--- a/com.unity.visualeffectgraph/Editor/Utils/VFXSystemBorder.cs
+++ b/com.unity.visualeffectgraph/Editor/Utils/VFXSystemBorder.cs
@@ -137,7 +137,7 @@ namespace UnityEditor.VFX.UI
         {
             if (IsDifferenceTooSmall(e.oldRect.x, e.newRect.x) &&
                 IsDifferenceTooSmall(e.oldRect.y, e.newRect.y) &&
-                IsDifferenceTooSmall(e.oldRect.width, e.newRect.height) &&
+                IsDifferenceTooSmall(e.oldRect.width, e.newRect.width) &&
                 IsDifferenceTooSmall(e.oldRect.height, e.newRect.height))
             {
                 return;


### PR DESCRIPTION
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1372213/

Depending on the DPI of the monitor, and the Windows scaling value (125% is the most common trigger), situations arise where the border/title system around VFX graph blocks constantly dirties itself causing a recursive error from the layout engine. This constant spam degrades the performance of the editor. 

This change adds specific checks to resolve scenarios where the internal values have been rounded, but the setting values have not. It also adds protection on the event-based call to do a similar check against the old/new values to avoid additional computation.

---
### Testing status
Tested on a 4k screen with DPI set to 125%
