### PR TITLE
[SG2] Match SG1 preview zoom behavior

### DIFF
--- a/com.unity.sg2/Editor/GraphUI/EditorCommon/CommandStateObserver/PreviewCommands.cs
+++ b/com.unity.sg2/Editor/GraphUI/EditorCommon/CommandStateObserver/PreviewCommands.cs
@@ -172,6 +172,8 @@ namespace UnityEditor.ShaderGraph.GraphUI
     public class ChangePreviewZoomCommand : ICommand
     {
         public const string UserPrefsKey = "PreviewZoom";
+        const float k_ZoomMin = 0.2f;
+        const float k_ZoomMax = 5.0f;
 
         float m_NewPreviewZoom;
         public ChangePreviewZoomCommand(float newPreviewZoom)
@@ -185,7 +187,7 @@ namespace UnityEditor.ShaderGraph.GraphUI
             ChangePreviewZoomCommand command
         )
         {
-            graphModel.MainPreviewData.scale += command.m_NewPreviewZoom;
+            graphModel.MainPreviewData.scale = Mathf.Clamp(graphModel.MainPreviewData.scale + command.m_NewPreviewZoom, k_ZoomMin, k_ZoomMax);
 
             // Lets the preview manager know to re-render the main preview output
             previewUpdateDispatcher.OnMainPreviewDataChanged();

--- a/com.unity.sg2/Editor/GraphUI/GraphElements/Views/MainPreviewView.cs
+++ b/com.unity.sg2/Editor/GraphUI/GraphElements/Views/MainPreviewView.cs
@@ -177,7 +177,7 @@ namespace UnityEditor.ShaderGraph.GraphUI
 
         void OnScroll(float scrollValue)
         {
-            float rescaleAmount = scrollValue * .03f;
+            float rescaleAmount = -scrollValue * .03f;
             var changePreviewZoomCommand = new ChangePreviewZoomCommand(rescaleAmount);
             m_CommandDispatcher.Dispatch(changePreviewZoomCommand);
         }


### PR DESCRIPTION
### Purpose of this PR

Fixes GSG-1363. Scrolling up now zooms in, and scrolling down now zooms out.

Also an incidental finding: it was possible to invert the preview by zooming in too far, so I re-added the zoom limits from SG1. I can back this change out if there's a reason not to add it.

---
### Testing status

- Tested main preview and ensured that it matched the expected behavior:
  > Pushing the scroll wheel forward should move the preview mesh closer to the camera, and pulling the scroll wheel toward you should move the object away.
- Ensured that min/max zoom are consistent with SG1