### PR TITLE
Fixed shadowcaster in universal for shader graph to use the newest up…

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed multi-edit for UniversalRenderPipelineAsset.
 - Fixed artifacts in Speed Tree 8 billboard LODs due to SpeedTree LOD smoothing/crossfading [case 1348407]
 - Drawing order of SRPDefaultUnlit is now the same as the Built-in Render Pipeline. [case 1325883](https://issuetracker.unity3d.com/product/unity/issues/guid/1325883/)
+- Fixed ShaderGraph needing updated normals for ShadowCaster in URP.
 
 ## [7.7.0] - 2021-04-28
 

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalPBRSubShader.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalPBRSubShader.cs
@@ -165,9 +165,9 @@ namespace UnityEditor.Rendering.Universal
             },
 
             // Required fields
-            requiredAttributes = new List<string>()
+            requiredVaryings = new List<string>()
             {
-                "Attributes.normalOS",
+                "Varyings.normalWS",
             },
 
             // Render State Overrides


### PR DESCRIPTION
### Purpose of this PR
This is a backport for this [PR](https://github.com/Unity-Technologies/Graphics/pull/5527). It ensures the shadow caster receives the newest update of the normals such that the shadow normal bias is correct.

---
### Testing status
I have tested the fix with the project given in the bug and tested if the universal graphics tests worked locally.