### PR TITLE
Re-enable reverted RPGlobalSettings tests 

### DIFF
--- a/com.unity.render-pipelines.high-definition/Tests/Editor/HDGlobalSettingsTests.cs
+++ b/com.unity.render-pipelines.high-definition/Tests/Editor/HDGlobalSettingsTests.cs
@@ -1,0 +1,79 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+
+namespace UnityEngine.Rendering.HighDefinition.Tests
+{
+    public class HDGlobalSettingsTests : MonoBehaviour
+    {
+        HDRenderPipelineGlobalSettings initialGlobalSettings;
+        HDRenderPipelineGlobalSettings otherGlobalSettings;
+
+
+        [SetUp]
+        public void SetUp()
+        {
+            UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.DefaultGameObjects);
+            otherGlobalSettings = ScriptableObject.CreateInstance<HDRenderPipelineGlobalSettings>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ScriptableObject.DestroyImmediate(otherGlobalSettings);
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene);
+        }
+
+        void EnsureHDRPIsActivePipeline()
+        {
+            Camera.main.Render();
+            initialGlobalSettings = HDRenderPipelineGlobalSettings.instance;
+            Assert.IsInstanceOf<HDRenderPipeline>(RenderPipelineManager.currentPipeline);
+            Assert.IsNotNull(initialGlobalSettings);
+        }
+
+        [Test]
+        public void HDRPFrameRendered_GlobalSettingsShouldBeAssigned()
+        {
+            EnsureHDRPIsActivePipeline();
+        }
+
+        [Test]
+        public void HDRPFrameRendered_EnsureGlobalSettingsIfNullAssigned()
+        {
+            EnsureHDRPIsActivePipeline();
+
+            HDRenderPipelineGlobalSettings.UpdateGraphicsSettings(null);
+            Assert.IsNull(HDRenderPipelineGlobalSettings.instance);
+
+            Camera.main.Render();
+            Assert.IsNotNull(HDRenderPipelineGlobalSettings.instance);
+        }
+
+        [Test]
+        [Description("Case 1342987 - Support undo on Global Settings assignation ")]
+        public void Undo_HDRPActive_ChangeGlobalSettings()
+        {
+            EnsureHDRPIsActivePipeline();
+            Undo.IncrementCurrentGroup();
+            HDRenderPipelineGlobalSettings.UpdateGraphicsSettings(otherGlobalSettings);
+            Assert.AreEqual(otherGlobalSettings, HDRenderPipelineGlobalSettings.instance);
+
+            Undo.PerformUndo();
+            Assert.AreEqual(initialGlobalSettings, HDRenderPipelineGlobalSettings.instance);
+        }
+
+        [Test]
+        [Description("Case 1342987 - Support undo on Global Settings assignation ")]
+        public void Undo_HDRPActive_UnregisterGlobalSettings()
+        {
+            EnsureHDRPIsActivePipeline();
+            Undo.IncrementCurrentGroup();
+            HDRenderPipelineGlobalSettings.UpdateGraphicsSettings(null);
+            Assert.IsNull(HDRenderPipelineGlobalSettings.instance);
+
+            Undo.PerformUndo();
+            Assert.AreEqual(initialGlobalSettings, HDRenderPipelineGlobalSettings.instance);
+        }
+    }
+}

