### PR TITLE
[HDRP][DOCS][DXR] Update ray/path tracing docs regarding custom interpolator limitations

### DIFF
--- a/com.unity.render-pipelines.high-definition/Documentation~/Ray-Tracing-Getting-Started.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Ray-Tracing-Getting-Started.md
@@ -268,6 +268,7 @@ When building your custom shaders using shader graph, some nodes are incompatibl
 - DDX, DDY and DDXY nodes.
 - All the nodes under Inputs > Geometry (Position, View Direction, Normal, etc.) in View Space mode.
 - Checkerboard node.
+Furthermore, Shader Graphs that use [Custom Interpolators](../../com.unity.shadergraph/Documentation~/Custom-Interpolators.md) are not supported in ray tracing.
 
 ### Unsupported features of path tracing
 

--- a/com.unity.render-pipelines.high-definition/Documentation~/Ray-Tracing-Path-Tracing.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Ray-Tracing-Path-Tracing.md
@@ -109,6 +109,7 @@ HDRP path tracing in Unity 2020.2 has the following limitations:
 - If a Mesh in your scene has a Material assigned that does not have the `HDRenderPipeline` tag, the mesh will not appear in your scene. For more information, see [Ray tracing and Meshes](Ray-Tracing-Getting-Started.md#RayTracingMeshes).
 - Does not support 3D Text and TextMeshPro.
 - Does not support Shader Graph nodes that use derivatives (for example, a normal map that derives from a texture).
+- Does not support Shader Graphs that use [Custom Interpolators](../../com.unity.shadergraph/Documentation~/Custom-Interpolators.md).
 - Does not support decals.
 - Does not support tessellation.
 - Does not support Tube and Disc-shaped Area Lights.


### PR DESCRIPTION
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1374675/

Update the ray/path tracing docs regarding limitations in the support of Shader Graphs that use custom interpolator.

### Comments to reviewers
It is possible in theory to support Shader Graphs with custom interpolators in ray/path tracing, so perhaps we should add this in our backlog and fix it at some point. For now I'm just updating the docs.
