### PR TITLE
Small APV QoLs - clamp dilation and fix a tooltip

### DIFF
--- a/com.unity.render-pipelines.core/Editor/Lighting/ProbeVolume/ProbeVolumeBakingWindow.cs
+++ b/com.unity.render-pipelines.core/Editor/Lighting/ProbeVolume/ProbeVolumeBakingWindow.cs
@@ -418,6 +418,9 @@ namespace UnityEngine.Experimental.Rendering
                 var serializedSet = serializedSets.GetArrayElementAtIndex(m_BakingSets.index);
                 var probeVolumeBakingSettings = serializedSet.FindPropertyRelative("settings");
                 EditorGUILayout.PropertyField(probeVolumeBakingSettings);
+
+                // Clamp to make sure minimum we set for dilation distance is min probe distance
+                set.settings.dilationSettings.dilationDistance = Mathf.Max(set.profile.minDistanceBetweenProbes, set.settings.dilationSettings.dilationDistance);
             }
             else
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ProbeVolume/ProbeVolumesOptions.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ProbeVolume/ProbeVolumesOptions.cs
@@ -25,9 +25,9 @@ namespace UnityEngine.Experimental.Rendering
         public ClampedFloatParameter viewBias = new ClampedFloatParameter(0.0f, 0.0f, 1.0f);
 
         /// <summary>
-        /// Whether the scale the bias for Probe Volumes by the minimum distance between probes.
+        /// Whether to scale the bias for Probe Volumes by the minimum distance between probes.
         /// </summary>
-        [AdditionalProperty, Tooltip("Whether the scale the bias for Probe Volumes by the minimum distance between probes.")]
+        [AdditionalProperty, Tooltip("Whether to scale the bias for Probe Volumes by the minimum distance between probes.")]
         public BoolParameter scaleBiasWithMinProbeDistance = new BoolParameter(false);
 
         /// <summary>


### PR DESCRIPTION
A couple of small QoL changes reported by @iM0ve . 

First clamping the dilation distance so it is always at least the minimum distance between probes. 
Also fix a small change in a tooltip. 

