### PR TITLE
Add info on After post-process info box

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/SurfaceOptionUIBlock.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/SurfaceOptionUIBlock.cs
@@ -142,7 +142,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
             public static GUIContent opaqueCullModeText = new GUIContent("Cull Mode", "For opaque objects, change the cull mode of the object.");
 
-            public static string afterPostProcessInfoBox = "If After post-process don't render, make sure they are enabled in the frame settings.\nAfter post-process material wont be ZTested. Enable the \"ZTest For After PostProcess\" checkbox in the Frame Settings to force the depth-test if the TAA is disabled.";
+            public static string afterPostProcessInfoBox = "If After post-process objects don't render, make sure to enable \"After Post-process\" in the frame settings.\nAfter post-process material wont be ZTested. Enable the \"ZTest For After PostProcess\" checkbox in the Frame Settings to force the depth-test if the TAA is disabled.";
 
             public static readonly GUIContent[] displacementModeLitNames = new GUIContent[] { new GUIContent("None"), new GUIContent("Vertex displacement"), new GUIContent("Pixel displacement") };
             public static readonly int[] displacementModeLitValues = new int[] { (int)DisplacementMode.None, (int)DisplacementMode.Vertex, (int)DisplacementMode.Pixel };


### PR DESCRIPTION
"Fix" for https://fogbugz.unity3d.com/f/cases/1371340/ . The bug itself does not repro, but the issue stems from the fact that by default after PP is off in frame settings. 

Added a new line to the info box to hopefully point the user in the right direction. 

**What did I test**: the repro package. 

Also I don't think we need to kick yamato for this as it is text only change. 