### PR TITLE
Occlusion culling for shadow maps

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added option to animate APV sample noise to smooth it out when TAA is enabled.
 - Added default DOTS compatible loading shader (MaterialLoading.shader)
 - Add #pragma editor_sync_compilation directive to MaterialError.shader
+- Added the culling matrix and near plane for lights, so that they can be custom-culled with the BatchRenderGroup API.
 
 ### Changed
 - Render Graph object pools are now cleared with render graph cleanup

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
@@ -2227,6 +2227,7 @@ namespace UnityEngine.Rendering.HighDefinition
                         out invViewProjection, out shadowRequest.projection,
                         out shadowRequest.deviceProjection, out shadowRequest.deviceProjectionYFlip, out shadowRequest.splitData
                     );
+                    shadowRequest.isOrthographic = false;
                     break;
                 case HDLightType.Spot:
                     float spotAngleForShadows = useCustomSpotLightShadowCone ? Math.Min(customSpotLightShadowCone, visibleLight.light.spotAngle) : visibleLight.light.spotAngle;
@@ -2236,6 +2237,7 @@ namespace UnityEngine.Rendering.HighDefinition
                         out shadowRequest.view, out invViewProjection, out shadowRequest.projection,
                         out shadowRequest.deviceProjection, out shadowRequest.deviceProjectionYFlip, out shadowRequest.splitData
                     );
+                    shadowRequest.isOrthographic = (spotLightShape == SpotLightShape.Box);
                     if (CustomViewCallbackEvent != null)
                     {
                         shadowRequest.view = CustomViewCallbackEvent(visibleLight.localToWorldMatrix);
@@ -2243,6 +2245,7 @@ namespace UnityEngine.Rendering.HighDefinition
                     break;
                 case HDLightType.Directional:
                     UpdateDirectionalShadowRequest(manager, shadowSettings, visibleLight, cullResults, viewportSize, shadowIndex, lightIndex, cameraPos, shadowRequest, out invViewProjection);
+                    shadowRequest.isOrthographic = true;
                     break;
                 case HDLightType.Area:
                     switch (areaLightShape)
@@ -2252,6 +2255,7 @@ namespace UnityEngine.Rendering.HighDefinition
                             forwardOffset = GetAreaLightOffsetForShadows(shapeSize, areaLightShadowCone);
                             HDShadowUtils.ExtractRectangleAreaLightData(visibleLight, forwardOffset, areaLightShadowCone, shadowNearPlane, shapeSize, viewportSize, normalBias, filteringQuality,
                                 out shadowRequest.view, out invViewProjection, out shadowRequest.projection, out shadowRequest.deviceProjection, out shadowRequest.deviceProjectionYFlip, out shadowRequest.splitData);
+                            shadowRequest.isOrthographic = false;
                             break;
                         case AreaLightShape.Tube:
                             //Tube do not cast shadow at the moment.

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
@@ -2227,7 +2227,6 @@ namespace UnityEngine.Rendering.HighDefinition
                         out invViewProjection, out shadowRequest.projection,
                         out shadowRequest.deviceProjection, out shadowRequest.deviceProjectionYFlip, out shadowRequest.splitData
                     );
-                    shadowRequest.isOrthographic = false;
                     break;
                 case HDLightType.Spot:
                     float spotAngleForShadows = useCustomSpotLightShadowCone ? Math.Min(customSpotLightShadowCone, visibleLight.light.spotAngle) : visibleLight.light.spotAngle;
@@ -2237,7 +2236,6 @@ namespace UnityEngine.Rendering.HighDefinition
                         out shadowRequest.view, out invViewProjection, out shadowRequest.projection,
                         out shadowRequest.deviceProjection, out shadowRequest.deviceProjectionYFlip, out shadowRequest.splitData
                     );
