### PR TITLE
Universal, Fix Swap Buffer Issue

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/RenderTargetBufferSystem.cs
+++ b/com.unity.render-pipelines.universal/Runtime/RenderTargetBufferSystem.cs
@@ -110,7 +110,7 @@ namespace UnityEngine.Rendering.Universal.Internal
 
         public RTHandle GetBufferA()
         {
-            return m_A.rtMSAA;
+            return (m_AllowMSAA && m_A.msaa > 1) ? m_A.rtMSAA : m_A.rtResolve;
         }
 
         public void EnableMSAA(bool enable)


### PR DESCRIPTION
While writing custom Scriptable Render Features, 
I stumbled upon a `Dimensions of color surface does not match dimensions of depth surface` error.

After some digging, I noticed that in the `UniversalRenderer`, line 1196 in `SwapColorBuffer`, we have:
`ConfigureCameraTarget(m_ColorBufferSystem.GetBackBuffer(cmd), m_ColorBufferSystem.GetBufferA());`

In some cases, this would result in `m_CameraColorTarget` and `m_CameraDepthTarget` RTs having different dimensions.

The cause is that when invoking `GetBufferA` on `RenderTargetBufferSystem`,
if msaa is not used, the `RTHandle` we get may not have been reallocated with the proper dimensions.

Indeed, in the `RenderTargetBufferSystem.ReAllocate`,
we do not reallocate the msaa rtHandles if msaa is not used (`!(desc.msaaSamples > 1)`).
So previously allocated msaa targets (with different dimensions) survive and later get used,
assigned as depth target through `GetBufferA()`.

While my fix seems to work,
I'm not very familiar with this area and will let you determine if it is indeed the right way to fix it.
I'm not sure I understand the introduction/use/implementation of `GetBufferA()` to begin with.
(It is only used in one place afaik.)