### PR TITLE
Fix build failing due to duplicate 2d menu name

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
@@ -9,7 +9,7 @@ namespace UnityEditor.Rendering.Universal
     {
         const int k_PixelPerfectCameraGameObjectMenuPriority = 5;
 
-        [MenuItem("GameObject/2D Object/Pixel Perfect Camera", priority = k_PixelPerfectCameraGameObjectMenuPriority)]
+        [MenuItem("GameObject/2D Object/Pixel Perfect Camera (URP)", priority = k_PixelPerfectCameraGameObjectMenuPriority)]
         static void GameObjectCreatePixelPerfectCamera(MenuCommand menuCommand)
         {
             var go = CreateGameObject("Pixel Perfect Camera", menuCommand, new[] { typeof(PixelPerfectCamera) });


### PR DESCRIPTION
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Fixes failing katana builds
https://katana.ds.unity3d.com/projects/Unity/builders/proj0-Test%20IntegrationTests%20-[…]29/builds/22410?unity_branch=graphics/vendoring/2021-11-05

https://katana.ds.unity3d.com/projects/Unity/builders/proj0-Test%20IntegrationTests%20-[…]%29/builds/9955?unity_branch=graphics/vendoring/2021-11-05

