### PR TITLE
URP Lighting - Revert utf bump

### DIFF
--- a/TestProjects/UniversalGraphicsTest_Lighting/Packages/manifest.json
+++ b/TestProjects/UniversalGraphicsTest_Lighting/Packages/manifest.json
@@ -12,7 +12,7 @@
     "com.unity.render-pipelines.universal": "file:../../../com.unity.render-pipelines.universal",
     "com.unity.shadergraph": "file:../../../com.unity.shadergraph",
     "com.unity.testing.urp": "file:../../../com.unity.testing.urp",
-    "com.unity.test-framework": "1.1.29",
+    "com.unity.test-framework": "1.1.18",
     "com.unity.test-framework.build": "0.0.1-preview.14",
     "com.unity.test-framework.utp-reporter": "1.0.2-preview",
     "com.unity.testframework.graphics": "7.8.14-preview",


### PR DESCRIPTION
### Purpose of this PR

[URP_Lighting on Win_Vulkan_Standalone_mono_Linear on version 2021.2 ](https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/2021.2%252Fstaging/.yamato%252Furp_lighting-win-vulkan.yml%2523URP_Lighting_Win_Vulkan_Standalone_mono_Linear_2021.2/9268404/job/results)is failing on 2021.2 [since the utf bump in this PR](https://github.com/Unity-Technologies/Graphics/pull/5741/files#diff-0d3684305a2912769e4f623ea46bb44bbad88fa7b12e3977fb901b04ddfd5d06).

This PR reverts the bump and sets utf to 1.1.18 until we investigate what is making the tests fail with 1.1.29

---
### Testing status
[URP Lighting](https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/urp-lighting%252Frevert-utf-bump/.yamato%252Fall-urp.yml%2523PR_URP_2021.2)