### PR TITLE
[SG2] Update inspector display for property nodes

### DIFF
--- a/com.unity.sg2/Editor/GraphUI/ModelInspectorFactoryExtensions.cs
+++ b/com.unity.sg2/Editor/GraphUI/ModelInspectorFactoryExtensions.cs
@@ -45,6 +45,11 @@ namespace UnityEditor.ShaderGraph.GraphUI
             return ui;
         }
 
+        public static IModelView CreateVariableNodeInspector(this ElementBuilder elementBuilder, GraphDataVariableNodeModel model)
+        {
+            return elementBuilder.CreateVariableDeclarationInspector((GraphDataVariableDeclarationModel) model.VariableDeclarationModel);
+        }
+
         public static IModelView CreateContextSectionInspector(this ElementBuilder elementBuilder, GraphDataContextNodeModel model)
         {
             var ui = new ShaderGraphModelInspector();


### PR DESCRIPTION
### Purpose of this PR

This PR makes the inspector for property nodes display the same as it did in SG1, showing the variable settings when selected.

Before:
![image](https://user-images.githubusercontent.com/10332426/187002603-717c4440-ebb3-4d55-aef7-f5f12e94763c.png)

After:
![image](https://user-images.githubusercontent.com/10332426/187002479-7b8765cc-aae7-4f09-9c83-be77c7dd6423.png)

---
### Testing status

- Settings are shown for properties both in the blackboard and as nodes: https://qatestrail.hq.unity3d.com/index.php?/cases/view/1103440

