### PR TITLE
Bump packages to 14.0.0

### DIFF
--- a/.yamato/_copycat.yml
+++ b/.yamato/_copycat.yml
@@ -9,7 +9,7 @@ nightly_katana_abv_validate:
   variables:
     MANIFEST: .copycat/graphics.json
     RELEASE_BRANCH: trunk
-    SRP_VERSION: "13.1.2"
+    SRP_VERSION: "14.0.0"
   skip_checkout: true
   commands:
     - eval "$COPYCAT_1"
@@ -31,7 +31,7 @@ vendor:
   variables:
     MANIFEST: .copycat/graphics.json
     RELEASE_BRANCH: trunk
-    SRP_VERSION: "13.1.2"
+    SRP_VERSION: "14.0.0"
   skip_checkout: true
   commands:
     - eval "$COPYCAT_1"

--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [14.0.0] - 2021-11-17
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Added
+- Context menu on Volume Parameters to restore them to their default values.
+
+### Fixed
+- Fixed XR support in CoreUtils.DrawFullscreen function.
 
 ## [13.1.2] - 2021-11-05
 
@@ -17,13 +20,11 @@ The version number for this package has increased due to a version update of a r
 
 ### Fixed
 - Fixed issue when changing volume profiles at runtime with a script (case 1364256).
-- Fixed XR support in CoreUtils.DrawFullscreen function.
 
 ## [13.1.1] - 2021-10-04
 
 ### Added
 - Added support for high performant unsafe (uint only) Radix, Merge and Insertion sort algorithms on CoreUnsafeUtils.
-- Context menu on Volume Parameters to restore them to their default values.
 - Added DebugFrameTiming class that can be used by render pipelines to display CPU/GPU frame timings and bottlenecks in Rendering Debugger.
 - Added new DebugUI widget types: ProgressBarValue and ValueTuple
 - Added common support code for FSR

--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [14.0.0] - 2021-11-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.2] - 2021-11-05
 
 ### Added

--- a/com.unity.render-pipelines.core/package.json
+++ b/com.unity.render-pipelines.core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.render-pipelines.core",
   "description": "SRP Core makes it easier to create or customize a Scriptable Render Pipeline (SRP). SRP Core contains reusable code, including boilerplate code for working with platform-specific graphics APIs, utility functions for common rendering operations, and  shader libraries. The code in SRP Core is use by the High Definition Render Pipeline (HDRP) and Universal Render Pipeline (URP). If you are creating a custom SRP from scratch or customizing a prebuilt SRP, using SRP Core will save you time.",
-  "version": "13.1.2",
+  "version": "14.0.0",
   "unity": "2022.1",
   "displayName": "Core RP Library",
   "dependencies": {

--- a/com.unity.render-pipelines.high-definition-config/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition-config/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [14.0.0] - 2021-11-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.2] - 2021-11-05
 
 Version Updated

--- a/com.unity.render-pipelines.high-definition-config/package.json
+++ b/com.unity.render-pipelines.high-definition-config/package.json
@@ -1,10 +1,10 @@
 {
   "name": "com.unity.render-pipelines.high-definition-config",
   "description": "Configuration files for the High Definition Render Pipeline.",
-  "version": "13.1.2",
+  "version": "14.0.0",
   "unity": "2022.1",
   "displayName": "High Definition RP Config",
   "dependencies": {
-    "com.unity.render-pipelines.core": "13.1.2"
+    "com.unity.render-pipelines.core": "14.0.0"
   }
 }

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -6,25 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [14.0.0] - 2021-11-17
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
-
-## [13.1.2] - 2021-11-05
-
-### Added
-- Added minimal picking support for DOTS 1.0 (on parity with Hybrid Renderer V2)
+### Changed
+- Converted most TGA textures files to TIF to reduce the size of HDRP material samples.
+- Changed sample scene in HDRP material samples: add shadow transparency (raster, ray-traced, path-traced).
+- Support for encoded HDR cubemaps, configurable via the HDR Cubemap Encoding project setting.
+- The rendering order of decals that have a similar draw order value was modified. The new order should be the reverse of the previous order.
 
 ### Fixed
