### PR TITLE
Clean up Public API Documentation

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.cs
@@ -483,7 +483,6 @@ namespace UnityEngine.Rendering.HighDefinition
         }
 
         /// <summary>
-        /// <summary>
         /// Returns true if camera visibility is frozen.
         /// </summary>
         /// <returns>True if camera visibility is frozen</returns>

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/AtmosphericScattering/Fog.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/AtmosphericScattering/Fog.cs
@@ -126,7 +126,7 @@ namespace UnityEngine.Rendering.HighDefinition
         private ClampedFloatParameter m_VolumetricFogBudget = new ClampedFloatParameter(0.25f, 0.0f, 1.0f);
 
         /// <summary>Controls how Unity shares resources between Screen (XY) and Depth (Z) resolutions.</summary>
-        /// <remarks>A value of 0 means Unity allocates all of the resources to the XY resolution, which reduces aliasing, but increases noise. A value of 1 means Unity allocates all of the resources to the Z resolution, which reduces noise, but increases aliasing. This property allows for linear interpolation between the two configurations.<remarks>
+        /// <remarks>A value of 0 means Unity allocates all of the resources to the XY resolution, which reduces aliasing, but increases noise. A value of 1 means Unity allocates all of the resources to the Z resolution, which reduces noise, but increases aliasing. This property allows for linear interpolation between the two configurations.</remarks>
         public float resolutionDepthRatio
         {
             get
@@ -138,6 +138,8 @@ namespace UnityEngine.Rendering.HighDefinition
             }
             set { m_ResolutionDepthRatio.value = value; }
         }
+
+        /// <summary>Controls how Unity shares resources between Screen (XY) and Depth (Z) resolutions.</summary>
         [AdditionalProperty]
         [SerializeField, FormerlySerializedAs("resolutionDepthRatio")]
         [Tooltip("Controls how Unity shares resources between Screen (x-axis and y-axis) and Depth (z-axis) resolutions.")]

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/HDRenderPipeline.VolumetricCloudsLighting.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/HDRenderPipeline.VolumetricCloudsLighting.cs
@@ -107,7 +107,7 @@ namespace UnityEngine.Rendering.HighDefinition
             }
         }
 
-        public static void OnComputeAmbientProbeDone(AsyncGPUReadbackRequest request)
+        static void OnComputeAmbientProbeDone(AsyncGPUReadbackRequest request)
         {
             if (!request.hasError)
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.PostProcess.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.PostProcess.cs
@@ -4079,7 +4079,7 @@ namespace UnityEngine.Rendering.HighDefinition
         }
 
         // Returns color balance coefficients in the LMS space
