### PR TITLE
Enables per node includes on the DecalPass.template

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/Decal/DecalPass.template
+++ b/com.unity.render-pipelines.universal/Editor/Decal/DecalPass.template
@@ -81,6 +81,9 @@ Pass
     // Graph Properties
     $splice(GraphProperties)
 
+    // Graph Includes
+    $splice(GraphIncludes)
+
     // Graph Functions
     $splice(GraphFunctions)
 


### PR DESCRIPTION
This line is also in the ShaderPass.template used by the other URP targets. 

Without it, custom function nodes referencing a file cannot be used with the decal target. 
The PR also fixes procedural shadergraph nodes (like simple noise) not compiling when used with the decal target. Reason being that the required include was not being included. 