### PR TITLE
Update occlusion radius for directional light sample

### DIFF
--- a/com.unity.render-pipelines.high-definition/Samples~/LensFlareSamples/ExampleDirectionalLight.unity
+++ b/com.unity.render-pipelines.high-definition/Samples~/LensFlareSamples/ExampleDirectionalLight.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 688.0918, g: 738.20264, b: 723.74976, a: 1}
+  m_IndirectSpecularColor: {r: 687.1787, g: 737.74316, b: 735.8723, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -195,6 +195,7 @@ MonoBehaviour:
   m_Profile: {fileID: 11400000, guid: 621d000f3cc3e774ea8675637c871a5b, type: 2}
   m_StaticLightingSkyUniqueID: 4
   m_StaticLightingCloudsUniqueID: 0
+  m_StaticLightingVolumetricClouds: 0
 --- !u!4 &268609154
 Transform:
   m_ObjectHideFlags: 1
@@ -630,7 +631,7 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   useOcclusion: 1
-  occlusionRadius: 90
+  occlusionRadius: 0.73
   sampleCount: 32
   occlusionOffset: 0
   scale: 1
@@ -864,7 +865,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isGlobal: 1
+  m_IsGlobal: 1
   priority: 0
   blendDistance: 0
   weight: 1
@@ -932,10 +933,12 @@ MonoBehaviour:
   taaAntiFlicker: 0.5
   taaMotionVectorRejection: 0
   taaAntiHistoryRinging: 0
+  taaBaseBlendFactor: 0.875
   physicalParameters:
     m_Iso: 200
     m_ShutterSpeed: 0.005
     m_Aperture: 16
+    m_FocusDistance: 10
     m_BladeCount: 5
     m_Curvature: {x: 2, y: 11}
     m_BarrelClipping: 0.25


### PR DESCRIPTION
**Purpose of this PR**

Updating the occlusion radius for the directional light sample after bugfix PR [Making Flare occlusion radius consistent for directional lights regardless of far plane](https://github.com/Unity-Technologies/Graphics/pull/5643).
