### PR TITLE
Fix APV contribution in volumetric fog

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VolumetricLighting.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VolumetricLighting.compute
@@ -480,6 +480,9 @@ float3 EvaluateVoxelDiffuseGI(PositionInputs posInput, JitteredRay ray, float t0
     // for L0 term it'd just cancel out as both are just constant factors.
     EvaluateAdaptiveProbeVolume(GetAbsolutePositionWS(posInput.positionWS), posInput.positionSS, apvDiffuseGI);
 
+    const float cornetteShanksZonalHarmonicL0 = sqrt(4.0f * PI);
+    weight *= PI * cornetteShanksZonalHarmonicL0;
+
     // It is possible that some invalid probes are sampled due to how APV is laying the probes
     // For now the safest way is to ignore the NaN data when sampled.
     if (AnyIsNaN(apvDiffuseGI))


### PR DESCRIPTION
The scaling of the sampled APV data in volumetric lighting was wrong (probably a regression at some point) 

**Before**
<img width="1093" alt="Broken" src="https://user-images.githubusercontent.com/43168857/136988660-c3514957-ad1b-42de-9151-af2b999c39f4.png">

<img width="1093" alt="0_broken_emissive_inside" src="https://user-images.githubusercontent.com/43168857/136988671-bbc14aff-1f01-4571-b244-421b83e69214.png">


**After**
<img width="1093" alt="Fixed" src="https://user-images.githubusercontent.com/43168857/136988611-eb814d47-adc1-43f3-a848-1efe2c7f3b6f.png">
<img width="1093" alt="0_fixed_emissive_inside" src="https://user-images.githubusercontent.com/43168857/136988621-ad1b9793-1d26-4408-b9e1-56a11d3b7f73.png">


