### PR TITLE
Fix immutable assets issue

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Materials/Decal.mat
+++ b/com.unity.render-pipelines.universal/Runtime/Materials/Decal.mat
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  version: 4
+  version: 5
 --- !u!21 &2100000
 Material:
   serializedVersion: 6


### PR DESCRIPTION
### Purpose of this PR

From current srp2core PR tests ([link](https://bokken-artifacts-ui.bf.unity3d.com/katana-production/proj0-Test_EditorTests_-_Windows64Editor___WindowsStandaloneSupport/44153430_05_11_2021_10_37_16_+0000/build/ReportedArtifacts/TestReport.html)):
```
The package cache was invalidated and rebuilt because the following immutable asset(s) were unexpectedly altered:
  Packages/com.unity.render-pipelines.universal/Runtime/Materials/Decal.mat
```

This PR is regenerating the material to fix the issue.

---
### Testing status
Rerunning the failing builder using these changes in the srp2core branch.
