### PR TITLE
Fix inf with specular occlusion from bent normal

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/CommonLighting.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/CommonLighting.hlsl
@@ -303,7 +303,7 @@ real GetSpecularOcclusionFromBentAO(real3 V, real3 bentNormalWS, real3 normalWS,
     // sharpness = (log(Y) - log(A)) / (cos(X) - 1)
     // For AO cone, cos(X) = sqrt(1 - ambientOcclusion)
     // -> for Y = 0.1, sharpness = -1.0 / (sqrt(1-ao) - 1)
-    float vs = -1.0f / (sqrt(1.0f - ambientOcclusion) - 1.0f);
+    float vs = -1.0f / min(sqrt(1.0f - ambientOcclusion) - 1.0f, -0.001f);
 
     // 2. Approximate upper hemisphere with sharpness = 0.8 and amplitude = 1
     float us = 0.8f;


### PR DESCRIPTION

### Purpose of this PR

When the AO is equal to 1, there was a division by 0.
(note that i failed the commit message, it's when AO=1 not 0)

---
### Testing status

Tested that there is no more division by 0
