### PR TITLE
Revert "[SG2] Fix exception when deleting a connected node"

### DIFF
--- a/com.unity.sg2/Editor/GraphUI/DataModel/Constants/BaseShaderGraphConstant.cs
+++ b/com.unity.sg2/Editor/GraphUI/DataModel/Constants/BaseShaderGraphConstant.cs
@@ -19,7 +19,7 @@ namespace UnityEditor.ShaderGraph.GraphUI
         protected string portName;
         GraphHandler graphHandler => graphModel.GraphHandler;
 
-        public bool IsInitialized => !string.IsNullOrEmpty(nodeName) && graphHandler != null && graphHandler.GetNode(nodeName) != null;
+        public bool IsInitialized => !string.IsNullOrEmpty(nodeName) && graphHandler != null;
         public FieldHandler GetField()
         {
             if (!IsInitialized) return null;

--- a/com.unity.sg2/Tests/GraphUI/GraphNodeTests.cs
+++ b/com.unity.sg2/Tests/GraphUI/GraphNodeTests.cs
@@ -233,30 +233,6 @@ namespace UnityEditor.ShaderGraph.GraphUI.UnitTests
         }
 
         [UnityTest]
-        public IEnumerator TestConnectedNodeCanBeDeleted()
-        {
-            yield return m_TestInteractionHelper.AddNodeFromSearcherAndValidate("Float");
-            yield return m_TestInteractionHelper.AddNodeFromSearcherAndValidate("Truncate");
-            yield return m_TestInteractionHelper.AddNodeFromSearcherAndValidate("Add");
-
-            m_TestInteractionHelper.ConnectNodes("Float", "Truncate");
-            m_TestInteractionHelper.ConnectNodes("Truncate", "Add", "Out", "B");
-
-            Assert.AreEqual(2, m_GraphView.GraphModel.EdgeModels.Count, "Initial graph should have 2 edges");
-
-            var middleNode = m_Window.GetNodeModelFromGraphByName("Truncate");
-
-            m_GraphView.Dispatch(new SelectElementsCommand(SelectElementsCommand.SelectionMode.Replace, middleNode));
-            yield return null;
-
-            m_TestEventHelper.SendDeleteCommand();
-            yield return null;
-
-            Assert.AreEqual(0, m_GraphView.GraphModel.EdgeModels.Count, "Deleting a node should delete the connected edges");
-            Assert.IsFalse(m_GraphView.GraphModel.NodeModels.Contains(middleNode), "Deleted node should be removed from the graph");
-        }
-
-        [UnityTest]
         public IEnumerator TestNodeCanBeCopied()
         {
             yield return m_TestInteractionHelper.AddNodeFromSearcherAndValidate("Add");


### PR DESCRIPTION
Reverts Unity-Technologies/Graphics#7621. This PR had the undiscovered side effect of breaking certain searcher previews. The previous branch will be restored and a better fix will be implemented there.