### PR TITLE
[ShaderGraph] [2021.2] Fix for 1383046

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Version Updated
 The version number for this package has increased due to a version update of a related graphics package.
 
+### Fixed
+  - Fixed a validation error in ShaderGraph when using the SimpleNoise node both inside and outside a subgraph [1383046] (https://issuetracker.unity3d.com/issues/validation-error-is-usually-thrown-when-simple-noise-node-is-both-in-a-shadergraph-and-in-a-sub-graph)
+
 ## [12.1.2] - 2021-10-22
 
 ### Fixed

--- a/com.unity.shadergraph/Editor/Data/Util/FunctionRegistry.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/FunctionRegistry.cs
@@ -55,7 +55,9 @@ namespace UnityEditor.ShaderGraph
             var startIndex = builder.length;
             generator(builder);
             var length = builder.length - startIndex;
-            var code = builder.ToString(startIndex, length);
+
+            // trim fixes mismatched whitespace issue when nodes come from subgraphs
+            var code = builder.ToString(startIndex, length).Trim();
 
             // validate some assumptions around generics
             bool isGenericName = name.Contains("$");


### PR DESCRIPTION
### Purpose of this PR
Fixing https://fogbugz.unity3d.com/f/cases/1383046/
This issue is already fixed in 2022.1+ via this much larger PR:
- #5491

However we don't want to backport that PR.

This PR addresses just this specific issue for 2021.2.

The issue in 2021.2 is that the functions coming from this node get whitespace appended to them when they are in a subgraph, and it detects the whitespace as a different function.

I added a call to trim the whitespace from all functions before comparing them.

---
### Testing status
Tested against repro case: colliding functions no longer collide.
Ran ShaderGraph tests locally (PC D3D11) -- success.

Yamato tests:
ShaderGraph: 🟡 
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/2021.2%252Fsg%252Ffix%252F1383046/.yamato%252Fall-shadergraph.yml%2523PR_ShaderGraph_2021.2/10259680/job/pipeline

Master:
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/2021.2%252Fsg%252Ffix%252F1383046/.yamato%252Fall-shadergraph.yml%2523PR_ShaderGraph_2021.2/10266213/job/pipeline

Same jobs failing in master (Linux Vulkan & Windows DX11) -- tracked down to an upgrade from GTX gpus to RTX gpus on the test farm, changing the behavior of the sin() HLSL function, so not related to this PR.

URP: 🟢
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/2021.2%252Fsg%252Ffix%252F1383046/.yamato%252Fall-universal_split.yml%2523PR_Universal_Split_2021.2/10369086/job/pipeline

---
### Comments to reviewers
Notes for the reviewers you have assigned.
