### PR TITLE
[SRP] Add warning for users that want to use pixel perfect cam with other renderers

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [13.1.1] - 2021-10-04
 
 ### Added
+- Added a warning when using Pixel Perfect Camera in SRP without a 2D Renderer and exposed RenderPipelineConverter for 2D Pixel Perfect to URP converter.
 - Added Depth Texture setting for Overlay Camera.
 - Added Depth Priming support for Vulkan with MSAA.
 - Added Shadows and Additional Lights off variants stripping.

--- a/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEditor.SceneManagement;
 using UnityEngine;
-using UnityEngine.Experimental.Rendering.Universal;
+using UnityEngine.Rendering.Universal;
 
 namespace UnityEditor.Rendering.Universal
 {

--- a/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/GameObjectCreation.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEditor.SceneManagement;
 using UnityEngine;
-using UnityEngine.Rendering.Universal;
+using UnityEngine.Experimental.Rendering.Universal;
 
 namespace UnityEditor.Rendering.Universal
 {

--- a/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
@@ -22,7 +22,7 @@ namespace UnityEditor.Rendering.Universal
             public GUIContent runInEditMode = new GUIContent("Run In Edit Mode", "Enable this to preview Camera setting changes in Edit Mode. This will cause constant changes to the Scene while active.");
             public const string cameraStackingWarning = "Pixel Perfect Camera won't function properly if stacked with another camera.";
             public const string nonRenderer2DWarning = "URP Pixel Perfect Camera requires a camera using a 2D Renderer. Some features, such as Upscale Render Texture, are not supported with other Renderers.";
-            public static GUIContent overrideUsage = EditorGUIUtility.TrTextContent("Override and Use");
+            public const string nonRenderer2DError = "URP Pixel Perfect Camera requires a camera using a 2D Renderer.";
 
             public GUIStyle centeredLabel;
 
@@ -48,7 +48,6 @@ namespace UnityEditor.Rendering.Universal
         private Vector2 m_GameViewSize = Vector2.zero;
         private GUIContent m_CurrentPixelRatioValue;
         bool m_CameraStacking;
-        static bool m_OverrideUsage = false;
 
         private void LazyInit()
         {
@@ -92,6 +91,7 @@ namespace UnityEditor.Rendering.Universal
             m_CameraStacking = false;
 
             var cameraData = GetCameraData();
+
             if (cameraData == null || cameraData.scriptableRenderer == null)
                 return;
 
@@ -135,20 +135,15 @@ namespace UnityEditor.Rendering.Universal
         {
             LazyInit();
 
-            if (!UsingRenderer2D() && !m_OverrideUsage)
+            if(!UsingSRP())
+            {
+                EditorGUILayout.HelpBox(Style.nonRenderer2DError, MessageType.Error);
+                return;
+            }
+            else if (!UsingRenderer2D())
             {
                 EditorGUILayout.HelpBox(Style.nonRenderer2DWarning, MessageType.Warning);
-
-                // Allow to override usage if using SRP
-                if (UsingSRP())
-                {
-                    EditorGUILayout.Space();
-                    if (GUILayout.Button(Style.overrideUsage))
-                        m_OverrideUsage = true;
-
-                }
-
-                return;
+                EditorGUILayout.Space();
             }
 
             float originalLabelWidth = EditorGUIUtility.labelWidth;

--- a/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
@@ -135,7 +135,7 @@ namespace UnityEditor.Rendering.Universal
         {
             LazyInit();
 
-            if(!UsingSRP())
+            if (!UsingSRP())
             {
                 EditorGUILayout.HelpBox(Style.nonRenderer2DError, MessageType.Error);
                 return;

--- a/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
@@ -21,7 +21,8 @@ namespace UnityEditor.Rendering.Universal
             public GUIContent currentPixelRatio = new GUIContent("Current Pixel Ratio", "Ratio of the rendered Sprites compared to their original size.");
             public GUIContent runInEditMode = new GUIContent("Run In Edit Mode", "Enable this to preview Camera setting changes in Edit Mode. This will cause constant changes to the Scene while active.");
             public const string cameraStackingWarning = "Pixel Perfect Camera won't function properly if stacked with another camera.";
-            public const string nonRenderer2DError = "Pixel Perfect Camera requires a camera using a 2D Renderer.";
+            public const string nonRenderer2DWarning = "Pixel Perfect Camera requires a camera using a 2D Renderer. Some features, such as Upscale Render Texture, are not supported with other Renderers.";
+            public static GUIContent overrideUsage = EditorGUIUtility.TrTextContent("Override and Use");
 
             public GUIStyle centeredLabel;
 
@@ -47,6 +48,7 @@ namespace UnityEditor.Rendering.Universal
         private Vector2 m_GameViewSize = Vector2.zero;
         private GUIContent m_CurrentPixelRatioValue;
         bool m_CameraStacking;
+        static bool m_OverrideUsage = false;
 
         private void LazyInit()
         {
@@ -124,9 +126,14 @@ namespace UnityEditor.Rendering.Universal
         {
             LazyInit();
 
-            if (!UsingRenderer2D())
+            if (!UsingRenderer2D() && !m_OverrideUsage)
             {
-                EditorGUILayout.HelpBox(Style.nonRenderer2DError, MessageType.Error);
+                EditorGUILayout.HelpBox(Style.nonRenderer2DWarning, MessageType.Warning);
+                EditorGUILayout.Space();
+
+                if (GUILayout.Button(Style.overrideUsage))
+                    m_OverrideUsage = true;
+
                 return;
             }
 

--- a/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
@@ -21,7 +21,7 @@ namespace UnityEditor.Rendering.Universal
             public GUIContent currentPixelRatio = new GUIContent("Current Pixel Ratio", "Ratio of the rendered Sprites compared to their original size.");
             public GUIContent runInEditMode = new GUIContent("Run In Edit Mode", "Enable this to preview Camera setting changes in Edit Mode. This will cause constant changes to the Scene while active.");
             public const string cameraStackingWarning = "Pixel Perfect Camera won't function properly if stacked with another camera.";
-            public const string nonRenderer2DWarning = "Pixel Perfect Camera requires a camera using a 2D Renderer. Some features, such as Upscale Render Texture, are not supported with other Renderers.";
+            public const string nonRenderer2DWarning = "URP Pixel Perfect Camera requires a camera using a 2D Renderer. Some features, such as Upscale Render Texture, are not supported with other Renderers.";
             public static GUIContent overrideUsage = EditorGUIUtility.TrTextContent("Override and Use");
 
             public GUIStyle centeredLabel;

--- a/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
@@ -59,11 +59,23 @@ namespace UnityEditor.Rendering.Universal
                 m_CurrentPixelRatioValue = new GUIContent();
         }
 
-        bool UsingRenderer2D()
+        UniversalAdditionalCameraData GetCameraData()
         {
             PixelPerfectCamera obj = target as PixelPerfectCamera;
             UniversalAdditionalCameraData cameraData = null;
             obj?.TryGetComponent(out cameraData);
+            return cameraData;
+        }
+
+        bool UsingSRP()
+        {
+            var cameraData = GetCameraData();
+            return cameraData?.scriptableRenderer != null;
+        }
+
+        bool UsingRenderer2D()
+        {
+            var cameraData = GetCameraData();
 
             if (cameraData != null)
             {
@@ -79,11 +91,8 @@ namespace UnityEditor.Rendering.Universal
         {
             m_CameraStacking = false;
 
-            PixelPerfectCamera obj = target as PixelPerfectCamera;
-            UniversalAdditionalCameraData cameraData = null;
-            obj?.TryGetComponent(out cameraData);
-
-            if (cameraData == null)
+            var cameraData = GetCameraData();
+            if (cameraData == null || cameraData.scriptableRenderer == null)
                 return;
 
             if (cameraData.renderType == CameraRenderType.Base)
@@ -129,10 +138,15 @@ namespace UnityEditor.Rendering.Universal
             if (!UsingRenderer2D() && !m_OverrideUsage)
             {
                 EditorGUILayout.HelpBox(Style.nonRenderer2DWarning, MessageType.Warning);
-                EditorGUILayout.Space();
 
-                if (GUILayout.Button(Style.overrideUsage))
-                    m_OverrideUsage = true;
+                // Allow override usage if using SRP
+                if(UsingSRP())
+                {
+                    EditorGUILayout.Space();
+                    if (GUILayout.Button(Style.overrideUsage))
+                        m_OverrideUsage = true;
+
+                }
 
                 return;
             }

--- a/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/PixelPerfectCameraEditor.cs
@@ -139,8 +139,8 @@ namespace UnityEditor.Rendering.Universal
             {
                 EditorGUILayout.HelpBox(Style.nonRenderer2DWarning, MessageType.Warning);
 
-                // Allow override usage if using SRP
-                if(UsingSRP())
+                // Allow to override usage if using SRP
+                if (UsingSRP())
                 {
                     EditorGUILayout.Space();
                     if (GUILayout.Button(Style.overrideUsage))

--- a/com.unity.render-pipelines.universal/Editor/Camera/UniversalRenderPipelineCameraUI.Drawers.cs
+++ b/com.unity.render-pipelines.universal/Editor/Camera/UniversalRenderPipelineCameraUI.Drawers.cs
@@ -61,7 +61,7 @@ namespace UnityEditor.Rendering.Universal
         static void DrawerProjection(UniversalRenderPipelineSerializedCamera p, Editor owner)
         {
             var camera = p.serializedObject.targetObject as Camera;
-            bool pixelPerfectEnabled = camera.TryGetComponent<PixelPerfectCamera>(out var pixelPerfectCamera) && pixelPerfectCamera.enabled;
+            bool pixelPerfectEnabled = camera.TryGetComponent<UnityEngine.Experimental.Rendering.Universal.PixelPerfectCamera>(out var pixelPerfectCamera) && pixelPerfectCamera.enabled;
             if (pixelPerfectEnabled)
                 EditorGUILayout.HelpBox(Styles.pixelPerfectInfo, MessageType.Info);
 

--- a/com.unity.render-pipelines.universal/Editor/Camera/UniversalRenderPipelineCameraUI.Drawers.cs
+++ b/com.unity.render-pipelines.universal/Editor/Camera/UniversalRenderPipelineCameraUI.Drawers.cs
@@ -61,7 +61,7 @@ namespace UnityEditor.Rendering.Universal
         static void DrawerProjection(UniversalRenderPipelineSerializedCamera p, Editor owner)
         {
             var camera = p.serializedObject.targetObject as Camera;
-            bool pixelPerfectEnabled = camera.TryGetComponent<UnityEngine.Experimental.Rendering.Universal.PixelPerfectCamera>(out var pixelPerfectCamera) && pixelPerfectCamera.enabled;
+            bool pixelPerfectEnabled = camera.TryGetComponent<PixelPerfectCamera>(out var pixelPerfectCamera) && pixelPerfectCamera.enabled;
             if (pixelPerfectEnabled)
                 EditorGUILayout.HelpBox(Styles.pixelPerfectInfo, MessageType.Info);
 

--- a/com.unity.render-pipelines.universal/Editor/Converter/RenderPipelineConverter.cs
+++ b/com.unity.render-pipelines.universal/Editor/Converter/RenderPipelineConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("PPv2URPConverters")]
+[assembly: InternalsVisibleTo("Unity.2D.PixelPerfect.Editor")]
 namespace UnityEditor.Rendering.Universal.Converters
 {
     // Might need to change this name before making it public

--- a/com.unity.render-pipelines.universal/Runtime/2D/PixelPerfectCamera.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/PixelPerfectCamera.cs
@@ -3,7 +3,7 @@ using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
 using UnityEngine.Scripting.APIUpdating;
 
-namespace UnityEngine.Experimental.Rendering.Universal
+namespace UnityEngine.Rendering.Universal
 {
     /// <summary>
     /// The Pixel Perfect Camera component ensures your pixel art remains crisp and clear at different resolutions, and stable in motion.

--- a/com.unity.render-pipelines.universal/Runtime/2D/PixelPerfectCamera.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/PixelPerfectCamera.cs
@@ -3,7 +3,7 @@ using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
 using UnityEngine.Scripting.APIUpdating;
 
-namespace UnityEngine.Rendering.Universal
+namespace UnityEngine.Experimental.Rendering.Universal
 {
     /// <summary>
     /// The Pixel Perfect Camera component ensures your pixel art remains crisp and clear at different resolutions, and stable in motion.


### PR DESCRIPTION
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

There are users that are using pixel perfect camera with 3d renderer and are unable to do so since we added a restriction with 2d renderer only. Added a warning for users to know that certain features will not be supported, and remove restriction from using in SRP.

Also expose RenderPipelineConverter to 2d pixel perfect package to create URP Pixel Perfect Converter in this changelist
https://github.cds.internal.unity3d.com/unity/2d/pull/1514

---
### Testing status
Describe what manual/automated tests were performed for this PR

Tested on 2022.1.0a16
Open 3D URP Template scene.
Add a Pixel Perfect Camera component to the Main Camera.
Observe warning message.
Access to use Pixel Perfect Camera component is allowed.

![Screenshot 2021-11-22 103532](https://user-images.githubusercontent.com/82013253/142794236-a2ca86ef-24d6-4a41-b77d-05fdcf8a9e6c.png)

Go to Project Settings -> Graphics -> Scriptable Render Pipeline Settings and remove Renderer Asset.
Observe error message on Pixel Perfect Camera component.

![Screenshot 2021-11-22 103427](https://user-images.githubusercontent.com/82013253/142794380-0e517644-c9dd-498a-84b5-2dd6dc26ab62.png)

Create a 2D Renderer and 2D Renderer Asset
Go to Project Settings -> Graphics -> Scriptable Render Pipeline Settings and add the 2D Renderer Asset.
Observe no error or warning messages on component

---
### Comments to reviewers
Notes for the reviewers you have assigned.
