### PR TITLE
[2022.1 backport ] URP: configure the RenderTargetBufferSystem when using preview camera

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -6,19 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [13.1.5] - 2021-12-17
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed
+- Fixed null error when generating a new shader preview.
 
 ## [13.1.4] - 2021-12-04
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
-
-## Fixed
+### Fixed
 - Fixed a performance regression in the 2D renderer regarding the PostProcessPass [case 1385385]
 - Fixed a regression where filtering the scene view yielded incorrect visual results [case 1388171] (https://issuetracker.unity3d.com/product/unity/issues/guid/1360233)
 - Fixed incorrect light indexing on Windows Editor with Android target. [case 1378103](https://issuetracker.unity3d.com/product/unity/issues/guid/1378103/)
-
 
 ## [13.1.3] - 2021-11-17
 

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
@@ -535,7 +535,7 @@ namespace UnityEngine.Rendering.Universal
                 }
 
                 // Doesn't create texture for Overlay cameras as they are already overlaying on top of created textures.
-                if (intermediateRenderTexture)
+                if (intermediateRenderTexture || isPreviewCamera)
                     CreateCameraRenderTarget(context, ref cameraTargetDescriptor, useDepthPriming);
 
                 m_ActiveCameraColorAttachment = createColorTexture && !sceneViewFilterEnabled ? m_ColorBufferSystem.PeekBackBuffer() : m_XRTargetHandleAlias;


### PR DESCRIPTION
# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
Fixes `NullReferenceException` on `Worker0` when generating a new preview.

---
### Testing status

Tested locally a reproducible case on UniversalGraphicsTest_Terrain 230_Decals: Select Terrain and open edit trees menu.
Others tested locally reproducible case with shadergraph
