### PR TITLE
Add missing attributes

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Data/PostProcessData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/PostProcessData.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace UnityEngine.Rendering.Universal
 {
-    [Serializable]
+    [Serializable, ReloadGroup]
     public class PostProcessData : ScriptableObject
     {
 #if UNITY_EDITOR

--- a/com.unity.render-pipelines.universal/Runtime/Data/XRSystemData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/XRSystemData.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace UnityEngine.Rendering.Universal
 {
-    [Serializable]
+    [Serializable, ReloadGroup]
     public class XRSystemData : ScriptableObject
     {
 #if UNITY_EDITOR


### PR DESCRIPTION
### Purpose of this PR
Fix issue https://fogbugz.unity3d.com/f/cases/1376316/

Note: Issue was an integration issue totally on Universal side. When creating group in the resources as dedicated class for PostProcess, the attribute [ReloadGroup] was forgotten. This forbid the resource reloader to inspect inside those class as all the reloading is done with the renderdata asset as entry point.

I checked a little and there is same issue (missing [ReloadGroup]) with XR asset.

---
### Testing status
Step by step debugged to ensure now PostProcess is inspected by the reloader now. Also bug's step to reproduce don't produce the issue on last unity version + last master.

---
### Comments to reviewers
@phi-lira, I let your team handle any relevant back port for this.
