### PR TITLE
[URP] Port HDRP Mip Bias Logic to URP

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -224,8 +224,7 @@ namespace UnityEngine.Rendering.Universal
             // Calculate a bias value which corrects the mip lod selection logic when image scaling is active.
             // We clamp this value to 0.0 or less to make sure we don't end up reducing image detail in the downsampling case.
             float mipBias = Math.Min((float)-Math.Log(cameraWidth / scaledCameraWidth, 2.0f), 0.0f);
-            cmd.SetGlobalFloat(ShaderPropertyId.globalMipBias, mipBias);
-            cmd.SetGlobalFloat(ShaderPropertyId.globalMipBiasPow2, Mathf.Pow(2.0f, mipBias));
+            cmd.SetGlobalVector(ShaderPropertyId.globalMipBias, new Vector2(mipBias, Mathf.Pow(2.0f, mipBias)));
 
             //Set per camera matrices.
             SetCameraMatrices(cmd, ref cameraData, true);

--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -221,6 +221,12 @@ namespace UnityEngine.Rendering.Universal
 
             cmd.SetGlobalVector(ShaderPropertyId.screenSize, new Vector4(cameraWidth, cameraHeight, 1.0f / cameraWidth, 1.0f / cameraHeight));
 
+            // Calculate a bias value which corrects the mip lod selection logic when image scaling is active.
+            // We clamp this value to 0.0 or less to make sure we don't end up reducing image detail in the downsampling case.
+            float mipBias = Math.Min((float)-Math.Log(cameraWidth / scaledCameraWidth, 2.0f), 0.0f);
+            cmd.SetGlobalFloat(ShaderPropertyId.globalMipBias, mipBias);
+            cmd.SetGlobalFloat(ShaderPropertyId.globalMipBiasPow2, Mathf.Pow(2.0f, mipBias));
+
             //Set per camera matrices.
             SetCameraMatrices(cmd, ref cameraData, true);
         }

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -311,7 +311,6 @@ namespace UnityEngine.Rendering.Universal
         public static readonly int zBufferParams = Shader.PropertyToID("_ZBufferParams");
         public static readonly int orthoParams = Shader.PropertyToID("unity_OrthoParams");
         public static readonly int globalMipBias = Shader.PropertyToID("_GlobalMipBias");
-        public static readonly int globalMipBiasPow2 = Shader.PropertyToID("_GlobalMipBiasPow2");
 
         public static readonly int screenSize = Shader.PropertyToID("_ScreenSize");
 

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -310,6 +310,8 @@ namespace UnityEngine.Rendering.Universal
         public static readonly int projectionParams = Shader.PropertyToID("_ProjectionParams");
         public static readonly int zBufferParams = Shader.PropertyToID("_ZBufferParams");
         public static readonly int orthoParams = Shader.PropertyToID("unity_OrthoParams");
+        public static readonly int globalMipBias = Shader.PropertyToID("_GlobalMipBias");
+        public static readonly int globalMipBiasPow2 = Shader.PropertyToID("_GlobalMipBiasPow2");
 
         public static readonly int screenSize = Shader.PropertyToID("_ScreenSize");
 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl
@@ -103,6 +103,77 @@
     #define GATHER_BLUE_TEXTURE2D_X(textureName, samplerName, coord2)       GATHER_BLUE_TEXTURE2D(textureName, samplerName, coord2)
 #endif
 
