### PR TITLE
[URP] Document Mixed Lighting in URP PostPro Tests

### DIFF
--- a/TestProjects/UniversalGraphicsTest_PostPro/Assets/Test/Editor/PostProEditorTests.cs
+++ b/TestProjects/UniversalGraphicsTest_PostPro/Assets/Test/Editor/PostProEditorTests.cs
@@ -11,6 +11,10 @@ class FoundationEditorTests
         UniversalProjectAssert.AllRenderersPostProcessing(kProjectName, expectDisabled: false);
     }
 
+    /// <summary>
+    /// The URP post processing tests expect all pipeline assets to explicitly disable mixed lighting support
+    /// since it significantly increases project build times.
+    /// </summary>
     [Test]
     public void CheckIfMixedLightingDisabled()
     {


### PR DESCRIPTION
### Purpose of this PR
This change adds a small comment to the URP PostPro tests which explains
the reasoning for an assert related to mixed lighting.

---
### Testing status
Comment only changes
