### PR TITLE
Removed dublicate text in URP Template readme

### DIFF
--- a/com.unity.template-universal/Assets/Readme.asset
+++ b/com.unity.template-universal/Assets/Readme.asset
@@ -36,10 +36,6 @@ MonoBehaviour:
     linkText:
     url:
   - heading: 
-    text: 'This template contains a sample Scene that contains examples of how to configure lighting settings, Materials, Shaders, and post-processing effects in URP, several preconfigured Universal Render Pipeline Assets that let you quickly swap between graphics quality levels, and Presets that have been optimized for use with URP.'
-    linkText:
-    url:
-  - heading: 
     text: 'To read more about URP and its built-in features, see the '
     linkText: URP documentation.
     url: https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@latest/index.html

--- a/com.unity.template-universal/Packages/com.unity.template.universal/CHANGELOG.md
+++ b/com.unity.template-universal/Packages/com.unity.template.universal/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project template will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [12.4.1] - 2022-08-08
+
+### Fixed
+- Removed duplicate text in readme
+
 ## [12.4.0] - 2022-04-08
 
 ### Added

--- a/com.unity.template-universal/Packages/com.unity.template.universal/package.json
+++ b/com.unity.template-universal/Packages/com.unity.template.universal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.template.universal",
   "displayName": "Universal Render Pipeline",
-  "version": "12.4.0",
+  "version": "12.4.1",
   "type": "template",
   "unity": "2021.3",
   "host": "hub",


### PR DESCRIPTION
### Purpose of this PR
A section of the text in the readme of the URP Template was duplicated. This PR removes that duplicate section. 