-- Fixed compilation errors when using Elipse, Rectangle, Polygon, Checkerboard, RoundedPolygon, RoundedRectangle in a ray tracing shader graph (case 1377610).
-- Fixed outdated documentation about supported GPUs for ray tracing (case 1375895).
-- Fixed outdated documentation about recursie ray tracing effects support (case 1374904).
-- Fixed Shadow Matte not appearing in ray tracing effects (case 1364005).
-- Fixed Crash issue when adding an area light on its own.
-- Fixed rendertarget ColorMask in Forward with virtual texturing and transparent motion vectors.
-- Fixed light unit conversion after changing mid gray value.
-- Fixed Focus distance in path traced depth of field now takes into account the focus mode setting (volume vs camera).
-- Fixed stencil buffer resolve when MSAA is enabled so that OR operator is used instead of picking the last sample.
-- Fixed Lens Flare visible when being behind a camera with Panini Projection on (case 1370214);
 - Fixed some XR devices: Pulling camera world space position from mainViewConstants instead of transform.
 - Fixed Xbox Series X compilation issue with DoF shader
 - Fixed references to reflection probes that wouldn't be cleared when unloading a scene. (case 1357459)
@@ -51,12 +39,25 @@ The version number for this package has increased due to a version update of a r
 - Fixed dirtiness handling in path tracing, when using multiple cameras at once (case 1376940).
 - Fixed taa jitter for after post process materials (case 1380967).
 
+## [13.1.2] - 2021-11-05
+
+### Added
+- Added minimal picking support for DOTS 1.0 (on parity with Hybrid Renderer V2)
+
+### Fixed
+- Fixed compilation errors when using Elipse, Rectangle, Polygon, Checkerboard, RoundedPolygon, RoundedRectangle in a ray tracing shader graph (case 1377610).
+- Fixed outdated documentation about supported GPUs for ray tracing (case 1375895).
+- Fixed outdated documentation about recursie ray tracing effects support (case 1374904).
+- Fixed Shadow Matte not appearing in ray tracing effects (case 1364005).
+- Fixed Crash issue when adding an area light on its own.
+- Fixed rendertarget ColorMask in Forward with virtual texturing and transparent motion vectors.
+- Fixed light unit conversion after changing mid gray value.
+- Fixed Focus distance in path traced depth of field now takes into account the focus mode setting (volume vs camera).
+- Fixed stencil buffer resolve when MSAA is enabled so that OR operator is used instead of picking the last sample.
+- Fixed Lens Flare visible when being behind a camera with Panini Projection on (case 1370214);
+
 ### Changed
 - Optimizations for the physically based depth of field.
-- Converted most TGA textures files to TIF to reduce the size of HDRP material samples.
-- Changed sample scene in HDRP material samples: add shadow transparency (raster, ray-traced, path-traced).
-- Support for encoded HDR cubemaps, configurable via the HDR Cubemap Encoding project setting.
-- The rendering order of decals that have a similar draw order value was modified. The new order should be the reverse of the previous order.
 
 ## [13.1.1] - 2021-10-04
 

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [14.0.0] - 2021-11-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.2] - 2021-11-05
 
 ### Added

--- a/com.unity.render-pipelines.high-definition/package.json
+++ b/com.unity.render-pipelines.high-definition/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.render-pipelines.high-definition",
   "description": "The High Definition Render Pipeline (HDRP) is a high-fidelity Scriptable Render Pipeline built by Unity to target modern (Compute Shader compatible) platforms. HDRP utilizes Physically-Based Lighting techniques, linear lighting, HDR lighting, and a configurable hybrid Tile/Cluster deferred/Forward lighting architecture and gives you the tools you need to create games, technical demos, animations, and more to a high graphical standard.",
