### PR TITLE
[Universal] CopyDepth pass editor ConfigureTarget for DX11-only

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Passes/CopyDepthPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/CopyDepthPass.cs
@@ -54,6 +54,8 @@ namespace UnityEngine.Rendering.Universal.Internal
             var isDepth = (destination.rt && destination.rt.graphicsFormat == GraphicsFormat.None);
             descriptor.graphicsFormat = isDepth ? GraphicsFormat.D32_SFloat_S8_UInt : GraphicsFormat.R32_SFloat;
             descriptor.msaaSamples = 1;
+            // This is a temporary workaround for Editor as not setting any depth here
+            // would lead to overwriting depth in certain scenarios (reproducable while running DX11 tests)
 #if UNITY_EDITOR
             if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D11)
                 ConfigureTarget(destination, destination, GraphicsFormat.R32_SFloat, descriptor.width, descriptor.height, descriptor.msaaSamples);

--- a/com.unity.render-pipelines.universal/Runtime/Passes/CopyDepthPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/CopyDepthPass.cs
@@ -55,10 +55,11 @@ namespace UnityEngine.Rendering.Universal.Internal
             descriptor.graphicsFormat = isDepth ? GraphicsFormat.D32_SFloat_S8_UInt : GraphicsFormat.R32_SFloat;
             descriptor.msaaSamples = 1;
 #if UNITY_EDITOR
-            ConfigureTarget(destination, destination, GraphicsFormat.R32_SFloat, descriptor.width, descriptor.height, descriptor.msaaSamples);
-#else
-            ConfigureTarget(destination, descriptor.graphicsFormat, descriptor.width, descriptor.height, descriptor.msaaSamples, isDepth);
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D11)
+                ConfigureTarget(destination, destination, GraphicsFormat.R32_SFloat, descriptor.width, descriptor.height, descriptor.msaaSamples);
+            else
 #endif
+            ConfigureTarget(destination, descriptor.graphicsFormat, descriptor.width, descriptor.height, descriptor.msaaSamples, isDepth);
             if (m_ShouldClear)
                 ConfigureClear(ClearFlag.All, Color.black);
         }


### PR DESCRIPTION
To fix some errors on Vulkan tests, we need to make this call of ConfigureTarget dx11 exclusive as recently an error that would cause a failure on Vulkan 

Ran URP Foundation tests that were failing - no related errors found anymore (only known instabilities/failures)