-                    shadowRequest.isOrthographic = (spotLightShape == SpotLightShape.Box);
                     if (CustomViewCallbackEvent != null)
                     {
                         shadowRequest.view = CustomViewCallbackEvent(visibleLight.localToWorldMatrix);
@@ -2245,7 +2243,6 @@ namespace UnityEngine.Rendering.HighDefinition
                     break;
                 case HDLightType.Directional:
                     UpdateDirectionalShadowRequest(manager, shadowSettings, visibleLight, cullResults, viewportSize, shadowIndex, lightIndex, cameraPos, shadowRequest, out invViewProjection);
-                    shadowRequest.isOrthographic = true;
                     break;
                 case HDLightType.Area:
                     switch (areaLightShape)
@@ -2255,7 +2252,6 @@ namespace UnityEngine.Rendering.HighDefinition
                             forwardOffset = GetAreaLightOffsetForShadows(shapeSize, areaLightShadowCone);
                             HDShadowUtils.ExtractRectangleAreaLightData(visibleLight, forwardOffset, areaLightShadowCone, shadowNearPlane, shapeSize, viewportSize, normalBias, filteringQuality,
                                 out shadowRequest.view, out invViewProjection, out shadowRequest.projection, out shadowRequest.deviceProjection, out shadowRequest.deviceProjectionYFlip, out shadowRequest.splitData);
-                            shadowRequest.isOrthographic = false;
                             break;
                         case AreaLightShape.Tube:
                             //Tube do not cast shadow at the moment.

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAtlas.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAtlas.cs
@@ -278,7 +278,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 passData.shadowRequests = m_ShadowRequests;
                 passData.clearMaterial = m_ClearMaterial;
                 passData.debugClearAtlas = m_LightingDebugSettings.clearShadowAtlas;
-                passData.shadowDrawSettings = new ShadowDrawingSettings(cullResults, 0, false);
+                passData.shadowDrawSettings = new ShadowDrawingSettings(cullResults, 0);
                 passData.shadowDrawSettings.useRenderingLayerMaskTest = frameSettings.IsEnabled(FrameSettingsField.LightLayers);
                 passData.isRenderingOnACache = m_IsACacheForShadows;
 
@@ -334,7 +334,6 @@ namespace UnityEngine.Rendering.HighDefinition
 
                             data.shadowDrawSettings.lightIndex = shadowRequest.lightIndex;
                             data.shadowDrawSettings.splitData = shadowRequest.splitData;
-                            data.shadowDrawSettings.isOrthographic = shadowRequest.isOrthographic;
 
                             // Setup matrices for shadow rendering:
                             Matrix4x4 view = shadowRequest.view;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAtlas.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAtlas.cs
@@ -278,7 +278,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 passData.shadowRequests = m_ShadowRequests;
                 passData.clearMaterial = m_ClearMaterial;
                 passData.debugClearAtlas = m_LightingDebugSettings.clearShadowAtlas;
-                passData.shadowDrawSettings = new ShadowDrawingSettings(cullResults, 0);
+                passData.shadowDrawSettings = new ShadowDrawingSettings(cullResults, 0, false);
                 passData.shadowDrawSettings.useRenderingLayerMaskTest = frameSettings.IsEnabled(FrameSettingsField.LightLayers);
                 passData.isRenderingOnACache = m_IsACacheForShadows;
 
@@ -334,6 +334,7 @@ namespace UnityEngine.Rendering.HighDefinition
 
                             data.shadowDrawSettings.lightIndex = shadowRequest.lightIndex;
                             data.shadowDrawSettings.splitData = shadowRequest.splitData;
+                            data.shadowDrawSettings.isOrthographic = shadowRequest.isOrthographic;
 
                             // Setup matrices for shadow rendering:
                             Matrix4x4 view = shadowRequest.view;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowManager.cs
@@ -103,7 +103,6 @@ namespace UnityEngine.Rendering.HighDefinition
         public Rect dynamicAtlasViewport;
         public Rect cachedAtlasViewport;
         public bool zClip;
-        public bool isOrthographic;
         public Vector4[] frustumPlanes;
 
         // Store the final shadow indice in the shadow data array

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowManager.cs
@@ -103,6 +103,7 @@ namespace UnityEngine.Rendering.HighDefinition
         public Rect dynamicAtlasViewport;
         public Rect cachedAtlasViewport;
         public bool zClip;
+        public bool isOrthographic;
         public Vector4[] frustumPlanes;
 
         // Store the final shadow indice in the shadow data array

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowUtils.cs
@@ -268,7 +268,9 @@ namespace UnityEngine.Rendering.HighDefinition
             deviceProj = GL.GetGPUProjectionMatrix(proj, false);
             deviceProjYFlip = GL.GetGPUProjectionMatrix(proj, true);
             InvertPerspective(ref deviceProj, ref view, out vpinverse);
-            return CoreMatrixUtils.MultiplyPerspectiveMatrix(deviceProj, view);
+            Matrix4x4 matrix = CoreMatrixUtils.MultiplyPerspectiveMatrix(deviceProj, view);
+            splitData.cullingMatrix = matrix;
+            return matrix;
         }
 
         static Matrix4x4 ExtractPointLightMatrix(VisibleLight vl, uint faceIdx, float nearPlane, float guardAngle, out Matrix4x4 view, out Matrix4x4 proj, out Matrix4x4 deviceProj, out Matrix4x4 deviceProjYFlip, out Matrix4x4 vpinverse, out Vector4 lightDir, out ShadowSplitData splitData)