-        public static Vector3 GetColorBalanceCoeffs(float temperature, float tint)
+        static Vector3 GetColorBalanceCoeffs(float temperature, float tint)
         {
             // Range ~[-1.5;1.5] works best
             float t1 = temperature / 65f;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingManager.cs
@@ -217,18 +217,10 @@ namespace UnityEngine.Rendering.HighDefinition
         /// </summary>
         /// <param name="targetRTAS">Ray Tracing Acceleration structure the renderer should be added to.</param>
         /// <param name="currentRenderer">The renderer that should be added to the RTAS.</param>
-        /// <param name="rayTracedShadow">Flag that defines if at least one light has ray traced shadows.</param>
-        /// <param name="aoEnabled">Flag that defines if ray traced ambient occlusion will be evaluated using this RTAS.</param>
-        /// <param name="aoLayerValue">Layer mask to include objects into the ray traced ambient occlusion.</param>
-        /// <param name="reflEnabled">Flag that defines if ray traced reflections will be evaluated using this RTAS.</param>
-        /// <param name="reflLayerValue">Layer mask to include objects into the ray traced reflections.</param>
-        /// <param name="giEnabled">Flag that defines if ray traced global illumination will be evaluated using this RTAS.</param>
-        /// <param name="giLayerValue">Layer mask to include objects into the ray traced global illumination.</param>
-        /// <param name="recursiveEnabled">Flag that defines if recursive rendering will be evaluated using this RTAS.</param>
-        /// <param name="rrLayerValue">Layer mask to include objects into the recursive rendering.</param>
-        /// <param name="pathTracingEnabled">Flag that defines if path tracing will be evaluated using this RTAS.</param>
-        /// <param name="ptLayerValue">Layer mask to include objects into the path tracing.</param>
-        /// <returns>AccelerationStructureStatus type.</returns>
+        /// <param name="effectsParameters">Structure defining the enabled ray tracing and path tracing effects for a camera.</param>
+        /// <param name="transformDirty">Flag that indicates if the renderer's transform has changed.</param>
+        /// <param name="materialsDirty">Flag that indicates if any of the renderer's materials have changed.</param>
+        /// <returns></returns>
         public static AccelerationStructureStatus AddInstanceToRAS(RayTracingAccelerationStructure targetRTAS, Renderer currentRenderer, HDEffectsParameters effectsParameters, ref bool transformDirty, ref bool materialsDirty)
         {
             // Get all the materials of the mesh renderer
@@ -463,7 +455,14 @@ namespace UnityEngine.Rendering.HighDefinition
                 + m_RayTracingLights.reflectionProbeArray.Count;
         }
 
-        static public HDEffectsParameters EvaluateEffectsParameters(HDCamera hdCamera, bool rayTracedShadows, bool rayTracedContactShadows)
+        /// <summary>
+        /// Function that returns the ray tracing and path tracing effects that are enabled for a given camera.
+        /// </summary>
+        /// <param name="hdCamera">The input camera</param>
+        /// <param name="rayTracedShadows">Flag that defines if at least one light has ray traced shadows.</param>
+        /// <param name="rayTracedContactShadows">Flag that defines if at least one light has ray traced contact shadows</param>
+        /// <returns>HDEffectsParameters type.</returns>
+        public static HDEffectsParameters EvaluateEffectsParameters(HDCamera hdCamera, bool rayTracedShadows, bool rayTracedContactShadows)
         {
             HDEffectsParameters parameters = new HDEffectsParameters();
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Utility/HDUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Utility/HDUtils.cs
@@ -19,8 +19,10 @@ namespace UnityEngine.Rendering.HighDefinition
         internal const PerObjectData k_RendererConfigurationBakedLightingWithShadowMask = k_RendererConfigurationBakedLighting | PerObjectData.OcclusionProbe | PerObjectData.OcclusionProbeProxyVolume | PerObjectData.ShadowMask;
 
         /// <summary>Returns the render configuration for baked static lighting, this value can be used in a RendererListDesc call to render Lit objects.</summary>
+        /// <returns></returns>
         public static PerObjectData GetBakedLightingRenderConfig() => k_RendererConfigurationBakedLighting;
         /// <summary>Returns the render configuration for baked static lighting with shadow masks, this value can be used in a RendererListDesc call to render Lit objects when shadow masks are enabled.</summary>
+        /// <returns></returns>
         public static PerObjectData GetBakedLightingWithShadowMaskRenderConfig() => k_RendererConfigurationBakedLightingWithShadowMask;
 
         /// <summary>Default HDAdditionalReflectionData</summary>


### PR DESCRIPTION
### Purpose of this PR
This PR cleans up the API documentation so that we are again passing the documentation tool validation.

Before:
![image](https://user-images.githubusercontent.com/28882975/138955030-0e079987-0423-4f57-b294-5b60cc503655.png)

After:
![image](https://user-images.githubusercontent.com/28882975/138955118-e105840e-5fac-436f-80c1-25977dabaf90.png)

---
### Testing status
Running Yamato just in case the access level change I made on one function doesn't cause any issues to the tests. 

---
### Comments to reviewers
Adding Anis just for awareness as I update documentation related to acceleration structure / fog.
