### PR TITLE
[2022.1 backport] DecalRendererFeature: Convert to using RTHandles 

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -6,15 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [13.1.6] - 2022-01-14
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed
+- Fixed some rendering inconsistencies when using Decals.
 
 ## [13.1.5] - 2021-12-17
 
 ### Fixed
 - Fixed a depth non-clear in XR due to wrong depth slice being checked.
-
-## Fixed
 - Fixed decal compilation issue on mac.
 - Fixed incorrect lighting attenuation on Editor when build target is a mobile platform [case 1387142]
 

--- a/com.unity.render-pipelines.universal/Editor/Camera/UniversalRenderPipelineCameraUI.Drawers.cs
+++ b/com.unity.render-pipelines.universal/Editor/Camera/UniversalRenderPipelineCameraUI.Drawers.cs
@@ -73,7 +73,7 @@ namespace UnityEditor.Rendering.Universal
         {
             int selectedRenderer = p.renderer.intValue;
             ScriptableRenderer scriptableRenderer = UniversalRenderPipeline.asset.GetRenderer(selectedRenderer);
-            bool isDeferred = scriptableRenderer is UniversalRenderer { renderingMode: RenderingMode.Deferred };
+            bool isDeferred = scriptableRenderer is UniversalRenderer { renderingModeRequested: RenderingMode.Deferred };
 
             EditorGUI.BeginChangeCheck();
 

--- a/com.unity.render-pipelines.universal/Editor/ShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderPreprocessor.cs
@@ -940,7 +940,7 @@ namespace UnityEditor.Rendering.Universal
                 if (renderer is UniversalRenderer)
                 {
                     UniversalRenderer universalRenderer = (UniversalRenderer)renderer;
-                    if (universalRenderer.renderingMode == RenderingMode.Deferred)
+                    if (universalRenderer.renderingModeRequested == RenderingMode.Deferred)
                     {
                         hasDeferredRenderer |= true;
                         accurateGbufferNormals |= universalRenderer.accurateGbufferNormals;

--- a/com.unity.render-pipelines.universal/Runtime/Decal/DBuffer/DBufferRenderPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Decal/DBuffer/DBufferRenderPass.cs
@@ -25,16 +25,12 @@ namespace UnityEngine.Rendering.Universal
         private ProfilingSampler m_ProfilingSampler;
 
         private RTHandle m_DBufferDepth;
-        private RTHandle m_CameraDepthTexture;
-        private RTHandle m_CameraDepthAttachment;
 
         internal DeferredLights deferredLights { get; set; }
         private bool isDeferred => deferredLights != null;
         internal RTHandle[] dBufferColorHandles { get; private set; }
 
         internal RTHandle dBufferDepth => m_DBufferDepth;
-        internal RTHandle cameraDepthTexture => m_CameraDepthTexture;
-        internal RTHandle cameraDepthAttachment => m_CameraDepthAttachment;
 
         public DBufferRenderPass(Material dBufferClear, DBufferSettings settings, DecalDrawDBufferSystem drawSystem)
         {
@@ -52,71 +48,63 @@ namespace UnityEngine.Rendering.Universal
 
             int dBufferCount = (int)settings.surfaceData + 1;
             dBufferColorHandles = new RTHandle[dBufferCount];
-            for (int dbufferIndex = 0; dbufferIndex < dBufferCount; ++dbufferIndex)
-                dBufferColorHandles[dbufferIndex] = RTHandles.Alloc(s_DBufferNames[dbufferIndex], name: s_DBufferNames[dbufferIndex]);
             m_DBufferCount = dBufferCount;
-
-            m_DBufferDepth = RTHandles.Alloc(s_DBufferDepthName, name: s_DBufferDepthName);
-            m_CameraDepthTexture = RTHandles.Alloc("_CameraDepthTexture", name: "_CameraDepthTexture");
-            m_CameraDepthAttachment = RTHandles.Alloc("_CameraDepthAttachment", name: "_CameraDepthAttachment");
         }
 
         public void Dispose()
         {
-            m_DBufferDepth.Release();
-            m_CameraDepthTexture.Release();
-            m_CameraDepthAttachment.Release();
+            m_DBufferDepth?.Release();
             foreach (var handle in dBufferColorHandles)
-                handle.Release();
+                handle?.Release();
         }
 
-        public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+        public void Setup(in CameraData cameraData)
         {
             // base
             {
-                var desc = renderingData.cameraData.cameraTargetDescriptor;
+                var desc = cameraData.cameraTargetDescriptor;
                 desc.graphicsFormat = QualitySettings.activeColorSpace == ColorSpace.Linear ? GraphicsFormat.R8G8B8A8_SRGB : GraphicsFormat.R8G8B8A8_UNorm;
                 desc.depthBufferBits = 0;
                 desc.msaaSamples = 1;
 
-                cmd.GetTemporaryRT(Shader.PropertyToID(s_DBufferNames[0]), desc);
+                RenderingUtils.ReAllocateIfNeeded(ref dBufferColorHandles[0], desc, name: s_DBufferNames[0]);
             }
 
             if (m_Settings.surfaceData == DecalSurfaceData.AlbedoNormal || m_Settings.surfaceData == DecalSurfaceData.AlbedoNormalMAOS)
             {
-                var desc = renderingData.cameraData.cameraTargetDescriptor;
+                var desc = cameraData.cameraTargetDescriptor;
                 desc.graphicsFormat = GraphicsFormat.R8G8B8A8_UNorm;
                 desc.depthBufferBits = 0;
                 desc.msaaSamples = 1;
 
-                cmd.GetTemporaryRT(Shader.PropertyToID(s_DBufferNames[1]), desc);
+                RenderingUtils.ReAllocateIfNeeded(ref dBufferColorHandles[1], desc, name: s_DBufferNames[1]);
             }
 
             if (m_Settings.surfaceData == DecalSurfaceData.AlbedoNormalMAOS)
             {
-                var desc = renderingData.cameraData.cameraTargetDescriptor;
+                var desc = cameraData.cameraTargetDescriptor;
                 desc.graphicsFormat = GraphicsFormat.R8G8B8A8_UNorm;
                 desc.depthBufferBits = 0;
                 desc.msaaSamples = 1;
 
-                cmd.GetTemporaryRT(Shader.PropertyToID(s_DBufferNames[2]), desc);
+                RenderingUtils.ReAllocateIfNeeded(ref dBufferColorHandles[2], desc, name: s_DBufferNames[2]);
             }
 
             // depth
             RTHandle depthHandle;
-            if (!isDeferred)
+            if (isDeferred)
             {
-                var depthDesc = renderingData.cameraData.cameraTargetDescriptor;
-                depthDesc.graphicsFormat = GraphicsFormat.None; //Depth only rendering
-                depthDesc.depthStencilFormat = renderingData.cameraData.cameraTargetDescriptor.depthStencilFormat;
-                depthDesc.msaaSamples = 1;
-
-                cmd.GetTemporaryRT(Shader.PropertyToID(m_DBufferDepth.name), depthDesc);
-                depthHandle = m_DBufferDepth;
+                depthHandle = cameraData.renderer.cameraDepthTargetHandle;
             }
             else
             {
-                depthHandle = m_CameraDepthAttachment;
+                var depthDesc = cameraData.cameraTargetDescriptor;
+                depthDesc.graphicsFormat = GraphicsFormat.None; //Depth only rendering
+                depthDesc.depthStencilFormat = cameraData.cameraTargetDescriptor.depthStencilFormat;
+                depthDesc.msaaSamples = 1;
+
+                RenderingUtils.ReAllocateIfNeeded(ref m_DBufferDepth, depthDesc, name: s_DBufferDepthName);
+                depthHandle = m_DBufferDepth;
             }
 
             ConfigureTarget(dBufferColorHandles, depthHandle);
@@ -133,9 +121,19 @@ namespace UnityEngine.Rendering.Universal
                 context.ExecuteCommandBuffer(cmd);
                 cmd.Clear();
 
+                cmd.SetGlobalTexture(dBufferColorHandles[0].name, dBufferColorHandles[0].nameID);
+                if (m_Settings.surfaceData == DecalSurfaceData.AlbedoNormal || m_Settings.surfaceData == DecalSurfaceData.AlbedoNormalMAOS)
+                    cmd.SetGlobalTexture(dBufferColorHandles[1].name, dBufferColorHandles[1].nameID);
+                if (m_Settings.surfaceData == DecalSurfaceData.AlbedoNormalMAOS)
+                    cmd.SetGlobalTexture(dBufferColorHandles[2].name, dBufferColorHandles[2].nameID);
+
                 if (isDeferred)
                 {
                     cmd.SetGlobalTexture("_CameraNormalsTexture", deferredLights.GbufferAttachmentIdentifiers[deferredLights.GBufferNormalSmoothnessIndex]);
+                }
+                else
+                {
+                    cmd.SetGlobalTexture(m_DBufferDepth.name, m_DBufferDepth.nameID);
                 }
 
                 CoreUtils.SetKeyword(cmd, ShaderKeywordStrings.DBufferMRT1, m_Settings.surfaceData == DecalSurfaceData.Albedo);
@@ -191,11 +189,6 @@ namespace UnityEngine.Rendering.Universal
             CoreUtils.SetKeyword(cmd, ShaderKeywordStrings.DBufferMRT1, false);
             CoreUtils.SetKeyword(cmd, ShaderKeywordStrings.DBufferMRT2, false);
             CoreUtils.SetKeyword(cmd, ShaderKeywordStrings.DBufferMRT3, false);
-
-            for (int dbufferIndex = 0; dbufferIndex < m_DBufferCount; ++dbufferIndex)
-            {
-                cmd.ReleaseTemporaryRT(Shader.PropertyToID(s_DBufferNames[dbufferIndex]));
-            }
         }
     }
 }

--- a/com.unity.render-pipelines.universal/Runtime/RendererFeatures/DecalRendererFeature.cs
+++ b/com.unity.render-pipelines.universal/Runtime/RendererFeatures/DecalRendererFeature.cs
@@ -262,7 +262,7 @@ namespace UnityEngine.Rendering.Universal
                 return DecalTechnique.Invalid;
             }
 
