### PR TITLE
[RPW] Fix crash when upgrading URP Global Settings when no render has been done

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -1205,7 +1205,7 @@ namespace UnityEngine.Rendering.Universal
 
             if (asset.k_AssetPreviousVersion < 10)
             {
-                UniversalRenderPipelineGlobalSettings.instance.shaderVariantLogLevel = (Rendering.ShaderVariantLogLevel) asset.m_ShaderVariantLogLevel;
+                UniversalRenderPipelineGlobalSettings.Ensure().shaderVariantLogLevel = (Rendering.ShaderVariantLogLevel) asset.m_ShaderVariantLogLevel;
                 asset.k_AssetPreviousVersion = 10;
             }
 


### PR DESCRIPTION
Null reference exception while migratting an URP asset to global settings.

Fix for issue introduced on: https://github.com/Unity-Technologies/Graphics/pull/6305

By making Ensure, we obtain the correct instance,(as if the instance is null, and no URP global settings have been created is created one)