@@ -307,6 +309,7 @@ namespace UnityEngine.Rendering.HighDefinition
             for (int i = 0; i < 6; i++)
                 splitData.SetCullingPlane(i, s_CachedPlanes[i]);
 
+            splitData.cullingMatrix = devProjView;
             return devProjView;
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowUtils.cs
@@ -58,6 +58,8 @@ namespace UnityEngine.Rendering.HighDefinition
                 deviceProjection = GL.GetGPUProjectionMatrix(projection, false);
                 deviceProjectionYFlip = GL.GetGPUProjectionMatrix(projection, true);
                 InvertOrthographic(ref deviceProjectionYFlip, ref view, out invViewProjection);
+                splitData.cullingMatrix = projection * view;
+                splitData.cullingNearPlane = nearPlane;
             }
         }
 
@@ -270,6 +272,7 @@ namespace UnityEngine.Rendering.HighDefinition
             InvertPerspective(ref deviceProj, ref view, out vpinverse);
             Matrix4x4 matrix = CoreMatrixUtils.MultiplyPerspectiveMatrix(deviceProj, view);
             splitData.cullingMatrix = matrix;
+            splitData.cullingNearPlane = nearPlane;
             return matrix;
         }
 
@@ -310,6 +313,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 splitData.SetCullingPlane(i, s_CachedPlanes[i]);
 
             splitData.cullingMatrix = devProjView;
+            splitData.cullingNearPlane = nearZ;
             return devProjView;
         }
 

--- a/com.unity.render-pipelines.universal/Runtime/Passes/AdditionalLightsShadowCasterPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/AdditionalLightsShadowCasterPass.cs
@@ -913,7 +913,7 @@ namespace UnityEngine.Rendering.Universal.Internal
 
                     ShadowSliceData shadowSliceData = m_AdditionalLightsShadowSlices[globalShadowSliceIndex];
 
