### PR TITLE
 Updated code owner for URP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # Universal RP Team and URP Guardian
 /com.unity.render-pipelines.universal/ @Unity-Technologies/universal-rp-team @Unity-Technologies/urp-trunk-guardian
-/com.unity.testing.urp-upgrade/ @Unity-Technologies/universal-rp-team @Unity-Technologies/url-trunk-guardian
+/com.unity.testing.urp-upgrade/ @Unity-Technologies/universal-rp-team @Unity-Technologies/urp-trunk-guardian
 /com.unity.testing.urp/ @Unity-Technologies/universal-rp-team @Unity-Technologies/urp-trunk-guardian
 /TestProjects/UniversalGraphicsTest_Foundation/ @Unity-Technologies/universal-rp-team @Unity-Technologies/urp-trunk-guardian
 /TestProjects/UniversalGraphicsTest_Lighting/ @Unity-Technologies/universal-rp-team @Unity-Technologies/urp-trunk-guardian


### PR DESCRIPTION
---
### Purpose of this PR
 This PR increases coverage of code ownership for URP team.

---
### Testing status
 Not needed.

---
### Comments to reviewers
 `Universal RP team` ownership means code review
 `URP Trunk Guardian` ownership means review or URP jobs are green before approving for merge. 
