### PR TITLE
URP: configure the RenderTargetBufferSystem when using preview camera

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed FXAA quality issues when render scale is not 1.0.
 - Fixed an issue where specular color was not matching behaviour in Legacy and HDRP. [case 1326941](https://issuetracker.unity3d.com/issues/urp-specular-color-behavior-does-not-match-legacy-or-hdrp)
 - Fixed a shader compiler issue with mismatching variable types when calling lerp.
+- Fixed null error when generating a new shader preview.
 
 ## [13.1.2] - 2021-11-05
 

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
@@ -543,7 +543,7 @@ namespace UnityEngine.Rendering.Universal
                 }
 
                 // Doesn't create texture for Overlay cameras as they are already overlaying on top of created textures.
-                if (intermediateRenderTexture)
+                if (intermediateRenderTexture || isPreviewCamera)
                     CreateCameraRenderTarget(context, ref cameraTargetDescriptor, useDepthPriming);
 
                 m_ActiveCameraColorAttachment = createColorTexture ? m_ColorBufferSystem.PeekBackBuffer() : m_XRTargetHandleAlias;


### PR DESCRIPTION


# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
Fixes `NullReferenceException` on `Worker0` when generating a new preview.

---
### Testing status

Tested locally a reproducible case on UniversalGraphicsTest_Terrain 230_Decals: Select Terrain and open edit trees menu.
Others tested locally reproducible case with shadergraph