--- a/com.unity.render-pipelines.high-definition/Tests/Editor/HDGlobalSettingsTests.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Tests/Editor/HDGlobalSettingsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1180ed5f2a1913498d7741201dd18bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/Tests/Editor/UniversalGlobalSettingsTests.cs
+++ b/com.unity.render-pipelines.universal/Tests/Editor/UniversalGlobalSettingsTests.cs
@@ -1,0 +1,81 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+using UnityEditor.Rendering.Universal.Internal;
+using UnityEngine.Experimental.Rendering.Universal;
+using UnityEngine.TestTools;
+using UnityEditor.SceneManagement;
+
+class UniversalGlobalSettingsTests
+{
+    UniversalRenderPipelineGlobalSettings initialGlobalSettings;
+    UniversalRenderPipelineGlobalSettings otherGlobalSettings;
+
+    [SetUp]
+    public void SetUp()
+    {
+        UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.DefaultGameObjects);
+        otherGlobalSettings = ScriptableObject.CreateInstance<UniversalRenderPipelineGlobalSettings>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        ScriptableObject.DestroyImmediate(otherGlobalSettings);
+        EditorSceneManager.NewScene(NewSceneSetup.EmptyScene);
+    }
+
+    void EnsureUniversalRPIsActivePipeline()
+    {
+        Camera.main.Render();
+        initialGlobalSettings = UniversalRenderPipelineGlobalSettings.instance;
+        Assert.IsInstanceOf<UniversalRenderPipeline>(RenderPipelineManager.currentPipeline);
+        Assert.IsNotNull(initialGlobalSettings);
+    }
+
+    [Test]
+    public void URPFrameRendered_GlobalSettingsShouldBeAssigned()
+    {
+        EnsureUniversalRPIsActivePipeline();
+    }
+
+    [Test]
+    public void URPFrameRendered_EnsureGlobalSettingsIfNullAssigned()
+    {
+        EnsureUniversalRPIsActivePipeline();
+
+        UniversalRenderPipelineGlobalSettings.UpdateGraphicsSettings(null);
+        Assert.IsNull(UniversalRenderPipelineGlobalSettings.instance);
+
+        Camera.main.Render();
+        Assert.IsNotNull(UniversalRenderPipelineGlobalSettings.instance);
+    }
+
+    [Test]
+    [Description("Case 1342987 - Support undo on Global Settings assignation ")]
+    public void Undo_URPActive_ChangeGlobalSettings()
+    {
+        EnsureUniversalRPIsActivePipeline();
+        Undo.IncrementCurrentGroup();
+        UniversalRenderPipelineGlobalSettings.UpdateGraphicsSettings(otherGlobalSettings);
+        Assert.AreEqual(otherGlobalSettings, UniversalRenderPipelineGlobalSettings.instance);
+
+        Undo.PerformUndo();
+        Assert.AreEqual(initialGlobalSettings, UniversalRenderPipelineGlobalSettings.instance);
+    }
+
+    [Test]
+    [Description("Case 1342987 - Support undo on Global Settings assignation ")]
+    public void Undo_UPActive_UnregisterGlobalSettings()
+    {
+        EnsureUniversalRPIsActivePipeline();
+        Undo.IncrementCurrentGroup();
+        UniversalRenderPipelineGlobalSettings.UpdateGraphicsSettings(null);
+        Assert.IsNull(UniversalRenderPipelineGlobalSettings.instance);
+
+        Undo.PerformUndo();
+        Assert.AreEqual(initialGlobalSettings, UniversalRenderPipelineGlobalSettings.instance);
+    }
+}

--- a/com.unity.render-pipelines.universal/Tests/Editor/UniversalGlobalSettingsTests.cs.meta
+++ b/com.unity.render-pipelines.universal/Tests/Editor/UniversalGlobalSettingsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59559b7e05a876a45bd815c6e5e874e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR
Re-enable tests that were backed out in #5548.

The bug https://fogbugz.unity3d.com/f/cases/1365351/ that required us to remove tests has now been fixed, so we can re-enable the tests.

---
### Testing status
Verifying that the test can be enabled by ensuring that "HDRP on Win_DX11_editmode_mono_Linear" does not print following error message:

```
[02:15:30.878 Information] LogEntry
	severity: Warning
	message: 2 TextureIDs were not freed
```
Example of a test that would cause Katana (and Srp2Core) to fail: https://unity-ci.cds.internal.unity3d.com/job/8560876

---
### Comments to reviewers
@theo-pnv is it possible to ensure that this type of problem would cause a Yamato failure? Currently it's possible this test is green in Yamato but red in Katana, and will cause confusion in the future.
