### PR TITLE
[Universal][Editor] Fixing incorrect light attenuation with mobile build target selected

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed missing depth for Depth of Field in an overlay camera. [case 1365623](https://issuetracker.unity3d.com/product/unity/issues/guid/1365623/)
 - Fixed FXAA quality issues when render scale is not 1.0.
 - Fixed an issue where specular color was not matching behaviour in Legacy and HDRP. [case 1326941](https://issuetracker.unity3d.com/issues/urp-specular-color-behavior-does-not-match-legacy-or-hdrp)
+- Fixed incorrect light attenuation on Editor when mobile build target is active. [case 1387142](https://issuetracker.unity3d.com/issues/directional-light-light-is-bigger-in-the-editor-when-the-build-target-is-ios-or-android)
 
 ## [13.1.2] - 2021-11-05
 

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -793,9 +793,13 @@ namespace UnityEngine.Rendering.Universal
                 float lightRangeSqrOverFadeRangeSqr = -lightRangeSqr / fadeRangeSqr;
                 float oneOverLightRangeSqr = 1.0f / Mathf.Max(0.0001f, lightRange * lightRange);
 
-                // On untethered devices: Use the faster linear smoothing factor (SHADER_HINT_NICE_QUALITY).
+                // On untethered devices and Editor if mobile target (as SHADER_API_MOBILE now affects Editor as well): Use the faster linear smoothing factor (SHADER_HINT_NICE_QUALITY).
                 // On other devices: Use the smoothing factor that matches the GI.
-                lightAttenuation.x = Application.isMobilePlatform || SystemInfo.graphicsDeviceType == GraphicsDeviceType.Switch ? oneOverFadeRangeSqr : oneOverLightRangeSqr;
+                bool isMobileBuildTarget = false;
+                #if UNITY_EDITOR && (UNITY_IOS || UNITY_ANDROID)
+                    isMobileBuildTarget = true;
+                #endif
+                lightAttenuation.x = Application.isMobilePlatform || isMobileBuildTarget || SystemInfo.graphicsDeviceType == GraphicsDeviceType.Switch ? oneOverFadeRangeSqr : oneOverLightRangeSqr;
                 lightAttenuation.y = lightRangeSqrOverFadeRangeSqr;
             }
 


### PR DESCRIPTION
Recently SHADER_API_MOBILE started working on editor as well, depending on the active build target. Attenuation had a single check for mobile platform which wouldn't be set on Editor. This PR includes a check for editor and sets correct values leading to correct rendering

Fix for https://fogbugz.unity3d.com/f/cases/1387142/

Tested manually on editor and ios with the bug case project