### PR TITLE
Fix invalid viewport being set during post process pass when using Pixel Perfect Camera

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - MaterialReimporter.ReimportAllMaterials now batches the asset database changes to improve performance.
 
 ### Fixed
+- Fixed post processing with Pixel Perfect camera [case 1363763](https://issuetracker.unity3d.com/product/unity/issues/guid/1363763/)
 - Fixed the LensFlare flicker with TAA on SceneView (case 1356734).
 - Fixed an issue where Unlit and ParticlesUnlit shaders did not have HDR color selection for albedo [case 1283767](https://issuetracker.unity3d.com/issues/built-in-unlit-particle-shader-has-hdr-color-selection-for-albedo-urp-unlit-particles-do-not)
 - Fixed a regression where ShaderGraph screen position was not correct in game view and when using XR [1369450]

--- a/com.unity.render-pipelines.universal/Runtime/2D/Renderer2D.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Renderer2D.cs
@@ -187,7 +187,7 @@ namespace UnityEngine.Rendering.Universal
                     renderingData.cameraData.camera.orthographicSize = ppc.orthographicSize;
 
                     colorTextureFilterMode = FilterMode.Point;
-                    ppcUpscaleRT = ppc.gridSnapping == PixelPerfectCamera.GridSnapping.UpscaleRenderTexture;
+                    ppcUpscaleRT = ppc.gridSnapping == PixelPerfectCamera.GridSnapping.UpscaleRenderTexture || ppc.requiresUpscalePass;
                 }
             }
 

--- a/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
@@ -593,7 +593,7 @@ namespace UnityEngine.Rendering.Universal.Internal
                     cameraData.renderer.ConfigureCameraTarget(cameraTarget, cameraTarget);
                     cmd.SetViewProjectionMatrices(Matrix4x4.identity, Matrix4x4.identity);
 
-                    if ((m_Destination == RenderTargetHandle.CameraTarget && !m_UseSwapBuffer) || m_ResolveToScreen)
+                    if ((m_Destination == RenderTargetHandle.CameraTarget && !m_UseSwapBuffer) || (m_ResolveToScreen && m_UseSwapBuffer))
                         cmd.SetViewport(cameraData.pixelRect);
 
                     cmd.DrawMesh(RenderingUtils.fullscreenMesh, Matrix4x4.identity, m_Materials.uber);


### PR DESCRIPTION
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Fixes https://fogbugz.unity3d.com/f/cases/1363763/ where the frame doesn't scale correctly when post process is enabled with pixel perfect camera.

---
### Testing status
Describe what manual/automated tests were performed for this PR

Tested on  2022.1.0a13
Open project in FB case.
Ensure changing resolution of game view doesn't create visual artifacts.
Ensure changing ReferenceResolutionX and ReferenceResolutionX on Pixel Perfect Camera component doesn't create visual artifacts.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
