### PR TITLE
[Yamato] Add all DX11 job for URP

### DIFF
--- a/.yamato/all-urp.yml
+++ b/.yamato/all-urp.yml
@@ -69,8 +69,8 @@ Nightly_URP_trunk:
          rerun: on_new_revision
       -  path: .yamato/urp_upgrade.yml#URP_Upgrade_test_win_trunk
          rerun: on_new_revision
-All_URP_on_Win_DX11_trunk:
-    name: All URP on Win DX11 on trunk
+All_URP_on_Win_DX11_playmode_trunk:
+    name: All URP on Win DX11 playmode on trunk
     variables:
         CUSTOM_REVISION: '{{trunk.changeset.id}}'
         UTR_VERSION: "current"
@@ -149,8 +149,8 @@ Nightly_URP_CUSTOM-REVISION:
          rerun: on_new_revision
       -  path: .yamato/urp_upgrade.yml#URP_Upgrade_test_win_CUSTOM-REVISION
          rerun: on_new_revision
-All_URP_on_Win_DX11_CUSTOM-REVISION:
-    name: All URP on Win DX11 on CUSTOM-REVISION
+All_URP_on_Win_DX11_playmode_CUSTOM-REVISION:
+    name: All URP on Win DX11 playmode on CUSTOM-REVISION
     variables:
         CUSTOM_REVISION: custom_revision_not_set
         UTR_VERSION: "current"

--- a/.yamato/config/urp.metafile
+++ b/.yamato/config/urp.metafile
@@ -35,7 +35,7 @@ jobs:
 #     - .yamato/all-urpupdate_boatattack.yml#URPUpdate_BoatAttack_<TRACK>
       - .yamato/all-urpupdate_top_asset_store.yml#URPUpdate_Top_Asset_Store_<TRACK>
       - .yamato/urp_upgrade.yml#URP_Upgrade_test_win_<TRACK>
-  - name: All <PROJECT_NAME> on Win DX11
+  - name: All <PROJECT_NAME> on Win DX11 playmode
     dependencies:
       - .yamato/urp_2d-win-dx11.yml#URP_2D_Win_DX11_playmode_mono_Linear_<TRACK>
       - .yamato/urp_foundation-win-dx11.yml#URP_Foundation_Win_DX11_playmode_mono_Linear_<TRACK>


### PR DESCRIPTION
---
### Purpose of this PR
Adds a new job `All URP on Win DX11 playmode on trunk` which covers playmode on DX11 for each URP split project, to run minimal coverage for URP.


See pipeline [here](https://unity-ci.cds.internal.unity3d.com/job/9466827)