### PR TITLE
Ignore GlobalSettings tests for non-SRP test projects

### DIFF
--- a/com.unity.render-pipelines.high-definition/Tests/Editor/HDGlobalSettingsTests.cs
+++ b/com.unity.render-pipelines.high-definition/Tests/Editor/HDGlobalSettingsTests.cs
@@ -27,6 +27,11 @@ namespace UnityEngine.Rendering.HighDefinition.Tests
         void EnsureHDRPIsActivePipeline()
         {
             Camera.main.Render();
+
+            // Skip test if project is not configured to be SRP project
+            if (RenderPipelineManager.currentPipeline == null)
+                Assert.Ignore("Test project has no SRP configured, skipping test");
+
             initialGlobalSettings = HDRenderPipelineGlobalSettings.instance;
             Assert.IsInstanceOf<HDRenderPipeline>(RenderPipelineManager.currentPipeline);
             Assert.IsNotNull(initialGlobalSettings);

--- a/com.unity.render-pipelines.universal/Tests/Editor/UniversalGlobalSettingsTests.cs
+++ b/com.unity.render-pipelines.universal/Tests/Editor/UniversalGlobalSettingsTests.cs
@@ -30,6 +30,11 @@ class UniversalGlobalSettingsTests
     void EnsureUniversalRPIsActivePipeline()
     {
         Camera.main.Render();
+
+        // Skip test if project is not configured to be SRP project
+        if (RenderPipelineManager.currentPipeline == null)
+            Assert.Ignore("Test project has no SRP configured, skipping test");
+
         initialGlobalSettings = UniversalRenderPipelineGlobalSettings.instance;
         Assert.IsInstanceOf<UniversalRenderPipeline>(RenderPipelineManager.currentPipeline);
         Assert.IsNotNull(initialGlobalSettings);


### PR DESCRIPTION
### Purpose of this PR
This PR is addressing SRP2Core issue discussed on [this slack thread](https://unity.slack.com/archives/C01P2GQGA01/p1636359928011600), where HDRP/URP GlobalSettings tests failed on Katana even though they pass on Yamato.

**Root cause analysis**
In the unity repo, EditorTests are being run in an autogenerated test project that isn't configured to have a SRP active. In contrast, all test projects we have in Graphics repo are configured to have either URP or HDRP as the active render pipeline. Because of this, our graphics tests can be written with implicit assumptions about the test projects that are valid for all Graphics repo test projects, but invalid for test projects used on Katana. This can cause unexpected failures during srp2core, such as this one: [Test EditorTests - WindowsEditor (Isolated Packages Verified)](https://katana.ds.unity3d.com/projects/Unity/builders/proj0-Test%20EditorTests%20-%20Windows64Editor%20%28Isolated%20Packages%20Verified%29/builds/90022?unity_branch=graphics/vendoring/2021-11-05).

**Fix**
HDRP/URP GlobalSettings tests assume that a corresponding SRP is active. This assumption only holds in SRP test projects, so if nothing is configured, these tests are now disabled.

---
### Testing status
Verified locally that the tests are ignored for a non-SRP test project. **Right now this kind of test is not run in Yamato, we should fix that!**

Running Yamato to ensure the tests are still running and not ignored in SRP test projects.
