### PR TITLE
[URP] Disabling depth resolve temporarily on OSX because of gfx driver issues

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/RenderingUtils.cs
+++ b/com.unity.render-pipelines.universal/Runtime/RenderingUtils.cs
@@ -485,6 +485,11 @@ namespace UnityEngine.Rendering.Universal
 
         internal static bool MultisampleDepthResolveSupported()
         {
+            // Temporarily disabling depth resolve a driver bug on OSX when using some AMD graphics cards. Temporarily disabling depth resolve on that platform
+            // TODO: re-enable once the issue is investigated/fixed
+            if (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)
+                return false;
+
             // Should we also check if the format has stencil and check stencil resolve capability only in that case?
             return SystemInfo.supportsMultisampleResolveDepth && SystemInfo.supportsMultisampleResolveStencil;
         }


### PR DESCRIPTION
---
### Purpose of this PR
We can consistently reproduce an issue with depth MSAA resolve on OSX platforms using AMD Radeon Pro 5500M.
The resolved depth looks rasterized in wireframe mode.

XCode GPU capture:

![image](https://user-images.githubusercontent.com/69153427/145377730-85df8621-9dff-4ecb-8442-b85a14dbb5bf.png)

Unity Frame Debugger:

![image](https://user-images.githubusercontent.com/69153427/145377828-e2959b45-413d-486c-9d9c-0d43f6086d29.png)

This PR temporarily disable depth resolve on OSX as a workaround, while the driver issue is being investigated

---
### Testing status
Locally on OSX Editor, OSX Player, iOS, AMD Radeon Pro 5500 M card, UHD Intel card

---
### Comments to reviewers
