### PR TITLE
[SG2] Fix InvalidCastException on duplicating Sample Texture 2D node

### DIFF
--- a/com.unity.sg2/Editor/GraphUI/DataModel/Constants/BaseShaderGraphConstant.cs
+++ b/com.unity.sg2/Editor/GraphUI/DataModel/Constants/BaseShaderGraphConstant.cs
@@ -76,7 +76,7 @@ namespace UnityEditor.ShaderGraph.GraphUI
 
         public IConstant Clone()
         {
-            var copy = (GraphTypeConstant)Activator.CreateInstance(GetType());
+            var copy = (BaseShaderGraphConstant)Activator.CreateInstance(GetType());
             copy.Initialize(graphModel, nodeName, portName);
             copy.ObjectValue = GetStoredValueForCopy();
             return copy;


### PR DESCRIPTION
### Purpose of this PR

This PR fixes a bug where duplicating Sample Texture 2D (or other node with texture types) would cause an InvalidCastException.

Before:

https://user-images.githubusercontent.com/10332426/186526482-35f09903-231d-48f6-b1db-123847ebf2b1.mp4

After:

https://user-images.githubusercontent.com/10332426/186526811-3ff3d5b4-3274-42d3-8a6f-940c215d8a31.mp4

---
### Testing status

- Manual
  - Duplicated a lone Sample Texture 2D node using both Ctrl-C/V and Ctrl-D
  - Cut/pasted a lone Sample Texture 2D node (not pictured above)
  - Undid/redid the above operations
  - Repeated above tests with a node with incoming/outgoing edges:
    - ![image](https://user-images.githubusercontent.com/10332426/186528297-060f53da-927d-4bf6-9054-27bf57108674.png)
  - Covered by "Undo/Redo & Copy/Paste" section in TestRail
