### PR TITLE
Add 2d menu item for creating URP Pixel Perfect Camera

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
@@ -12,7 +12,7 @@ namespace UnityEditor.Rendering.Universal
         [MenuItem("GameObject/2D Object/Pixel Perfect Camera", priority = k_PixelPerfectCameraGameObjectMenuPriority)]
         static void GameObjectCreatePixelPerfectCamera(MenuCommand menuCommand)
         {
-            var go = CreateGameObject("Pixel Perfect Camera", menuCommand, new []{typeof(PixelPerfectCamera)});
+            var go = CreateGameObject("Pixel Perfect Camera", menuCommand, new[] { typeof(PixelPerfectCamera) });
             go.GetComponent<PixelPerfectCamera>().gridSnapping = PixelPerfectCamera.GridSnapping.PixelSnapping;
         }
 
@@ -32,7 +32,7 @@ namespace UnityEditor.Rendering.Universal
             Undo.RegisterCreatedObjectUndo(newGO, string.Format("Create {0}", name));
             return newGO;
         }
-        
+
         internal static void Place(GameObject go, GameObject parentTransform)
         {
             if (parentTransform != null)
@@ -59,7 +59,7 @@ namespace UnityEditor.Rendering.Universal
             Undo.SetCurrentGroupName("Create " + go.name);
             Selection.activeGameObject = go;
         }
-        
+
         internal static void PlaceGameObjectInFrontOfSceneView(GameObject go)
         {
             var view = SceneView.lastActiveSceneView;

--- a/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
@@ -1,0 +1,72 @@
+using System;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering.Universal;
+
+namespace UnityEditor.Rendering.Universal
+{
+    static class GameObjectCreation
+    {
+        const int k_PixelPerfectCameraGameObjectMenuPriority = 5;
+
+        [MenuItem("GameObject/2D Object/Pixel Perfect Camera", priority = k_PixelPerfectCameraGameObjectMenuPriority)]
+        static void GameObjectCreatePixelPerfectCamera(MenuCommand menuCommand)
+        {
+            var go = CreateGameObject("Pixel Perfect Camera", menuCommand, new []{typeof(PixelPerfectCamera)});
+            go.GetComponent<PixelPerfectCamera>().gridSnapping = PixelPerfectCamera.GridSnapping.PixelSnapping;
+        }
+
+        static public GameObject CreateGameObject(string name, MenuCommand menuCommand, params Type[] components)
+        {
+            var parent = menuCommand.context as GameObject;
+            var newGO = ObjectFactory.CreateGameObject(name, components);
+            newGO.name = name;
+            Selection.activeObject = newGO;
+            Place(newGO, parent);
+            if (EditorSettings.defaultBehaviorMode == EditorBehaviorMode.Mode2D)
+            {
+                var position = newGO.transform.position;
+                position.z = 0;
+                newGO.transform.position = position;
+            }
+            Undo.RegisterCreatedObjectUndo(newGO, string.Format("Create {0}", name));
+            return newGO;
+        }
+        
+        internal static void Place(GameObject go, GameObject parentTransform)
+        {
+            if (parentTransform != null)
+            {
+                var transform = go.transform;
+                Undo.SetTransformParent(transform, parentTransform.transform, "Reparenting");
+                transform.localPosition = Vector3.zero;
+                transform.localRotation = Quaternion.identity;
+                transform.localScale = Vector3.one;
+                go.layer = parentTransform.gameObject.layer;
+
+                if (parentTransform.GetComponent<RectTransform>())
+                    ObjectFactory.AddComponent<RectTransform>(go);
+            }
+            else
+            {
+                PlaceGameObjectInFrontOfSceneView(go);
+
+                StageUtility.PlaceGameObjectInCurrentStage(go); // may change parent
+            }
+
+            // Only at this point do we know the actual parent of the object and can modify its name accordingly.
+            GameObjectUtility.EnsureUniqueNameForSibling(go);
+            Undo.SetCurrentGroupName("Create " + go.name);
+            Selection.activeGameObject = go;
+        }
+        
+        internal static void PlaceGameObjectInFrontOfSceneView(GameObject go)
+        {
+            var view = SceneView.lastActiveSceneView;
+            if (view != null)
+            {
+                view.MoveToView(go.transform);
+            }
+        }
+    }
+}

--- a/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs.meta
+++ b/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b080c5c57a34e6e4584e1e2c3e96a0c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Missing menu option for creating a URP Pixel Perfect Camera.


---
### Testing status
Describe what manual/automated tests were performed for this PR

Should test together with https://github.cds.internal.unity3d.com/unity/2d/pull/1480

Open a new 2d URP project. Ensure 2d Pixel Perfect Package is not installed.
Right click on hierarchy to create a new Pixel Perfect Camera

![image](https://user-images.githubusercontent.com/82013253/138209516-4e3f85e7-56b2-47de-a690-8a1af961d03e.png)


---
### Comments to reviewers
Notes for the reviewers you have assigned.
