### PR TITLE
Bump all packages to 13.1.5

### DIFF
--- a/.yamato/_copycat.yml
+++ b/.yamato/_copycat.yml
@@ -9,7 +9,7 @@ nightly_katana_abv_validate:
   variables:
     MANIFEST: .copycat/graphics.json
     RELEASE_BRANCH: 2022.1/staging
-    SRP_VERSION: "5"
+    SRP_VERSION: "13.1.5"
   skip_checkout: true
   commands:
     - eval "$COPYCAT_1"

--- a/.yamato/_copycat.yml
+++ b/.yamato/_copycat.yml
@@ -9,7 +9,7 @@ nightly_katana_abv_validate:
   variables:
     MANIFEST: .copycat/graphics.json
     RELEASE_BRANCH: 2022.1/staging
-    SRP_VERSION: "13.1.4"
+    SRP_VERSION: "5"
   skip_checkout: true
   commands:
     - eval "$COPYCAT_1"
@@ -31,7 +31,7 @@ vendor:
   variables:
     MANIFEST: .copycat/graphics.json
     RELEASE_BRANCH: 2022.1/staging
-    SRP_VERSION: "13.1.4"
+    SRP_VERSION: "13.1.5"
   skip_checkout: true
   commands:
     - eval "$COPYCAT_1"

--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [13.1.5] - 2021-12-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.4] - 2021-12-04
 
 ### Fixed

--- a/com.unity.render-pipelines.core/package.json
+++ b/com.unity.render-pipelines.core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.render-pipelines.core",
   "description": "SRP Core makes it easier to create or customize a Scriptable Render Pipeline (SRP). SRP Core contains reusable code, including boilerplate code for working with platform-specific graphics APIs, utility functions for common rendering operations, and  shader libraries. The code in SRP Core is use by the High Definition Render Pipeline (HDRP) and Universal Render Pipeline (URP). If you are creating a custom SRP from scratch or customizing a prebuilt SRP, using SRP Core will save you time.",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "unity": "2022.1",
   "displayName": "Core RP Library",
   "dependencies": {

--- a/com.unity.render-pipelines.high-definition-config/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition-config/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [13.1.5] - 2021-12-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.4] - 2021-12-04
 
 Version Updated

--- a/com.unity.render-pipelines.high-definition-config/package.json
+++ b/com.unity.render-pipelines.high-definition-config/package.json
@@ -1,10 +1,10 @@
 {
   "name": "com.unity.render-pipelines.high-definition-config",
   "description": "Configuration files for the High Definition Render Pipeline.",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "unity": "2022.1",
   "displayName": "High Definition RP Config",
   "dependencies": {
-    "com.unity.render-pipelines.core": "13.1.4"
+    "com.unity.render-pipelines.core": "13.1.5"
   }
 }

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [13.1.5] - 2021-12-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.4] - 2021-12-04
 
 ### Fixed

--- a/com.unity.render-pipelines.high-definition/package.json
+++ b/com.unity.render-pipelines.high-definition/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.render-pipelines.high-definition",
   "description": "The High Definition Render Pipeline (HDRP) is a high-fidelity Scriptable Render Pipeline built by Unity to target modern (Compute Shader compatible) platforms. HDRP utilizes Physically-Based Lighting techniques, linear lighting, HDR lighting, and a configurable hybrid Tile/Cluster deferred/Forward lighting architecture and gives you the tools you need to create games, technical demos, animations, and more to a high graphical standard.",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "unity": "2022.1",
   "displayName": "High Definition RP",
   "dependencies": {
@@ -11,10 +11,10 @@
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.imageconversion": "1.0.0",
     "com.unity.modules.terrain": "1.0.0",
-    "com.unity.render-pipelines.core": "13.1.4",
-    "com.unity.shadergraph": "13.1.4",
-    "com.unity.visualeffectgraph": "13.1.4",
-    "com.unity.render-pipelines.high-definition-config": "13.1.4"
+    "com.unity.render-pipelines.core": "13.1.5",
+    "com.unity.shadergraph": "13.1.5",
+    "com.unity.visualeffectgraph": "13.1.5",
+    "com.unity.render-pipelines.high-definition-config": "13.1.5"
   },
   "keywords": [
     "graphics",

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [13.1.5] - 2021-12-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.4] - 2021-12-04
 
 Version Updated

--- a/com.unity.render-pipelines.universal/ValidationExceptions.json
+++ b/com.unity.render-pipelines.universal/ValidationExceptions.json
@@ -3,11 +3,11 @@
     {
       "ValidationTest": "Package Lifecycle Validation",
       "ExceptionError": "Package com.unity.render-pipelines.universal@13.1.1 depends on package com.unity.burst@1.5.0 which is in an invalid track for release purposes. Release versions can only depend on Release versions.",
-      "PackageVersion": "13.1.4"
+      "PackageVersion": "13.1.5"
     },
     {
       "ValidationTest": "API Updater Configuration Validation",
-      "PackageVersion": "13.1.4"
+      "PackageVersion": "13.1.5"
     }
   ]
 }