-  "version": "13.1.2",
+  "version": "14.0.0",
   "unity": "2022.1",
   "displayName": "High Definition RP",
   "dependencies": {
@@ -11,10 +11,10 @@
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.imageconversion": "1.0.0",
     "com.unity.modules.terrain": "1.0.0",
-    "com.unity.render-pipelines.core": "13.1.2",
-    "com.unity.shadergraph": "13.1.2",
-    "com.unity.visualeffectgraph": "13.1.2",
-    "com.unity.render-pipelines.high-definition-config": "13.1.2"
+    "com.unity.render-pipelines.core": "14.0.0",
+    "com.unity.shadergraph": "14.0.0",
+    "com.unity.visualeffectgraph": "14.0.0",
+    "com.unity.render-pipelines.high-definition-config": "14.0.0"
   },
   "keywords": [
     "graphics",

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -6,16 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [14.0.0] - 2021-11-17
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Added
+- Renderer Features can now use the HelpURLAttribute to specify a documentation URL to be used in the inspector.
+- Added inspector documentation URLs to the SSAO, Decal, and Render Objects renderer features.
+- Changed "_USE_DRAW_PROCEDURAL" to be used only in vertex shader in Post Processing related shaders as they are not needed for fragment shaders. In result we now generate less shader variants.
+
+### Fixed
+- Fix shadow rendering correctly to work with shader stripping in WebGl. [case 1381881](https://issuetracker.unity3d.com/issues/webgl-urp-mesh-is-not-rendered-in-the-scene-on-webgl-build)
+- VFX: Incorrect Decal rendering when rendescale is different than one [case 1343674](https://issuetracker.unity3d.com/product/unity/issues/guid/1343674/)
+- Fixed inspector documentation URLs for the URP asset and Universal Renderer asset.
 
 ## [13.1.2] - 2021-11-05
 
 ### Added
 - Added minimal picking support for DOTS 1.0 (on parity with Hybrid Renderer V2)
 - Added support for `RTHandle`.
-- Renderer Features can now use the HelpURLAttribute to specify a documentation URL to be used in the inspector.
-- Added inspector documentation URLs to the SSAO, Decal, and Render Objects renderer features.
 
 ### Changed
 - Converted internal render targets to use `RTHandle` targets instead of `RenderTargetHandle` and `RenderTargetIdentifier`.
@@ -33,14 +38,11 @@ The version number for this package has increased due to a version update of a r
 - Fixed an issue with MSAA falling back to the incorrect value when sample count 2 is not supported on some Android GPUs
 - Fixed decals to work with native render pass [case 1353141](https://issuetracker.unity3d.com/issues/urp-decals-are-not-visible-in-game-view-after-modifying-urp-asset-properties)
 - Fixed decals to work with render scale [1353885](https://issuetracker.unity3d.com/issues/urp-builtin-to-urp-render-pipeline-converter-freezes-the-editor-when-converting-rendering-settings)
-- Fix shadow rendering correctly to work with shader stripping in WebGl. [case 1381881](https://issuetracker.unity3d.com/issues/webgl-urp-mesh-is-not-rendered-in-the-scene-on-webgl-build)
-- VFX: Incorrect Decal rendering when rendescale is different than one [case 1343674](https://issuetracker.unity3d.com/product/unity/issues/guid/1343674/)
-- Fixed inspector documentation URLs for the URP asset and Universal Renderer asset.
-
+- Fixed an issue in where the _ScreenParams is not setup correctly.
+- Fixed an issue where intermediate rendertextures were not scaled when a camera was rendering to a texture [case 1342895](https://issuetracker.unity3d.com/issues/camera-rendertocubemap-offsets-and-stretches-out-the-ambient-occlusionl-layer-when-the-render-scale-is-not-equal-to-1)
 ## [13.1.1] - 2021-10-04
 
 ### Added
-- Added a warning when using Pixel Perfect Camera in SRP without a 2D Renderer and exposed RenderPipelineConverter for 2D Pixel Perfect to URP converter.
 - Added Depth Texture setting for Overlay Camera.
 - Added Depth Priming support for Vulkan with MSAA.
 - Added Shadows and Additional Lights off variants stripping.
@@ -58,7 +60,6 @@ The version number for this package has increased due to a version update of a r
 - Multiply blend now keeps DstAlpha as it's RGB only.
 - Particle AlphaModulate() renamed to AlphaModulateAndPremultiply() as it does both. Moved separate AlphaModulate() and AlphaPremultiply() to URP shader library. Fix double alpha multiply for ParticleLit.
 - Improved blending modes trigger a material update which tries to keep the existing look intact. This is not always possible and manual blend mode changes might be required.
-- Changed "_USE_DRAW_PROCEDURAL" to be used only in vertex shader in Post Processing related shaders as they are not needed for fragment shaders. In result we now generate less shader variants.
 
 ### Fixed
 - Fixed incorrect premultiply blend mode. case 1260085, case 1357703, [case 1347301](https://issuetracker.unity3d.com/product/unity/issues/guid/1347301/)
@@ -73,8 +74,6 @@ The version number for this package has increased due to a version update of a r
 - Fixed disabled debug lighting modes on Vulkan and OpenGL following a shader compiler fix. [case 1334240]
 - Fixed an issue in where the Convert Renderering Settings would cause a freeze. [case 1353885](https://issuetracker.unity3d.com/issues/urp-builtin-to-urp-render-pipeline-converter-freezes-the-editor-when-converting-rendering-settings)
 - Fixed incorrect behavior of Reflections with Smoothness lighting debug mode. [case 1374181]
-- Fixed an issue in where the _ScreenParams is not setup correctly.
-- Fixed an issue where intermediate rendertextures were not scaled when a camera was rendering to a texture [case 1342895](https://issuetracker.unity3d.com/issues/camera-rendertocubemap-offsets-and-stretches-out-the-ambient-occlusionl-layer-when-the-render-scale-is-not-equal-to-1)
 
 ## [13.1.0] - 2021-09-24
 ### Added

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [14.0.0] - 2021-11-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.2] - 2021-11-05
 
 ### Added

--- a/com.unity.render-pipelines.universal/ValidationExceptions.json
+++ b/com.unity.render-pipelines.universal/ValidationExceptions.json
@@ -2,12 +2,12 @@
   "Exceptions": [
     {
       "ValidationTest": "Package Lifecycle Validation",
-      "ExceptionError": "Package com.unity.render-pipelines.universal@13.1.1 depends on package com.unity.burst@1.5.0 which is in an invalid track for release purposes. Release versions can only depend on Release versions.",
-      "PackageVersion": "13.1.2"
+      "ExceptionError": "Package com.unity.render-pipelines.universal@14.0.0depends on package com.unity.burst@1.5.0 which is in an invalid track for release purposes. Release versions can only depend on Release versions.",
+      "PackageVersion": "14.0.0"
     },
     {
       "ValidationTest": "API Updater Configuration Validation",
-      "PackageVersion": "13.1.2"
+      "PackageVersion": "14.0.0"
     }
   ]
 }

--- a/com.unity.render-pipelines.universal/package.json
+++ b/com.unity.render-pipelines.universal/package.json
@@ -1,14 +1,14 @@
 {
   "name": "com.unity.render-pipelines.universal",
   "description": "The Universal Render Pipeline (URP) is a prebuilt Scriptable Render Pipeline, made by Unity. URP provides artist-friendly workflows that let you quickly and easily create optimized graphics across a range of platforms, from mobile to high-end consoles and PCs.",
-  "version": "13.1.2",
+  "version": "14.0.0",
   "unity": "2022.1",
   "displayName": "Universal RP",
   "dependencies": {
     "com.unity.mathematics": "1.2.1",
     "com.unity.burst": "1.5.0",
-    "com.unity.render-pipelines.core": "13.1.2",
-    "com.unity.shadergraph": "13.1.2"
+    "com.unity.render-pipelines.core": "14.0.0",
+    "com.unity.shadergraph": "14.0.0"
   },
   "keywords": [
     "graphics",

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [14.0.0] - 2021-11-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.2] - 2021-11-05
 
 ### Fixed

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -6,14 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [14.0.0] - 2021-11-17
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed
+ - Gradient field doesn't support HDR values [Case 1381867](https://issuetracker.unity3d.com/product/unity/issues/guid/1381867/)
+ - Fixed the behavior of checkerboard node with raytracing
 
 ## [13.1.2] - 2021-11-05
 
 ### Fixed
  - Fixed a recent regression in ShaderGraph Screen Position behavior on some platforms in Built-in, Universal and HDRP [1369450]
- - Gradient field doesn't support HDR values [Case 1381867](https://issuetracker.unity3d.com/product/unity/issues/guid/1381867/)
 
 ## [13.1.1] - 2021-10-04
 
@@ -41,7 +41,6 @@ The version number for this package has increased due to a version update of a r
  - Fixed missing shader keyword stage during keyword copying.
  - Fixed a ShaderGraph warning when connecting a node using Object Space BiTangent to the vertex stage [1361512] (https://issuetracker.unity3d.com/issues/shader-graph-cross-implicit-truncation-of-vector-type-errors-are-thrown-when-connecting-transform-node-to-vertex-block)
  - Fixed upgrade warnings on SpeedTree8 subgraphs.
- - Fixed the behavior of checkerboard node with raytracing
 
 ## [13.1.0] - 2021-09-24
 

--- a/com.unity.shadergraph/package.json
+++ b/com.unity.shadergraph/package.json
@@ -1,11 +1,11 @@
 {
   "name": "com.unity.shadergraph",
   "description": "The Shader Graph package adds a visual Shader editing tool to Unity. You can use this tool to create Shaders in a visual way instead of writing code. Specific render pipelines can implement specific graph features. Currently, both the High Definition Rendering Pipeline and the Universal Rendering Pipeline support Shader Graph.",
-  "version": "13.1.2",
+  "version": "14.0.0",
   "unity": "2022.1",
   "displayName": "Shader Graph",
   "dependencies": {
-    "com.unity.render-pipelines.core": "13.1.2",
+    "com.unity.render-pipelines.core": "14.0.0",
     "com.unity.searcher": "4.9.1"
   },
   "samples": [

--- a/com.unity.testing.graphics-performance/package.json
+++ b/com.unity.testing.graphics-performance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.testing.graphics-performance",
   "displayName": "Performance Graphics Tests Framework",
-  "version": "13.1.2",
+  "version": "14.0.0",
   "unity": "2022.1",
   "unityRelease": "0a7",
   "description": "Provides performance framework helpers for writing tests for graphics code, such as test scene asset description, performance performance report and shader static analysis.",

--- a/com.unity.testing.visualeffectgraph/package.json
+++ b/com.unity.testing.visualeffectgraph/package.json
@@ -1,12 +1,12 @@
 {
   "name": "com.unity.testing.visualeffectgraph",
   "displayName": "Visual Effect Graphic Tests",
-  "version": "13.1.2",
+  "version": "14.0.0",
   "unity": "2022.1",
   "unityRelease": "0a7",
   "description": "This package contains common graphics tests from several scriptable renderpipeline",
   "dependencies": {
-    "com.unity.visualeffectgraph": "13.1.2",
+    "com.unity.visualeffectgraph": "14.0.0",
     "com.unity.testframework.graphics": "7.8.11-preview",
     "com.unity.testing.graphics-performance": "8.0.0",
     "com.unity.test-framework": "1.1.29"

--- a/com.unity.visualeffectgraph/CHANGELOG.md
+++ b/com.unity.visualeffectgraph/CHANGELOG.md
@@ -6,14 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [14.0.0] - 2021-11-17
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed
+- Gradient field doesn't support HDR values [Case 1381867](https://issuetracker.unity3d.com/product/unity/issues/guid/1381867/)
 
 ## [13.1.2] - 2021-11-05
 
 ### Fixed
 - Removed extra nodes in Ribbon template. [Case 1355602](https://issuetracker.unity3d.com/product/unity/issues/guid/1355602/)
-- Gradient field doesn't support HDR values [Case 1381867](https://issuetracker.unity3d.com/product/unity/issues/guid/1381867/)
 
 ## [13.1.1] - 2021-10-04
 ### Added

--- a/com.unity.visualeffectgraph/CHANGELOG.md
+++ b/com.unity.visualeffectgraph/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [14.0.0] - 2021-11-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.2] - 2021-11-05
 
 ### Fixed

--- a/com.unity.visualeffectgraph/package.json
+++ b/com.unity.visualeffectgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.visualeffectgraph",
   "displayName": "Visual Effect Graph",
-  "version": "13.1.2",
+  "version": "14.0.0",
   "unity": "2022.1",
   "description": "The Visual Effect Graph is a node based visual effect editor. It allows you to author next generation visual effects that Unity simulates directly on the GPU. The Visual Effect Graph is production-ready for the High Definition Render Pipeline and runs on all platforms supported by it. Full support for the Universal Render Pipeline and compatible mobile devices is still in development.",
   "keywords": [
@@ -12,8 +12,8 @@
     "particles"
   ],
   "dependencies": {
-    "com.unity.shadergraph": "13.1.2",
-    "com.unity.render-pipelines.core": "13.1.2"
+    "com.unity.shadergraph": "14.0.0",
+    "com.unity.render-pipelines.core": "14.0.0"
   },
   "samples": [
     {


### PR DESCRIPTION
### Purpose of this PR

- Bumped packages to 14.0.0
- Retro updated the changelogs and moved all changes since Nov. 17th (date of the last graphics code vendoring) to the new section.

---
### Testing status
Packages tests