### PR TITLE
[URP] Move GraphicsSettings.useScriptableRenderPipelineBatching setup at URP creation time

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -154,6 +154,8 @@ namespace UnityEngine.Rendering.Universal
 #endif
             SetSupportedRenderingFeatures();
 
+            GraphicsSettings.useScriptableRenderPipelineBatching = asset.useSRPBatcher;
+
             // In QualitySettings.antiAliasing disabled state uses value 0, where in URP 1
             int qualitySettingsMsaaSampleCount = QualitySettings.antiAliasing > 0 ? QualitySettings.antiAliasing : 1;
             bool msaaSampleCountNeedsUpdate = qualitySettingsMsaaSampleCount != asset.msaaSampleCount;
@@ -237,7 +239,6 @@ namespace UnityEngine.Rendering.Universal
 
             GraphicsSettings.lightsUseLinearIntensity = (QualitySettings.activeColorSpace == ColorSpace.Linear);
             GraphicsSettings.lightsUseColorTemperature = true;
-            GraphicsSettings.useScriptableRenderPipelineBatching = asset.useSRPBatcher;
             GraphicsSettings.defaultRenderingLayerMask = k_DefaultRenderingLayerMask;
             SetupPerFrameShaderConstants();
 #if ENABLE_VR && ENABLE_XR_MODULE


### PR DESCRIPTION
### Purpose of this PR
Fix for https://fogbugz.unity3d.com/f/cases/1368853/

Currently URP resets GraphicsSettings.useScriptableRenderPipelineBatching every frame, overriding any changes done by user API calls

HDRP already only sets this value up only at pipeline creation:
https://sourcegraph.ds.unity3d.com/github.com/Unity-Technologies/Graphics/-/blob/com.unity[…]inition/Runtime/RenderPipeline/HDRenderPipeline.cs?L500

---
### Testing status
tested the case repro project

---
### Comments to reviewers

