### PR TITLE
Changes to help with scene reloading when SRP code changes

### DIFF
--- a/com.unity.render-pipelines.core/Runtime/BatchRenderer/RenderBRG.cs
+++ b/com.unity.render-pipelines.core/Runtime/BatchRenderer/RenderBRG.cs
@@ -797,6 +797,7 @@ namespace UnityEngine.Rendering
 
     public class RenderBRG : MonoBehaviour
     {
+        private static bool s_QueryLoadedScenes = true;
         private Dictionary<Scene, SceneBRG> m_Scenes = new();
 
         private void OnEnable()
@@ -805,6 +806,17 @@ namespace UnityEngine.Rendering
             SceneManager.sceneUnloaded += OnSceneUnloaded;
 
             List<Scene> toAdd = new List<Scene>();
+
+            //During play mode, if we reload the render pipeline, this will help during restart to reparse any previously loaded scenes.
+            if (s_QueryLoadedScenes)
+            {
+                for (int s = 0; s < SceneManager.sceneCount; ++s)
+                {
+                    toAdd.Add(SceneManager.GetSceneAt(s));
+                }
+                s_QueryLoadedScenes = false;
+            }
+
             foreach (var sceneBrg in m_Scenes)
             {
                 if (sceneBrg.Value == null)
@@ -851,6 +863,9 @@ namespace UnityEngine.Rendering
 
         private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
+            if (m_Scenes.TryGetValue(scene, out var existingBRG) && existingBRG != null)
+                return;
+
             var renderers = new List<MeshRenderer>();
             foreach (var go in scene.GetRootGameObjects())
                 GetValidChildRenderers(go, renderers);


### PR DESCRIPTION
### Purpose of this PR
Fixing workflow issue when SRP reloading occurs.
The problem is that all managed and static members (such as the m_Scenes member of the RenderBRG) get blown away when you do a code change in the SRP.

This causes during the next restart of OnEnable to not load any of the previous geometry (since m_Scenes gets completely restarted)

I added a static bool to check the very first BRG that gets instantiated, to suck all the scenes already loaded.

This introduces the caveat that if the user adds the BRG in a sub scene, then this one will consequently add all the scenes to it.

If this behaviour is not desired then im open to new suggestions :)

Tested:
Setting breakpoints. Discovered this issue while working on visibility.
