### PR TITLE
[2022.2] Fixing an issue with PostProcessingData being added in renderers with the feature disabled

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Data/PostProcessData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/PostProcessData.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace UnityEngine.Rendering.Universal
 {
-    [Serializable, ReloadGroup]
+    [Serializable]
     public class PostProcessData : ScriptableObject
     {
 #if UNITY_EDITOR

--- a/com.unity.render-pipelines.universal/Runtime/Data/XRSystemData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/XRSystemData.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace UnityEngine.Rendering.Universal
 {
-    [Serializable, ReloadGroup]
+    [Serializable]
     public class XRSystemData : ScriptableObject
     {
 #if UNITY_EDITOR

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRendererData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRendererData.cs
@@ -262,9 +262,13 @@ namespace UnityEngine.Rendering.Universal
         private void ReloadAllNullProperties()
         {
 #if UNITY_EDITOR
-            ResourceReloader.TryReloadAllNullIn(this, UniversalRenderPipelineAsset.packagePath);
+                ResourceReloader.TryReloadAllNullIn(this, UniversalRenderPipelineAsset.packagePath);
+
+                if (postProcessData != null)
+                    ResourceReloader.TryReloadAllNullIn(postProcessData, UniversalRenderPipelineAsset.packagePath);
+
 #if ENABLE_VR && ENABLE_XR_MODULE
-            ResourceReloader.TryReloadAllNullIn(xrSystemData, UniversalRenderPipelineAsset.packagePath);
+                    ResourceReloader.TryReloadAllNullIn(xrSystemData, UniversalRenderPipelineAsset.packagePath);
 #endif
 #endif
         }

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRendererData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRendererData.cs
@@ -262,13 +262,13 @@ namespace UnityEngine.Rendering.Universal
         private void ReloadAllNullProperties()
         {
 #if UNITY_EDITOR
-                ResourceReloader.TryReloadAllNullIn(this, UniversalRenderPipelineAsset.packagePath);
+            ResourceReloader.TryReloadAllNullIn(this, UniversalRenderPipelineAsset.packagePath);
 
-                if (postProcessData != null)
-                    ResourceReloader.TryReloadAllNullIn(postProcessData, UniversalRenderPipelineAsset.packagePath);
+            if (postProcessData != null)
+                ResourceReloader.TryReloadAllNullIn(postProcessData, UniversalRenderPipelineAsset.packagePath);
 
 #if ENABLE_VR && ENABLE_XR_MODULE
-                    ResourceReloader.TryReloadAllNullIn(xrSystemData, UniversalRenderPipelineAsset.packagePath);
+            ResourceReloader.TryReloadAllNullIn(xrSystemData, UniversalRenderPipelineAsset.packagePath);
 #endif
 #endif
         }


### PR DESCRIPTION
# Purpose of this PR
This PR fixes an issue that came with #6747 regarding the PostProcessingData resources.
Six failing jobs came as a result of the PR being merged.

# Testing status
Ran the failing jobs in our CI and verified the bug is still fixed with these changes.