--- a/com.unity.render-pipelines.universal/package.json
+++ b/com.unity.render-pipelines.universal/package.json
@@ -1,14 +1,14 @@
 {
   "name": "com.unity.render-pipelines.universal",
   "description": "The Universal Render Pipeline (URP) is a prebuilt Scriptable Render Pipeline, made by Unity. URP provides artist-friendly workflows that let you quickly and easily create optimized graphics across a range of platforms, from mobile to high-end consoles and PCs.",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "unity": "2022.1",
   "displayName": "Universal RP",
   "dependencies": {
     "com.unity.mathematics": "1.2.1",
     "com.unity.burst": "1.5.0",
-    "com.unity.render-pipelines.core": "13.1.4",
-    "com.unity.shadergraph": "13.1.4"
+    "com.unity.render-pipelines.core": "13.1.5",
+    "com.unity.shadergraph": "13.1.5"
   },
   "keywords": [
     "graphics",

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [13.1.5] - 2021-12-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.4] - 2021-12-04
 
 Version Updated

--- a/com.unity.shadergraph/package.json
+++ b/com.unity.shadergraph/package.json
@@ -1,11 +1,11 @@
 {
   "name": "com.unity.shadergraph",
   "description": "The Shader Graph package adds a visual Shader editing tool to Unity. You can use this tool to create Shaders in a visual way instead of writing code. Specific render pipelines can implement specific graph features. Currently, both the High Definition Rendering Pipeline and the Universal Rendering Pipeline support Shader Graph.",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "unity": "2022.1",
   "displayName": "Shader Graph",
   "dependencies": {
-    "com.unity.render-pipelines.core": "13.1.4",
+    "com.unity.render-pipelines.core": "13.1.5",
     "com.unity.searcher": "4.9.1"
   },
   "samples": [

--- a/com.unity.testing.visualeffectgraph/package.json
+++ b/com.unity.testing.visualeffectgraph/package.json
@@ -1,12 +1,12 @@
 {
   "name": "com.unity.testing.visualeffectgraph",
   "displayName": "Visual Effect Graphic Tests",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "unity": "2022.1",
   "unityRelease": "0a7",
   "description": "This package contains common graphics tests from several scriptable renderpipeline",
   "dependencies": {
-    "com.unity.visualeffectgraph": "13.1.4",
+    "com.unity.visualeffectgraph": "13.1.5",
     "com.unity.testframework.graphics": "7.8.11-preview",
     "com.unity.testing.graphics-performance": "8.0.0",
     "com.unity.test-framework": "1.1.29"

--- a/com.unity.visualeffectgraph/CHANGELOG.md
+++ b/com.unity.visualeffectgraph/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [13.1.5] - 2021-12-17
+
+Version Updated
+The version number for this package has increased due to a version update of a related graphics package.
+
 ## [13.1.4] - 2021-12-04
 
 Version Updated

--- a/com.unity.visualeffectgraph/CHANGELOG.md
+++ b/com.unity.visualeffectgraph/CHANGELOG.md
@@ -5,9 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [13.1.5] - 2021-12-17
-
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed
+- Enable/disable state of VFX blocks and operators are preserved after copy/paste
 
 ## [13.1.4] - 2021-12-04
 

--- a/com.unity.visualeffectgraph/package.json
+++ b/com.unity.visualeffectgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.visualeffectgraph",
   "displayName": "Visual Effect Graph",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "unity": "2022.1",
   "description": "The Visual Effect Graph is a node based visual effect editor. It allows you to author next generation visual effects that Unity simulates directly on the GPU. The Visual Effect Graph is production-ready for the High Definition Render Pipeline and runs on all platforms supported by it. Full support for the Universal Render Pipeline and compatible mobile devices is still in development.",
   "keywords": [
@@ -12,8 +12,8 @@
     "particles"
   ],
   "dependencies": {
-    "com.unity.shadergraph": "13.1.4",
-    "com.unity.render-pipelines.core": "13.1.4"
+    "com.unity.shadergraph": "13.1.5",
+    "com.unity.render-pipelines.core": "13.1.5"
   },
   "samples": [
     {


### PR DESCRIPTION
### Purpose of this PR
Bumping packages to 13.1.5 on 2022.1 according to https://docs.google.com/spreadsheets/d/10dt8_LsIj6kfWJpw6eI4ipfVXK8YacyHRifp9cDe5o0/edit?pli=1#gid=1913882944

---
### Testing status
[Package tests](https://unity-ci.cds.internal.unity3d.com/project/902/branch/2022.1%2Fant%2Fbump-to-13.1.5/jobDefinition/.yamato%2F_projectcontext.yml%23all_package_ci_project_2022.1)
