### PR TITLE
[UniversalRP] [2022.1 Bugfix Backport] Fix mismatch between Editor-side and Runtime-side implementations of UnityEngine.Rendering.Universal.DecalRendererFeature.IsAutomaticDBuffer() (Case 1394637)

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -26,6 +26,7 @@ The version number for this package has increased due to a version update of a r
 - Removed the name input for the SSAO and Screen Space Shadows renderer features.
 
 ### Fixed
+- Fix mismatch on some platforms between Editor-side and Runtime-side implementations of UnityEngine.Rendering.Universal.DecalRendererFeature.IsAutomaticDBuffer() [case 1364134]
 - Fix shadow rendering correctly to work with shader stripping in WebGl. [case 1381881](https://issuetracker.unity3d.com/issues/webgl-urp-mesh-is-not-rendered-in-the-scene-on-webgl-build)
 - VFX: Incorrect Decal rendering when rendescale is different than one [case 1343674](https://issuetracker.unity3d.com/product/unity/issues/guid/1343674/)
 - Fixed inspector documentation URLs for the URP asset and Universal Renderer asset.

--- a/com.unity.render-pipelines.universal/Runtime/RendererFeatures/DecalRendererFeature.cs
+++ b/com.unity.render-pipelines.universal/Runtime/RendererFeatures/DecalRendererFeature.cs
@@ -326,6 +326,8 @@ namespace UnityEngine.Rendering.Universal
                 return true;
             if (selectedBuildTargetGroup == UnityEditor.BuildTargetGroup.WSA)
                 return true;
+            if (selectedBuildTargetGroup == UnityEditor.BuildTargetGroup.Switch)
+                return true;
             return false;
 #else
             return SystemInfo.deviceType == DeviceType.Desktop || SystemInfo.deviceType == DeviceType.Console;


### PR DESCRIPTION
This pull request is a backport of the bugfix https://github.com/Unity-Technologies/Graphics/pull/6729 to the 2022.1 release stream.


### Purpose of this PR

[Original implementation of UniversalRP Decals](https://github.com/Unity-Technologies/Graphics/pull/3926) introduces method `UnityEngine.Rendering.Universal.DecalRendererFeature.IsAutomaticDBuffer()` that defines whether a platform should use the DBuffer technique when "Automatic" is selected in the Decal Renderer Feature properties window.

However, for some platforms there is a mismatch between the Editor-side (called at application build time) and Runtime-side implementations. This causes the build process to excludes some shaders required by the technique, resulting in objects rendered with the magenta "Unity Error Shader" when Decal feature technique "Automatic" was selected:

![image](https://user-images.githubusercontent.com/43460825/149256303-8cd1e5a7-fee0-47a9-96cd-81bdc17497ea.png)




This pull request solves this issue, that was reported as [internal case 1394637](https://fogbugz.unity3d.com/f/cases/1394637/):

![image](https://user-images.githubusercontent.com/43460825/149256359-b55587e5-5b68-4ccd-bf9f-b64771e963bd.png)




---
### Testing status
I locally tested that the fix effectively solves the issue reported as [internal case 1394637](https://fogbugz.unity3d.com/f/cases/1394637/), using the repro-project attached to the issue ticket.
