### PR TITLE
[2022.2] Updating reference image for 050 Shader Graphs Deferred RenderPass WinEditor DX11

### DIFF
--- a/TestProjects/UniversalGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/050_Shader_Graphs_deferred_RenderPass.png
+++ b/TestProjects/UniversalGraphicsTest_Foundation/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/None/050_Shader_Graphs_deferred_RenderPass.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4825d7abf5f8df9707f791099323117c5cc16d0fe34afd3821b7688781d5be11
-size 149550
+oid sha256:a03ae15a1f4bd86ea306ed0869a7d9e94b8aa3eeb62f0c5248a81a569a41ec8c
+size 130548


### PR DESCRIPTION
# Purpose of this PR
Updating Reference Image for Windows Editor DX11 that I missed in #6693.