-                    var settings = new ShadowDrawingSettings(cullResults, originalLightIndex);
+                    var settings = new ShadowDrawingSettings(cullResults, originalLightIndex, false);
                     settings.useRenderingLayerMaskTest = UniversalRenderPipeline.asset.supportsLightLayers;
                     settings.splitData = shadowSliceData.splitData;
                     Vector4 shadowBias = ShadowUtils.GetShadowBias(ref shadowLight, visibleLightIndex,

--- a/com.unity.render-pipelines.universal/Runtime/Passes/AdditionalLightsShadowCasterPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/AdditionalLightsShadowCasterPass.cs
@@ -913,7 +913,7 @@ namespace UnityEngine.Rendering.Universal.Internal
 
                     ShadowSliceData shadowSliceData = m_AdditionalLightsShadowSlices[globalShadowSliceIndex];
 
-                    var settings = new ShadowDrawingSettings(cullResults, originalLightIndex, false);
+                    var settings = new ShadowDrawingSettings(cullResults, originalLightIndex);
                     settings.useRenderingLayerMaskTest = UniversalRenderPipeline.asset.supportsLightLayers;
                     settings.splitData = shadowSliceData.splitData;
                     Vector4 shadowBias = ShadowUtils.GetShadowBias(ref shadowLight, visibleLightIndex,

--- a/com.unity.render-pipelines.universal/Runtime/Passes/MainLightShadowCasterPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/MainLightShadowCasterPass.cs
@@ -217,7 +217,7 @@ namespace UnityEngine.Rendering.Universal.Internal
             CommandBuffer cmd = CommandBufferPool.Get();
             using (new ProfilingScope(cmd, ProfilingSampler.Get(URPProfileId.MainLightShadow)))
             {
-                var settings = new ShadowDrawingSettings(cullResults, shadowLightIndex, true);
+                var settings = new ShadowDrawingSettings(cullResults, shadowLightIndex);
                 settings.useRenderingLayerMaskTest = UniversalRenderPipeline.asset.supportsLightLayers;
 
                 for (int cascadeIndex = 0; cascadeIndex < m_ShadowCasterCascadesCount; ++cascadeIndex)

--- a/com.unity.render-pipelines.universal/Runtime/Passes/MainLightShadowCasterPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/MainLightShadowCasterPass.cs
@@ -217,7 +217,7 @@ namespace UnityEngine.Rendering.Universal.Internal
             CommandBuffer cmd = CommandBufferPool.Get();
             using (new ProfilingScope(cmd, ProfilingSampler.Get(URPProfileId.MainLightShadow)))
             {
-                var settings = new ShadowDrawingSettings(cullResults, shadowLightIndex);
+                var settings = new ShadowDrawingSettings(cullResults, shadowLightIndex, true);
                 settings.useRenderingLayerMaskTest = UniversalRenderPipeline.asset.supportsLightLayers;
 
                 for (int cascadeIndex = 0; cascadeIndex < m_ShadowCasterCascadesCount; ++cascadeIndex)

--- a/com.unity.render-pipelines.universal/Runtime/ShadowUtils.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ShadowUtils.cs
@@ -149,7 +149,6 @@ namespace UnityEngine.Rendering.Universal
             }
 
             shadowMatrix = GetShadowTransform(projMatrix, viewMatrix);
-            splitData.cullingMatrix = shadowMatrix;
             return success;
         }
 

--- a/com.unity.render-pipelines.universal/Runtime/ShadowUtils.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ShadowUtils.cs
@@ -149,6 +149,7 @@ namespace UnityEngine.Rendering.Universal
             }
 
             shadowMatrix = GetShadowTransform(projMatrix, viewMatrix);
+            splitData.cullingMatrix = shadowMatrix;
             return success;
         }
 


### PR DESCRIPTION
### Purpose of this PR

This PR doesn't directly add occlusion culling for shadow maps, but it paves the way to do so. We make the following changes:

### 1. Set `ShadowSplitData.cullingMatrix` and `ShadowSplitData.cullingNearPlane`.

This only needs to be done in HDRP because unlike URP, it doesn't call the engine functions `ComputeSpotShadowMatricesAndCullingPrimitives()` or `ComputePointShadowMatricesAndCullingPrimitives()`.

---
### Testing status

I have manually tested this with the following permutations, making sure that occlusion culling buffers look correct:
```
                    | HDRP | URP |
--------------------+------+-----|
Spot light          |    x |   x | All shapes. HDRP's box shape is a special case, because it is an ortho point light. I've validated that it works.
Point light         |    x |   x |
Directional light   |    x |   x |
Area light          |    x |     | URP doesn't support real-time area lights
Perspective camera  |    x |   x |
Orthographic camera |    x |   x | HDRP doesn't support ortho cameras apparently, but occlusion culling still works fine
```

---
### Comments to reviewers
Notes for the reviewers you have assigned.
