### PR TITLE
[backport 10.x.x] Fixing compilation issues on BuiltinGIUtilities.hlsl 

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinGIUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinGIUtilities.hlsl
@@ -61,6 +61,7 @@ void EvaluateLightmap(float3 positionRWS, float3 normalWS, float3 backNormalWS, 
 #endif
 
 #ifdef LIGHTMAP_ON
+    {
 #ifdef DIRLIGHTMAP_COMBINED
     SampleDirectionalLightmap(TEXTURE2D_LIGHTMAP_ARGS(LIGHTMAP_NAME, LIGHTMAP_SAMPLER_NAME),
             TEXTURE2D_LIGHTMAP_ARGS(LIGHTMAP_INDIRECTION_NAME, LIGHTMAP_SAMPLER_NAME),
@@ -70,9 +71,11 @@ void EvaluateLightmap(float3 positionRWS, float3 normalWS, float3 backNormalWS, 
     bakeDiffuseLighting += illuminance;
     backBakeDiffuseLighting += illuminance;
 #endif
+    }
 #endif
 
 #ifdef DYNAMICLIGHTMAP_ON
+    {
 #ifdef DIRLIGHTMAP_COMBINED
     SampleDirectionalLightmap(TEXTURE2D_ARGS(unity_DynamicLightmap, samplerunity_DynamicLightmap),
         TEXTURE2D_ARGS(unity_DynamicDirectionality, samplerunity_DynamicLightmap),
@@ -82,6 +85,7 @@ void EvaluateLightmap(float3 positionRWS, float3 normalWS, float3 backNormalWS, 
     bakeDiffuseLighting += illuminance;
     backBakeDiffuseLighting += illuminance;
 #endif
+    }
 #endif
 }
 


### PR DESCRIPTION
### Purpose of this PR

Backport of https://github.com/Unity-Technologies/Graphics/pull/6670/

Fixing compilation issues when dynamic lightmaps are on.

More info: https://unity3d.zendesk.com/agent/tickets/1133237

---
### Testing status
Testing done by partner. Info here https://unity3d.zendesk.com/agent/tickets/1133237

