### PR TITLE
Universal/fix shader paths

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineEditorResources.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineEditorResources.cs
@@ -38,7 +38,10 @@ namespace UnityEngine.Rendering.Universal
             [Reload("Runtime/Materials/Lit.mat")]
             public Material lit;
 
-            [Reload("Runtime/Materials/ParticlesLit.mat")]
+            // particleLit is the URP default material for new particle systems.
+            // ParticlesUnlit.mat is closest match to the built-in shader.
+            // This is correct (current 22.2) despite the Lit/Unlit naming conflict.
+            [Reload("Runtime/Materials/ParticlesUnlit.mat")]
             public Material particleLit;
 
             [Reload("Runtime/Materials/TerrainLit.mat")]

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineEditorResources.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineEditorResources.cs
@@ -7,13 +7,13 @@ namespace UnityEngine.Rendering.Universal
         [Serializable, ReloadGroup]
         public sealed class ShaderResources
         {
-            [Reload("Shaders/Autodesk Interactive/Autodesk Interactive.shadergraph")]
+            [Reload("Shaders/Autodesk Interactive/AutodeskInteractive.shadergraph")]
             public Shader autodeskInteractivePS;
 
-            [Reload("Shaders/Autodesk Interactive/Autodesk Interactive Transparent.shadergraph")]
+            [Reload("Shaders/Autodesk Interactive/AutodeskInteractiveTransparent.shadergraph")]
             public Shader autodeskInteractiveTransparentPS;
 
-            [Reload("Shaders/Autodesk Interactive/Autodesk Interactive Masked.shadergraph")]
+            [Reload("Shaders/Autodesk Interactive/AutodeskInteractiveMasked.shadergraph")]
             public Shader autodeskInteractiveMaskedPS;
 
             [Reload("Shaders/Terrain/TerrainDetailLit.shader")]

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineEditorResources.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineEditorResources.cs
@@ -7,13 +7,13 @@ namespace UnityEngine.Rendering.Universal
         [Serializable, ReloadGroup]
         public sealed class ShaderResources
         {
-            [Reload("Shaders/Autodesk Interactive/AutodeskInteractive.shadergraph")]
+            [Reload("Shaders/AutodeskInteractive/AutodeskInteractive.shadergraph")]
             public Shader autodeskInteractivePS;
 
-            [Reload("Shaders/Autodesk Interactive/AutodeskInteractiveTransparent.shadergraph")]
+            [Reload("Shaders/AutodeskInteractive/AutodeskInteractiveTransparent.shadergraph")]
             public Shader autodeskInteractiveTransparentPS;
 
-            [Reload("Shaders/Autodesk Interactive/AutodeskInteractiveMasked.shadergraph")]
+            [Reload("Shaders/AutodeskInteractive/AutodeskInteractiveMasked.shadergraph")]
             public Shader autodeskInteractiveMaskedPS;
 
             [Reload("Shaders/Terrain/TerrainDetailLit.shader")]


### PR DESCRIPTION
### Purpose of this PR
Fix URP shader resource reload paths.

---
### Testing status
Manually tested URP EditorResources "Reload All". No errors after this fix.