### PR TITLE
[Master] Making intermediate render textures scale with the RenderScale setting when a camera renders to a texture

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed disabled debug lighting modes on Vulkan and OpenGL following a shader compiler fix. [case 1334240]
 - Fixed an issue in where the Convert Renderering Settings would cause a freeze. [case 1353885](https://issuetracker.unity3d.com/issues/urp-builtin-to-urp-render-pipeline-converter-freezes-the-editor-when-converting-rendering-settings)
 - Fixed incorrect behavior of Reflections with Smoothness lighting debug mode. [case 1374181]
+- Fixed an issue where intermediate rendertextures were not scaled when a camera was rendering to a texture [case 1342895](https://issuetracker.unity3d.com/issues/camera-rendertocubemap-offsets-and-stretches-out-the-ambient-occlusionl-layer-when-the-render-scale-is-not-equal-to-1)
 
 ## [13.1.0] - 2021-09-24
 ### Added

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -551,8 +551,8 @@ namespace UnityEngine.Rendering.Universal
             else
             {
                 desc = camera.targetTexture.descriptor;
-                desc.width = camera.pixelWidth;
-                desc.height = camera.pixelHeight;
+                desc.width = (int)((float)camera.pixelWidth * renderScale);
+                desc.height = (int)((float)camera.pixelHeight * renderScale);
                 if (camera.cameraType == CameraType.SceneView && !isHdrEnabled)
                 {
                     desc.graphicsFormat = SystemInfo.GetGraphicsFormat(DefaultFormat.LDR);


### PR DESCRIPTION
# Purpose of this PR
Fixing [issue 1342895](https://issuetracker.unity3d.com/issues/camera-rendertocubemap-offsets-and-stretches-out-the-ambient-occlusionl-layer-when-the-render-scale-is-not-equal-to-1).

Currently when a camera has a texture assigned in the **"Output Texture"** field in the Camera Inspector, intermediate textures such as SSAO, Opaque Texture, etc would not be scaled when the Render Scale setting was set to something other than 1.0. It would only scale those textures when the **"Output Texture"** was unassigned. 

This PR changes that and makes sure the intermediate textures get scaled in those cases as well before we blit to the output texture.

# Testing status
Tested locally in the Editor (MAC)

# Comments to reviewers
As this is a change in URP Core, we need to test this change thoroughly to make sure it doesn't regress anything.
