### PR TITLE
[Backport 2022.1] URP 2D: Fix backbuffer in overlay cameras

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed ScreenSpaceShadows target which was not bound during draw. [case 1388353](https://issuetracker.unity3d.com/product/unity/issues/guid/1388353/)
 - Fixed an issue where the "Skip Iterations" option on Bloom could cause the effect to not run at all, which would cause flickering due to the Bloom texture being uninitialized. [case 1382991](https://issuetracker.unity3d.com/product/unity/issues/guid/1382991/)
 - Fixed camera sorting layer render target not being allocated in the 2d renderer [case 1389780](https://issuetracker.unity3d.com/issues/urp-2d-renderer-setrendertarget-function-throws-exception-after-upgrading-project-from-2021-dot-1-to-2022-dot-1)
+- Fixed rendering on overlay cameras in 2d with no post-processing [case 1387283](https://issuetracker.unity3d.com/product/unity/issues/guid/1387283)
 
 ## [13.1.6] - 2022-01-14
 

--- a/com.unity.render-pipelines.universal/Runtime/2D/Renderer2D.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Renderer2D.cs
@@ -123,15 +123,16 @@ namespace UnityEngine.Rendering.Universal
             }
             else    // Overlay camera
             {
+                cameraData.baseCamera.TryGetComponent<UniversalAdditionalCameraData>(out var baseCameraData);
+                var baseRenderer = (Renderer2D)baseCameraData.scriptableRenderer;
+
                 // These render textures are created by the base camera, but it's the responsibility of the last overlay camera's ScriptableRenderer
                 // to release the textures in its FinishRendering().
                 m_CreateColorTexture = true;
                 m_CreateDepthTexture = true;
 
-                m_ColorTextureHandle?.Release();
-                m_DepthTextureHandle?.Release();
-                m_ColorTextureHandle = RTHandles.Alloc("_CameraColorTexture", name: "_CameraColorTexture");
-                m_DepthTextureHandle = RTHandles.Alloc("_CameraDepthAttachment", name: "_CameraDepthAttachment");
+                m_ColorTextureHandle = baseRenderer.m_ColorTextureHandle;
+                m_DepthTextureHandle = baseRenderer.m_DepthTextureHandle;
 
                 colorTargetHandle = m_ColorTextureHandle;
                 depthTargetHandle = m_DepthTextureHandle;


### PR DESCRIPTION
### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR

What is happening is that prior to RTHandles, getTemporaryRT could be identified by Shader.PropertyToId(name).
However, using RTHandles, the RTID is now more complex.

This means that an overlay camera trying to get such a handle using PropertyToId will not map to the resource.
A similar issue anticipated and resolved in UniversalRenderer.

---
### Testing status

Tested the provided failing project on OSX in editor mode.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
