### PR TITLE
[URP][RenderPass] Adding additional ConfigureTarget to include depth and passing "fake" depth for editor in CopyDepth

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Passes/CopyDepthPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/CopyDepthPass.cs
@@ -51,8 +51,11 @@ namespace UnityEngine.Rendering.Universal.Internal
             var isDepth = (destination.rt && destination.rt.graphicsFormat == GraphicsFormat.None);
             descriptor.graphicsFormat = isDepth ? GraphicsFormat.D32_SFloat_S8_UInt : GraphicsFormat.R32_SFloat;
             descriptor.msaaSamples = 1;
-
+#if UNITY_EDITOR
+            ConfigureTarget(destination, destination, GraphicsFormat.R32_SFloat, descriptor.width, descriptor.height, descriptor.msaaSamples);
+#else
             ConfigureTarget(destination, descriptor.graphicsFormat, descriptor.width, descriptor.height, descriptor.msaaSamples, isDepth);
+#endif
             ConfigureClear(ClearFlag.None, Color.black);
         }
 

--- a/com.unity.render-pipelines.universal/Runtime/Passes/ScriptableRenderPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/ScriptableRenderPass.cs
@@ -583,7 +583,12 @@ namespace UnityEngine.Rendering.Universal
             depthOnly = depth;
             renderTargetFormat[0] = format;
         }
+        internal void ConfigureTarget(RTHandle colorAttachment, RTHandle depthAttachment, GraphicsFormat format, int width = -1, int height = -1, int sampleCount = -1, bool depth = false)
+        {
+            ConfigureTarget(colorAttachment, format, width, height, sampleCount, depth);
+            m_DepthAttachment = depthAttachment;
 
+        }
         /// <summary>
         /// Configures render targets for this render pass. Call this instead of CommandBuffer.SetRenderTarget.
         /// This method should be called inside Configure.


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

---
Adding additional ConfigureTarget for RenderPasses, as there is currently no way to add custom-sized color AND depth, so this was coming anyway. However, DX11 has a strange issue on the editor, that the default depth buffer would be kept when the CopyDepthPass outputs color.  This passes the same target as depth as well which forces the override of default depth

### Testing status
Describe what manual/automated tests were performed for this PR

---
### Comments to reviewers
Notes for the reviewers you have assigned.
