### PR TITLE
[2022.1 backport] Scriptable Renderer: Dismiss depth slice for non-camera passes check

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -6,19 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [13.1.5] - 2021-12-17
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed
+- Fixed a depth non-clear in XR due to wrong depth slice being checked.
 
 ## [13.1.4] - 2021-12-04
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
-
-## Fixed
+### Fixed
 - Fixed a performance regression in the 2D renderer regarding the PostProcessPass [case 1385385]
 - Fixed a regression where filtering the scene view yielded incorrect visual results [case 1388171] (https://issuetracker.unity3d.com/product/unity/issues/guid/1360233)
 - Fixed incorrect light indexing on Windows Editor with Android target. [case 1378103](https://issuetracker.unity3d.com/product/unity/issues/guid/1378103/)
-
 
 ## [13.1.3] - 2021-11-17
 

--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -1292,7 +1292,7 @@ namespace UnityEngine.Rendering.Universal
                 }
 
                 // Condition (m_CameraDepthTarget!=BuiltinRenderTextureType.CameraTarget) below prevents m_FirstTimeCameraDepthTargetIsBound flag from being reset during non-camera passes (such as Color Grading LUT). This ensures that in those cases, cameraDepth will actually be cleared during the later camera pass.
-                if (m_CameraDepthTarget.nameID != BuiltinRenderTextureType.CameraTarget && (passDepthAttachment.nameID == m_CameraDepthTarget.nameID || passColorAttachment.nameID == m_CameraDepthTarget.nameID) && m_FirstTimeCameraDepthTargetIsBound)
+                if (new RenderTargetIdentifier(m_CameraDepthTarget.nameID, 0, depthSlice: 0) != BuiltinRenderTextureType.CameraTarget && (passDepthAttachment.nameID == m_CameraDepthTarget.nameID || passColorAttachment.nameID == m_CameraDepthTarget.nameID) && m_FirstTimeCameraDepthTargetIsBound)
                 {
                     m_FirstTimeCameraDepthTargetIsBound = false;
 


### PR DESCRIPTION
The RTHandles conversion puts the XR depth slice for SPI (-1) on all
targets at an earlier stage. All equals checks against CameraTarget must
dismiss possible depth slice to be accurate.

This fixes a depth non-clear in vfx BatchRenderGroup_URP tests by
preventing `m_FirstTimeCameraDepthTargetIsBound` from being set to `false`
before batch opaque draw call.

 Backport of #6426
