### PR TITLE
[URP] Particles test fix

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -706,7 +706,7 @@ namespace UnityEngine.Rendering.Universal
             if (!cameraData.postProcessEnabled)
                 return false;
 
-            if (cameraData.antialiasing == AntialiasingMode.SubpixelMorphologicalAntiAliasing)
+            if (cameraData.antialiasing == AntialiasingMode.SubpixelMorphologicalAntiAliasing && cameraData.renderType == CameraRenderType.Base)
                 return true;
 
             var stack = VolumeManager.instance.stack;
@@ -935,7 +935,7 @@ namespace UnityEngine.Rendering.Universal
             cameraData.postProcessEnabled &= SystemInfo.graphicsDeviceType != GraphicsDeviceType.OpenGLES2;
 
             cameraData.requiresDepthTexture |= isSceneViewCamera;
-            cameraData.postProcessingRequiresDepthTexture |= CheckPostProcessForDepth(cameraData);
+            cameraData.postProcessingRequiresDepthTexture = CheckPostProcessForDepth(cameraData);
             cameraData.resolveFinalTarget = resolveFinalTarget;
 
             // Disable depth and color copy. We should add it in the renderer instead to avoid performance pitfalls

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -145,6 +145,9 @@ namespace UnityEngine.Rendering.Universal
         private UniversalRenderPipelineGlobalSettings m_GlobalSettings;
         public override RenderPipelineGlobalSettings defaultSettings => m_GlobalSettings;
 
+        // flag to keep track of depth buffer requirements by any of the cameras in the stack
+        internal static bool cameraStackRequiresDepthForPostprocessing = false;
+
         public UniversalRenderPipeline(UniversalRenderPipelineAsset asset)
         {
 #if UNITY_EDITOR
@@ -486,6 +489,8 @@ namespace UnityEngine.Rendering.Universal
                 var baseCameraRendererType = baseCameraAdditionalData?.scriptableRenderer.GetType();
                 bool shouldUpdateCameraStack = false;
 
+                cameraStackRequiresDepthForPostprocessing = false;
+
                 for (int i = 0; i < cameraStack.Count; ++i)
                 {
                     Camera currCamera = cameraStack[i];
@@ -504,6 +509,8 @@ namespace UnityEngine.Rendering.Universal
                             Debug.LogWarning(string.Format("Stack can only contain Overlay cameras. {0} will skip rendering.", currCamera.name));
                             continue;
                         }
+
+                        cameraStackRequiresDepthForPostprocessing |= CheckPostProcessForDepth();
 
                         var currCameraRendererType = data?.scriptableRenderer.GetType();
                         if (currCameraRendererType != baseCameraRendererType)
@@ -580,6 +587,9 @@ namespace UnityEngine.Rendering.Universal
             if (asset.useAdaptivePerformance)
                 ApplyAdaptivePerformance(ref baseCameraData);
 #endif
+            // update the base camera flag so that the scene depth is stored if needed by overlay cameras later in the frame
+            baseCameraData.postProcessingRequiresDepthTexture |= cameraStackRequiresDepthForPostprocessing;
+
             RenderSingleCamera(context, baseCameraData, anyPostProcessingEnabled);
             using (new ProfilingScope(null, Profiling.Pipeline.endCameraRendering))
             {
@@ -709,6 +719,11 @@ namespace UnityEngine.Rendering.Universal
             if (cameraData.antialiasing == AntialiasingMode.SubpixelMorphologicalAntiAliasing && cameraData.renderType == CameraRenderType.Base)
                 return true;
 
+            return CheckPostProcessForDepth();
+        }
+
+        static bool CheckPostProcessForDepth()
+        {
             var stack = VolumeManager.instance.stack;
 
             if (stack.GetComponent<DepthOfField>().IsActive())


### PR DESCRIPTION
---
### Purpose of this PR
This PR fixes a regression introduced by this PR which caused the Vulkan deferred particle tests to fail on Yamato:
https://github.com/Unity-Technologies/Graphics/pull/6549

On top of fixing the particles test provides a better fix for the overlay DOF bug case:
https://issuetracker.unity3d.com/product/unity/issues/guid/1365623/

To fix the overlay issue, I've added a flag to keep track of any depth buffer requirements for postprocessing by any camera in the stack, so that the base camera can make the proper decisions about storing or discarding the scene depth.

---
### Testing status
Local Windows Vulkan, Android Vulkan (Samsung S10 with Mali G76)

---
### Comments to reviewers