-            bool isDeferred = universalRenderer.renderingModeRequested == RenderingMode.Deferred;
+            bool isDeferred = universalRenderer.renderingModeActual == RenderingMode.Deferred;
             return GetTechnique(isDeferred);
         }
 

--- a/com.unity.render-pipelines.universal/Runtime/RendererFeatures/DecalRendererFeature.cs
+++ b/com.unity.render-pipelines.universal/Runtime/RendererFeatures/DecalRendererFeature.cs
@@ -262,7 +262,7 @@ namespace UnityEngine.Rendering.Universal
                 return DecalTechnique.Invalid;
             }
 
-            bool isDeferred = universalRenderer.renderingMode == RenderingMode.Deferred;
+            bool isDeferred = universalRenderer.renderingModeRequested == RenderingMode.Deferred;
             return GetTechnique(isDeferred);
         }
 
@@ -393,7 +393,7 @@ namespace UnityEngine.Rendering.Universal
                     m_DecalDrawForwardEmissiveSystem = new DecalDrawFowardEmissiveSystem(m_DecalEntityManager);
                     m_ForwardEmissivePass = new DecalForwardEmissivePass(m_DecalDrawForwardEmissiveSystem);
 
-                    if (universalRenderer.actualRenderingMode == RenderingMode.Deferred)
+                    if (universalRenderer.renderingModeActual == RenderingMode.Deferred)
                     {
                         m_DBufferRenderPass.deferredLights = universalRenderer.deferredLights;
                         m_DBufferRenderPass.deferredLights.DisableFramebufferFetchInput();
@@ -487,7 +487,7 @@ namespace UnityEngine.Rendering.Universal
                 m_DBufferRenderPass.Setup(renderingData.cameraData);
 
                 var universalRenderer = renderer as UniversalRenderer;
-                if (universalRenderer.actualRenderingMode == RenderingMode.Deferred)
+                if (universalRenderer.renderingModeActual == RenderingMode.Deferred)
                     m_CopyDepthPass.Setup(
                         renderer.cameraDepthTargetHandle,
                         universalRenderer.m_DepthTexture

--- a/com.unity.render-pipelines.universal/Runtime/RendererFeatures/DecalRendererFeature.cs
+++ b/com.unity.render-pipelines.universal/Runtime/RendererFeatures/DecalRendererFeature.cs
@@ -484,6 +484,8 @@ namespace UnityEngine.Rendering.Universal
         {
             if (m_Technique == DecalTechnique.DBuffer)
             {
+                m_DBufferRenderPass.Setup(renderingData.cameraData);
+
                 var universalRenderer = renderer as UniversalRenderer;
                 if (universalRenderer.actualRenderingMode == RenderingMode.Deferred)
                     m_CopyDepthPass.Setup(
@@ -509,6 +511,7 @@ namespace UnityEngine.Rendering.Universal
 
         protected override void Dispose(bool disposing)
         {
+            m_DBufferRenderPass?.Dispose();
             CoreUtils.Destroy(m_CopyDepthMaterial);
             CoreUtils.Destroy(m_DBufferClearMaterial);
 

--- a/com.unity.render-pipelines.universal/Runtime/RendererFeatures/ScreenSpaceAmbientOcclusion.cs
+++ b/com.unity.render-pipelines.universal/Runtime/RendererFeatures/ScreenSpaceAmbientOcclusion.cs
@@ -117,7 +117,7 @@ namespace UnityEngine.Rendering.Universal
         private class ScreenSpaceAmbientOcclusionPass : ScriptableRenderPass
         {
             // Properties
-            private bool isRendererDeferred => m_Renderer != null && m_Renderer is UniversalRenderer && ((UniversalRenderer)m_Renderer).renderingMode == RenderingMode.Deferred;
+            private bool isRendererDeferred => m_Renderer != null && m_Renderer is UniversalRenderer && ((UniversalRenderer)m_Renderer).renderingModeRequested == RenderingMode.Deferred;
 
             // Private Variables
             private bool m_SupportsR8RenderTextureFormat = SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.R8);

--- a/com.unity.render-pipelines.universal/Runtime/RendererFeatures/ScreenSpaceShadows.cs
+++ b/com.unity.render-pipelines.universal/Runtime/RendererFeatures/ScreenSpaceShadows.cs
@@ -54,7 +54,7 @@ namespace UnityEngine.Rendering.Universal
 
             if (shouldEnqueue)
             {
-                bool isDeferredRenderingMode = renderer is UniversalRenderer && ((UniversalRenderer)renderer).renderingMode == RenderingMode.Deferred;
+                bool isDeferredRenderingMode = renderer is UniversalRenderer && ((UniversalRenderer)renderer).renderingModeRequested == RenderingMode.Deferred;
 
                 m_SSShadowsPass.renderPassEvent = isDeferredRenderingMode
                     ? RenderPassEvent.AfterRenderingGbuffer


### PR DESCRIPTION
Backport of #6401

Pass: Remove RTI alises of universal renderer targets, these do not work
with RTHandles, you must get the actual references.
Pass: Convert dBufferColorHandles[0-2] and m_DBufferDepth to RTHandles
Pass: Set global textures in execute to use the same cmd.
Feature: Call pass dispose
Feature: Move setup of targets to Pass' Setup Function called from
SetupRenderPasses

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
The intention of this PR is fix breaking test 230 in Foundation.
It also fixes targets that weren't yet converted to RTHandles.

---
### Testing status
Test 230_Decal_Projector from UniversalGraphicsTest_Foundation was run with the `-xr-reuse-tests` which reliably produced a red test.

The test seemed to also fail more often if run after 120 to 124. This was also tested.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