+///
+/// Texture Sampling Macro Overrides for Scaling
+///
+/// When mip bias is supported by the underlying platform, the following section redefines all 2d texturing operations to support a global mip bias feature.
+/// This feature is used to improve rendering quality when image scaling is active. It achieves this by adding a bias value to the standard mip lod calculation
+/// which allows us to select the mip level based on the final image resolution rather than the current rendering resolution.
+
+#ifdef PLATFORM_SAMPLE_TEXTURE2D_BIAS
+    #ifdef  SAMPLE_TEXTURE2D
+        #undef  SAMPLE_TEXTURE2D
+        #define SAMPLE_TEXTURE2D(textureName, samplerName, coord2) \
+            PLATFORM_SAMPLE_TEXTURE2D_BIAS(textureName, samplerName, coord2,  _GlobalMipBias)
+    #endif
+    #ifdef  SAMPLE_TEXTURE2D_BIAS
+        #undef  SAMPLE_TEXTURE2D_BIAS
+        #define SAMPLE_TEXTURE2D_BIAS(textureName, samplerName, coord2, bias) \
+            PLATFORM_SAMPLE_TEXTURE2D_BIAS(textureName, samplerName, coord2,  (bias + _GlobalMipBias))
+    #endif
+#endif
+
+#ifdef PLATFORM_SAMPLE_TEXTURE2D_GRAD
+    #ifdef  SAMPLE_TEXTURE2D_GRAD
+        #undef  SAMPLE_TEXTURE2D_GRAD
+        #define SAMPLE_TEXTURE2D_GRAD(textureName, samplerName, coord2, dpdx, dpdy) \
+            PLATFORM_SAMPLE_TEXTURE2D_GRAD(textureName, samplerName, coord2, (dpdx * _GlobalMipBiasPow2), (dpdy * _GlobalMipBiasPow2))
+    #endif
+#endif
+
+#ifdef PLATFORM_SAMPLE_TEXTURE2D_ARRAY_BIAS
+    #ifdef  SAMPLE_TEXTURE2D_ARRAY
+        #undef  SAMPLE_TEXTURE2D_ARRAY
+        #define SAMPLE_TEXTURE2D_ARRAY(textureName, samplerName, coord2, index) \
+            PLATFORM_SAMPLE_TEXTURE2D_ARRAY_BIAS(textureName, samplerName, coord2, index, _GlobalMipBias)
+    #endif
+    #ifdef  SAMPLE_TEXTURE2D_ARRAY_BIAS
+        #undef  SAMPLE_TEXTURE2D_ARRAY_BIAS
+        #define SAMPLE_TEXTURE2D_ARRAY_BIAS(textureName, samplerName, coord2, index, bias) \
+            PLATFORM_SAMPLE_TEXTURE2D_ARRAY_BIAS(textureName, samplerName, coord2, index, (bias + _GlobalMipBias))
+    #endif
+#endif
+
+#ifdef PLATFORM_SAMPLE_TEXTURECUBE_BIAS
+    #ifdef  SAMPLE_TEXTURECUBE
+        #undef  SAMPLE_TEXTURECUBE
+        #define SAMPLE_TEXTURECUBE(textureName, samplerName, coord3) \
+            PLATFORM_SAMPLE_TEXTURECUBE_BIAS(textureName, samplerName, coord3, _GlobalMipBias)
+    #endif
+    #ifdef  SAMPLE_TEXTURECUBE_BIAS
+        #undef  SAMPLE_TEXTURECUBE_BIAS
+        #define SAMPLE_TEXTURECUBE_BIAS(textureName, samplerName, coord3, bias) \
+            PLATFORM_SAMPLE_TEXTURECUBE_BIAS(textureName, samplerName, coord3, (bias + _GlobalMipBias))
+    #endif
+#endif
+
+#ifdef PLATFORM_SAMPLE_TEXTURECUBE_ARRAY_BIAS
+
+    #ifdef  SAMPLE_TEXTURECUBE_ARRAY
+        #undef  SAMPLE_TEXTURECUBE_ARRAY
+        #define SAMPLE_TEXTURECUBE_ARRAY(textureName, samplerName, coord3, index)\
+            PLATFORM_SAMPLE_TEXTURECUBE_ARRAY_BIAS(textureName, samplerName, coord3, index, _GlobalMipBias)
+    #endif
+
+    #ifdef  SAMPLE_TEXTURECUBE_ARRAY_BIAS
+        #undef  SAMPLE_TEXTURECUBE_ARRAY_BIAS
+        #define SAMPLE_TEXTURECUBE_ARRAY_BIAS(textureName, samplerName, coord3, index, bias)\
+            PLATFORM_SAMPLE_TEXTURECUBE_ARRAY_BIAS(textureName, samplerName, coord3, index, (bias + _GlobalMipBias))
+    #endif
+#endif
+
+#define VT_GLOBAL_MIP_BIAS_MULTIPLIER (_GlobalMipBiasPow2)
+
 // Structs
 struct VertexPositionInputs
 {

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl
@@ -114,12 +114,12 @@
     #ifdef  SAMPLE_TEXTURE2D
         #undef  SAMPLE_TEXTURE2D
         #define SAMPLE_TEXTURE2D(textureName, samplerName, coord2) \
-            PLATFORM_SAMPLE_TEXTURE2D_BIAS(textureName, samplerName, coord2,  _GlobalMipBias)
+            PLATFORM_SAMPLE_TEXTURE2D_BIAS(textureName, samplerName, coord2,  _GlobalMipBias.x)
     #endif
     #ifdef  SAMPLE_TEXTURE2D_BIAS
         #undef  SAMPLE_TEXTURE2D_BIAS
         #define SAMPLE_TEXTURE2D_BIAS(textureName, samplerName, coord2, bias) \
-            PLATFORM_SAMPLE_TEXTURE2D_BIAS(textureName, samplerName, coord2,  (bias + _GlobalMipBias))
+            PLATFORM_SAMPLE_TEXTURE2D_BIAS(textureName, samplerName, coord2,  (bias + _GlobalMipBias.x))
     #endif
 #endif
 
@@ -127,7 +127,7 @@
     #ifdef  SAMPLE_TEXTURE2D_GRAD
         #undef  SAMPLE_TEXTURE2D_GRAD
         #define SAMPLE_TEXTURE2D_GRAD(textureName, samplerName, coord2, dpdx, dpdy) \
-            PLATFORM_SAMPLE_TEXTURE2D_GRAD(textureName, samplerName, coord2, (dpdx * _GlobalMipBiasPow2), (dpdy * _GlobalMipBiasPow2))
+            PLATFORM_SAMPLE_TEXTURE2D_GRAD(textureName, samplerName, coord2, (dpdx * _GlobalMipBias.y), (dpdy * _GlobalMipBias.y))
     #endif
 #endif
 
@@ -135,12 +135,12 @@
     #ifdef  SAMPLE_TEXTURE2D_ARRAY
         #undef  SAMPLE_TEXTURE2D_ARRAY
         #define SAMPLE_TEXTURE2D_ARRAY(textureName, samplerName, coord2, index) \
-            PLATFORM_SAMPLE_TEXTURE2D_ARRAY_BIAS(textureName, samplerName, coord2, index, _GlobalMipBias)
+            PLATFORM_SAMPLE_TEXTURE2D_ARRAY_BIAS(textureName, samplerName, coord2, index, _GlobalMipBias.x)
     #endif
     #ifdef  SAMPLE_TEXTURE2D_ARRAY_BIAS
         #undef  SAMPLE_TEXTURE2D_ARRAY_BIAS
         #define SAMPLE_TEXTURE2D_ARRAY_BIAS(textureName, samplerName, coord2, index, bias) \
-            PLATFORM_SAMPLE_TEXTURE2D_ARRAY_BIAS(textureName, samplerName, coord2, index, (bias + _GlobalMipBias))
+            PLATFORM_SAMPLE_TEXTURE2D_ARRAY_BIAS(textureName, samplerName, coord2, index, (bias + _GlobalMipBias.x))
     #endif
 #endif
 
@@ -148,12 +148,12 @@
     #ifdef  SAMPLE_TEXTURECUBE
         #undef  SAMPLE_TEXTURECUBE
         #define SAMPLE_TEXTURECUBE(textureName, samplerName, coord3) \
-            PLATFORM_SAMPLE_TEXTURECUBE_BIAS(textureName, samplerName, coord3, _GlobalMipBias)
+            PLATFORM_SAMPLE_TEXTURECUBE_BIAS(textureName, samplerName, coord3, _GlobalMipBias.x)
     #endif
     #ifdef  SAMPLE_TEXTURECUBE_BIAS
         #undef  SAMPLE_TEXTURECUBE_BIAS
         #define SAMPLE_TEXTURECUBE_BIAS(textureName, samplerName, coord3, bias) \
-            PLATFORM_SAMPLE_TEXTURECUBE_BIAS(textureName, samplerName, coord3, (bias + _GlobalMipBias))
+            PLATFORM_SAMPLE_TEXTURECUBE_BIAS(textureName, samplerName, coord3, (bias + _GlobalMipBias.x))
     #endif
 #endif
 
@@ -162,17 +162,17 @@
     #ifdef  SAMPLE_TEXTURECUBE_ARRAY
         #undef  SAMPLE_TEXTURECUBE_ARRAY
         #define SAMPLE_TEXTURECUBE_ARRAY(textureName, samplerName, coord3, index)\
-            PLATFORM_SAMPLE_TEXTURECUBE_ARRAY_BIAS(textureName, samplerName, coord3, index, _GlobalMipBias)
+            PLATFORM_SAMPLE_TEXTURECUBE_ARRAY_BIAS(textureName, samplerName, coord3, index, _GlobalMipBias.x)
     #endif
 
     #ifdef  SAMPLE_TEXTURECUBE_ARRAY_BIAS
         #undef  SAMPLE_TEXTURECUBE_ARRAY_BIAS
         #define SAMPLE_TEXTURECUBE_ARRAY_BIAS(textureName, samplerName, coord3, index, bias)\
-            PLATFORM_SAMPLE_TEXTURECUBE_ARRAY_BIAS(textureName, samplerName, coord3, index, (bias + _GlobalMipBias))
+            PLATFORM_SAMPLE_TEXTURECUBE_ARRAY_BIAS(textureName, samplerName, coord3, index, (bias + _GlobalMipBias.x))
     #endif
 #endif
 
-#define VT_GLOBAL_MIP_BIAS_MULTIPLIER (_GlobalMipBiasPow2)
+#define VT_GLOBAL_MIP_BIAS_MULTIPLIER (_GlobalMipBias.y)
 
 // Structs
 struct VertexPositionInputs

--- a/com.unity.render-pipelines.universal/ShaderLibrary/UnityInput.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/UnityInput.hlsl
@@ -59,6 +59,12 @@ float4 _ProjectionParams;
 // w = 1 + 1.0/height
 float4 _ScreenParams;
 
+// Mip Bias
+float _GlobalMipBias;
+
+// 2.0 ^ [Mip Bias]
+float _GlobalMipBiasPow2;
+
 // Values used to linearize the Z buffer (http://www.humus.name/temp/Linearize%20depth.txt)
 // x = 1-far/near
 // y = far/near

--- a/com.unity.render-pipelines.universal/ShaderLibrary/UnityInput.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/UnityInput.hlsl
@@ -59,11 +59,9 @@ float4 _ProjectionParams;
 // w = 1 + 1.0/height
 float4 _ScreenParams;
 
-// Mip Bias
-float _GlobalMipBias;
-
-// 2.0 ^ [Mip Bias]
-float _GlobalMipBiasPow2;
+// x = Mip Bias
+// y = 2.0 ^ [Mip Bias]
+float2 _GlobalMipBias;
 
 // Values used to linearize the Z buffer (http://www.humus.name/temp/Linearize%20depth.txt)
 // x = 1-far/near


### PR DESCRIPTION
### Purpose of this PR
This change integrates the mip bias logic from HDRP into URP. This logic
ensures that shaders select their mips based on the final screen
resolution rather than the current render resolution. In cases where
aggressive upscaling is taking place, this can significantly improve
texture detail in the final image.

50% Scaling Before:
![image](https://user-images.githubusercontent.com/89797527/140573460-0aa4683c-079c-4d26-b8a9-e79e988e2183.png)

50% Scaling After:
![image](https://user-images.githubusercontent.com/89797527/140573470-d961f937-cca7-4ca4-bf96-bc88e1a48f9f.png)

(Best compared in separate browser tabs since the previews here are scaled)

---
### Testing status
Tested before/after on Windows and Android
No clear performance difference on mobile (Adreno 650)

---
### Comments to reviewers
This is pretty much identical to how HDRP handles the mip bias logic with the exception of it not being behind an option in URP. I removed the option since it would have created more shader permutations (as far as I know) and it doesn't seem to negatively impact performance on the mobile hardware I tested. This might not be true for lower end devices.

---
### Notes for QA
The changes in this PR will be verified for quality as part of the larger FSR PR here: https://github.com/Unity-Technologies/Graphics/pull/6262
