### PR TITLE
 Updated Code Owner to add URP Trunk Guardian

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Code Ownership File
 
 # Universal RP General
-/com.unity.render-pipelines.universal/ @Unity-Technologies/universal-rp-team @Unity-Technologies/gfx-qa-urp
+/com.unity.render-pipelines.universal/ @Unity-Technologies/universal-rp-team @Unity-Technologies/urp-trunk-guardian
 
 # Universal RP 2D Renderer
 /com.unity.render-pipelines.universal/Editor/2D @Unity-Technologies/2d-graphics


### PR DESCRIPTION
### Purpose of this PR
 This PR changes code owner. It adds URP Trunk Guardian instead of QA.
 Release branches are protected and require code owner approval, this is to prevent PRs being merged without guardian review and check on nightly. 
 
 - Universal RP Team code owner reviews code. 
 - URP Trunk Guardian reviews yamato state.
 - QA is removed as code owner as this was noisy for QA team, we don't need to test every PR, we test upon demand or in the universal/staging branch. 

