### PR TITLE
[Backport 2022.1][1396416][1396418][1396422] Fixed Light2D Sprite Light not taking into account pivot and updates light properly when Sprite is modified

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed max light count cpu/gpu mismatch in Editor with Android target. [case 1392965](https://issuetracker.unity3d.com/product/unity/issues/guid/1392965/)
 - Fixed some rendering inconsistencies when using Decals.
 - Fixed an issue with too many variants being included in ShaderGraph shaders used in URP. [[case 1378545](https://issuetracker.unity3d.com/issues/some-lit-shaders-are-having-huge-count-of-variants-which-leads-to-project-build-prevention)]
+- Fixed Light2D Sprite Light not updating when Sprite properties are modified [case 1396416][case 1396418][case 1396422]
 
 ## [13.1.5] - 2021-12-17
 

--- a/com.unity.render-pipelines.universal/Editor/2D/Converter/ParametricToFreeformLightUpgrader.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/Converter/ParametricToFreeformLightUpgrader.cs
@@ -59,7 +59,7 @@ namespace UnityEditor.Rendering.Universal
                 }
 
                 light.shapePath = shapePath;
-                light.UpdateMesh(true);
+                light.UpdateMesh();
             }
         }
 

--- a/com.unity.render-pipelines.universal/Editor/2D/Light2DEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/Light2DEditor.cs
@@ -42,7 +42,7 @@ namespace UnityEditor.Rendering.Universal
                 for (var i = 0; i < shapeEditor.pointCount; ++i)
                     pointsProperty.GetArrayElementAtIndex(i).vector3Value = shapeEditor.GetPoint(i).position;
 
-                ((Light2D)(serializedObject.targetObject)).UpdateMesh(true);
+                ((Light2D)(serializedObject.targetObject)).UpdateMesh();
 
                 // This is untracked right now...
                 serializedObject.ApplyModifiedProperties();
@@ -815,7 +815,7 @@ namespace UnityEditor.Rendering.Universal
                     if (serializedObject.ApplyModifiedProperties())
                     {
                         if (meshChanged)
-                            lightObject.UpdateMesh(true);
+                            lightObject.UpdateMesh();
                     }
                 }
             }
@@ -824,8 +824,19 @@ namespace UnityEditor.Rendering.Universal
                 EditorGUILayout.HelpBox(Styles.renderPipelineUnassignedWarning);
 
                 if (meshChanged)
-                    lightObject.UpdateMesh(true);
+                    lightObject.UpdateMesh();
             }
+        }
+    }
+
+    internal class Light2DPostProcess : AssetPostprocessor
+    {
+        void OnPostprocessSprites(Texture2D texture, Sprite[] sprites)
+        {
+            var lights = Resources.FindObjectsOfTypeAll<Light2D>().Where(x => x.lightType == Light2D.LightType.Sprite && x.lightCookieSprite == null);
+
+            foreach (var light in lights)
+                light.MarkForUpdate();
         }
     }
 }

--- a/com.unity.render-pipelines.universal/Runtime/2D/Light2D.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Light2D.cs
@@ -185,6 +185,7 @@ namespace UnityEngine.Rendering.Universal
 
         internal bool hasCachedMesh => (vertices.Length > 1 && indices.Length > 1);
 
+        internal bool forceUpdate = false;
 
         /// <summary>
         /// The light's current type
@@ -195,7 +196,7 @@ namespace UnityEngine.Rendering.Universal
             set
             {
                 if (m_LightType != value)
-                    UpdateMesh(true);
+                    UpdateMesh();
 
                 m_LightType = value;
                 Light2DManager.ErrorIfDuplicateGlobalLight(this);
@@ -289,6 +290,10 @@ namespace UnityEngine.Rendering.Universal
         /// </summary>
         public bool renderVolumetricShadows => volumetricShadowsEnabled && shadowVolumeIntensity > 0;
 
+        internal void MarkForUpdate()
+        {
+            forceUpdate = true;
+        }
 
         internal void CacheValues()
         {
@@ -326,7 +331,7 @@ namespace UnityEngine.Rendering.Universal
             return LightUtility.GenerateSpriteMesh(this, m_LightCookieSprite);
         }
 
-        internal void UpdateMesh(bool forceUpdate)
+        internal void UpdateMesh(bool forceUpdate = false)
         {
             var shapePathHash = LightUtility.GetShapePathHash(shapePath);
             var fallOffSizeChanged = LightUtility.CheckForChange(m_ShapeLightFalloffSize, ref m_PreviousShapeLightFalloffSize);
@@ -338,8 +343,9 @@ namespace UnityEngine.Rendering.Universal
             var lightTypeChanged = LightUtility.CheckForChange(m_LightType, ref m_PreviousLightType);
             var hashChanged = fallOffSizeChanged || parametricRadiusChanged || parametricSidesChanged ||
                 parametricAngleOffsetChanged || spriteInstanceChanged || shapePathHashChanged || lightTypeChanged;
+
             // Mesh Rebuilding
-            if (hashChanged && forceUpdate)
+            if (hashChanged || forceUpdate)
             {
                 switch (m_LightType)
                 {
@@ -428,8 +434,10 @@ namespace UnityEngine.Rendering.Universal
             if (m_LightType == LightType.Global)
                 return;
 
-            UpdateMesh(true);
+            UpdateMesh(forceUpdate);
             UpdateBoundingSphere();
+
+            forceUpdate = false;
         }
 
         /// <summary>

--- a/com.unity.render-pipelines.universal/Runtime/2D/LightUtility.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/LightUtility.cs
@@ -482,7 +482,7 @@ namespace UnityEngine.Rendering.Universal
             {
                 vertices[i] = new LightMeshVertex
                 {
-                    position = new Vector3(srcVertices[i].x, srcVertices[i].y, 0) - center,
+                    position = new Vector3(srcVertices[i].x, srcVertices[i].y, 0),
                     color = color,
                     uv = srcUVs[i]
                 };


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Backport fixes
https://fogbugz.unity3d.com/f/cases/1402397/

---
### Testing status
Describe what manual/automated tests were performed for this PR

Tested on 2022.1.0b5
Same tests performed in the parent case #6788 

---
### Comments to reviewers
Notes for the reviewers you have assigned.
