### PR TITLE
[HDRP] Layer drawer used in ray/path tracing now matches 100% with the Camera one

### DIFF
--- a/com.unity.render-pipelines.core/Editor/Volume/Drawers/IntParameterDrawer.cs
+++ b/com.unity.render-pipelines.core/Editor/Volume/Drawers/IntParameterDrawer.cs
@@ -109,6 +109,41 @@ namespace UnityEditor.Rendering
     [VolumeParameterDrawer(typeof(LayerMaskParameter))]
     sealed class LayerMaskParameterDrawer : VolumeParameterDrawer
     {
+        private static int FieldToLayerMask(int field)
+        {
+            int mask = 0;
+            var layers = InternalEditorUtility.layers;
+            bool everything = true;
+            for (int c = 0; c < layers.Length; c++)
+            {
+                if ((field & (1 << c)) != 0)
+                    mask |= 1 << LayerMask.NameToLayer(layers[c]);
+                else
+                {
+                    mask &= ~(1 << LayerMask.NameToLayer(layers[c]));
+                    everything = false;
+                }
+            }
+
+            return everything ? -1 : mask;
+        }
+
+        private static int LayerMaskToField(int mask)
+        {
+            int field = 0;
+            var layers = InternalEditorUtility.layers;
+            bool everything = true;
+            for (int c = 0; c < layers.Length; c++)
+            {
+                if ((mask & (1 << LayerMask.NameToLayer(layers[c]))) != 0)
+                    field |= 1 << c;
+                else
+                    everything = false;
+            }
+
+            return everything ? -1 : field;
+        }
+
         public override bool OnGUI(SerializedDataParameter parameter, GUIContent title)
         {
             var value = parameter.value;
@@ -116,8 +151,9 @@ namespace UnityEditor.Rendering
             if (value.propertyType != SerializedPropertyType.LayerMask)
                 return false;
 
-            value.intValue = InternalEditorUtility.ConcatenatedLayersMaskToLayerMask(
-                EditorGUILayout.MaskField(title, InternalEditorUtility.LayerMaskToConcatenatedLayersMask(value.intValue), InternalEditorUtility.layers));
+            value.intValue = FieldToLayerMask(
+                EditorGUILayout.MaskField(title, LayerMaskToField(value.intValue), InternalEditorUtility.layers));
+
             return true;
         }
     }


### PR DESCRIPTION
Addresses: https://fogbugz.unity3d.com/f/cases/1368738

The layer drawer used in ray/path tracing now matches exactly the behaviour of the one found in the Camera.

Before:
- "Everything" mode was only setting to 1 the bits of named layers in the mask
- Unnamed layers bits could never be set to 1

Now:
- "Everything" mode sets the bitmask to ~0
- Setting manually all named layers to 1 sets the bitmask to the "Everything" value of ~0
- Unsetting any named layer from the "Everything" mode reverts to regular bitmask value
