### PR TITLE
Fix suggested names in Secondary Textures tab of Sprite Editor

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/2D/Renderer2DDataAuthoring.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Renderer2DDataAuthoring.cs
@@ -106,7 +106,7 @@ namespace UnityEngine.Rendering.Universal
             m_LightBlendStyles[3].blendMode = Light2DBlendStyle.BlendMode.Additive;
             m_LightBlendStyles[3].maskTextureChannel = Light2DBlendStyle.TextureChannel.R;
 
-            // Initialize Editor Prefs for Sprite Editor 
+            // Initialize Editor Prefs for Sprite Editor
             InitalizeSpriteEditorPrefs();
         }
 

--- a/com.unity.render-pipelines.universal/Runtime/2D/Renderer2DDataAuthoring.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Renderer2DDataAuthoring.cs
@@ -44,7 +44,7 @@ namespace UnityEngine.Rendering.Universal
             return null;
         }
 
-        private void OnEnableInEditor()
+        private void InitalizeSpriteEditorPrefs()
         {
             // Provide a list of suggested texture property names to Sprite Editor via EditorPrefs.
             const string suggestedNamesKey = "SecondarySpriteTexturePropertyNames";
@@ -75,6 +75,7 @@ namespace UnityEngine.Rendering.Universal
 
         private void Awake()
         {
+            // Initialize Light Blend Styles
             if (m_LightBlendStyles != null)
             {
                 for (int i = 0; i < m_LightBlendStyles.Length; ++i)
@@ -104,6 +105,9 @@ namespace UnityEngine.Rendering.Universal
             m_LightBlendStyles[3].name = "Additive with Mask";
             m_LightBlendStyles[3].blendMode = Light2DBlendStyle.BlendMode.Additive;
             m_LightBlendStyles[3].maskTextureChannel = Light2DBlendStyle.TextureChannel.R;
+
+            // Initialize Editor Prefs for Sprite Editor 
+            InitalizeSpriteEditorPrefs();
         }
 
 #endif

--- a/com.unity.render-pipelines.universal/Runtime/2D/Renderer2DDataAuthoring.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Renderer2DDataAuthoring.cs
@@ -44,7 +44,7 @@ namespace UnityEngine.Rendering.Universal
             return null;
         }
 
-        private void InitalizeSpriteEditorPrefs()
+        private void InitializeSpriteEditorPrefs()
         {
             // Provide a list of suggested texture property names to Sprite Editor via EditorPrefs.
             const string suggestedNamesKey = "SecondarySpriteTexturePropertyNames";
@@ -107,7 +107,7 @@ namespace UnityEngine.Rendering.Universal
             m_LightBlendStyles[3].maskTextureChannel = Light2DBlendStyle.TextureChannel.R;
 
             // Initialize Editor Prefs for Sprite Editor
-            InitalizeSpriteEditorPrefs();
+            InitializeSpriteEditorPrefs();
         }
 
 #endif


### PR DESCRIPTION
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Code was accidentally removed during a refactor which removed suggested names from showing in the Sprite Editor

---
### Testing status
Describe what manual/automated tests were performed for this PR

Open up a 2D URP Project.
Add a Sprite to the Project.
Open up Sprite Editor.
![image](https://user-images.githubusercontent.com/82013253/144986652-d22a9e79-c06e-4f97-8548-2beb960575ee.png)

Navigate to Secondary Textures tab.
Add a secondary texture and ensure the suggested dropdown box is present with _MaskTex and _NormalMap
![image](https://user-images.githubusercontent.com/82013253/144986751-4eb2d4bc-0f0f-4fc7-aa6f-d992cfd895d3.png)


---
### Comments to reviewers
Notes for the reviewers you have assigned.
