### PR TITLE
Scriptable Renderer: Dismiss depth slice for non-camera passes check

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -1290,7 +1290,7 @@ namespace UnityEngine.Rendering.Universal
                 }
 
                 // Condition (m_CameraDepthTarget!=BuiltinRenderTextureType.CameraTarget) below prevents m_FirstTimeCameraDepthTargetIsBound flag from being reset during non-camera passes (such as Color Grading LUT). This ensures that in those cases, cameraDepth will actually be cleared during the later camera pass.
-                if (m_CameraDepthTarget.nameID != BuiltinRenderTextureType.CameraTarget && (passDepthAttachment.nameID == m_CameraDepthTarget.nameID || passColorAttachment.nameID == m_CameraDepthTarget.nameID) && m_FirstTimeCameraDepthTargetIsBound)
+                if (new RenderTargetIdentifier(m_CameraDepthTarget.nameID, 0, depthSlice: 0) != BuiltinRenderTextureType.CameraTarget && (passDepthAttachment.nameID == m_CameraDepthTarget.nameID || passColorAttachment.nameID == m_CameraDepthTarget.nameID) && m_FirstTimeCameraDepthTargetIsBound)
                 {
                     m_FirstTimeCameraDepthTargetIsBound = false;
 


### PR DESCRIPTION
Scriptable Renderer: Dismiss depth slice for non-camera passes check

The RTHandles conversion puts the XR depth slice for SPI (-1) on all
targets at an earlier stage. All equals checks against CameraTarget must
dismiss possible depth slice to be accurate.

This fixes a depth non-clear in vfx BatchRenderGroup_URP tests by
preventing `m_FirstTimeCameraDepthTargetIsBound` from being set to `false`
before batch opaque draw call.

Should solve FogBugz 1384429 and 1385046

