### PR TITLE
[SG2] Add HDR flag to ParameterUIDescriptor

### DIFF
--- a/com.unity.sg2/Editor/GraphDeltaRegistry/FunctionDefinitions/ParameterUIDescriptor.cs
+++ b/com.unity.sg2/Editor/GraphDeltaRegistry/FunctionDefinitions/ParameterUIDescriptor.cs
@@ -12,6 +12,7 @@ namespace UnityEditor.ShaderGraph.Defs
         public string DisplayName { get; }
         public string Tooltip { get; }
         public bool UseColor { get; }
+        public bool IsHdr { get; }
         public bool UseSlider { get; }
         public bool InspectorOnly { get; }
         public readonly List<(string, object)> Options { get; }
@@ -21,6 +22,7 @@ namespace UnityEditor.ShaderGraph.Defs
             string displayName = null,
             string tooltip = "",
             bool useColor = false,
+            bool isHdr = false,
             bool useSlider = false,
             bool inspectorOnly = false,
             List<(string, object)> options = null
@@ -30,6 +32,7 @@ namespace UnityEditor.ShaderGraph.Defs
             DisplayName = displayName ?? name;
             Tooltip = tooltip;
             UseColor = useColor;
+            IsHdr = isHdr;
             UseSlider = useSlider;
             InspectorOnly = inspectorOnly;
             Options = options;

--- a/com.unity.sg2/Editor/GraphDeltaRegistry/FunctionDefinitions/StandardDefinitions/TestUINodes.cs
+++ b/com.unity.sg2/Editor/GraphDeltaRegistry/FunctionDefinitions/StandardDefinitions/TestUINodes.cs
@@ -682,6 +682,62 @@ namespace UnityEditor.ShaderGraph.Defs
         );
     }
 
+    internal class TestColorHDRNode : IStandardNode
+    {
+        public static string Name => "TestUIColorHDR";
+        public static int Version => 1;
+
+        public static FunctionDescriptor FunctionDescriptor => new(
+            "TestUIColorHDR", // Name
+            "Out = InHDR;",
+            new ParameterDescriptor[]
+            {
+                new ParameterDescriptor("In", TYPE.Vec4, GraphType.Usage.In),
+                new ParameterDescriptor("InHDR", TYPE.Vec4, GraphType.Usage.In),
+                new ParameterDescriptor("Static", TYPE.Vec4, GraphType.Usage.Static),
+                new ParameterDescriptor("StaticHDR", TYPE.Vec4, GraphType.Usage.Static),
+                new ParameterDescriptor("Out", TYPE.Vec4, GraphType.Usage.Out)
+            }
+        );
+
+        public static NodeUIDescriptor NodeUIDescriptor => new(
+            Version,
+            Name,
+            tooltip: String.Empty,
+            category: "Test",
+            synonyms: Array.Empty<string>(),
+            hasPreview: true,
+            parameters: new ParameterUIDescriptor[] {
+                new ParameterUIDescriptor(
+                    name: "In",
+                    displayName: "In",
+                    tooltip: "Default color picker",
+                    useColor: true
+                ),
+                new ParameterUIDescriptor(
+                    name: "InHDR",
+                    displayName: "InHDR",
+                    tooltip: "HDR color picker",
+                    useColor: true,
+                    isHdr: true
+                ),
+                new ParameterUIDescriptor(
+                    name: "Static",
+                    displayName: "Static",
+                    tooltip: "Default color picker",
+                    useColor: true
+                ),
+                new ParameterUIDescriptor(
+                    name: "StaticHDR",
+                    displayName: "StaticHDR",
+                    tooltip: "HDR color picker",
+                    useColor: true,
+                    isHdr: true
+                ),
+            }
+        );
+    }
+
     internal class TestUISliderNode : IStandardNode
     {
         public static string Name => "TestUISlider";

--- a/com.unity.sg2/Editor/GraphUI/ConstantEditorFactoryExtensions.cs
+++ b/com.unity.sg2/Editor/GraphUI/ConstantEditorFactoryExtensions.cs
@@ -49,7 +49,7 @@ namespace UnityEditor.ShaderGraph.GraphUI
 
                     if (length >= GraphType.Length.Three && parameterUIDescriptor.UseColor)
                     {
-                        return BuildColorConstantEditor(builder, constant, "", builder.Label, parameterUIDescriptor.Tooltip);
+                        return BuildColorConstantEditor(builder, constant, "", builder.Label, parameterUIDescriptor.Tooltip, parameterUIDescriptor.IsHdr);
                     }
 
                     break;

--- a/com.unity.sg2/Editor/GraphUI/GraphElements/ModelUI/GraphDataNode.cs
+++ b/com.unity.sg2/Editor/GraphUI/GraphElements/ModelUI/GraphDataNode.cs
@@ -246,7 +246,8 @@ namespace UnityEditor.ShaderGraph.GraphUI
                             this,
                             ussClassName,
                             portHandler.LocalID,
-                            includeAlpha: false);
+                            includeAlpha: false,
+                            isHdr: parameterUIDescriptor.IsHdr);
                     }
                     else
                     {
@@ -266,7 +267,8 @@ namespace UnityEditor.ShaderGraph.GraphUI
                             this,
                             ussClassName,
                             portHandler.LocalID,
-                            includeAlpha: true);
+                            includeAlpha: true,
+                            isHdr: parameterUIDescriptor.IsHdr);
                     }
                     else
                     {

--- a/com.unity.sg2/Editor/GraphUI/GraphElements/ModelUI/StaticPortParts/ColorPart.cs
+++ b/com.unity.sg2/Editor/GraphUI/GraphElements/ModelUI/StaticPortParts/ColorPart.cs
@@ -12,20 +12,23 @@ namespace UnityEditor.ShaderGraph.GraphUI
         protected override string FieldName => "sg-color-field";
 
         bool m_IncludeAlpha;
+        bool m_IsHdr;
 
         int length =>
             m_IncludeAlpha ? 4 : 3;
 
-        public ColorPart(string name, IGraphElementModel model, IModelView ownerElement, string parentClassName, string portName, bool includeAlpha)
+        public ColorPart(string name, IGraphElementModel model, IModelView ownerElement, string parentClassName, string portName, bool includeAlpha, bool isHdr = false)
             : base(name, model, ownerElement, parentClassName, portName)
         {
             m_IncludeAlpha = includeAlpha;
+            m_IsHdr = isHdr;
         }
 
         protected override void BuildPartUI(VisualElement parent)
         {
             base.BuildPartUI(parent);
             m_Field.showAlpha = m_IncludeAlpha;
+            m_Field.hdr = m_IsHdr;
             m_Field.AddStylesheet("StaticPortParts/ColorPart.uss");
         }
 


### PR DESCRIPTION
### Purpose of this PR

This PR adds a flag `isHdr` to ParameterUIDescriptor. This will let us implement a color node with HDR support.

![image](https://user-images.githubusercontent.com/10332426/192041559-c0ce83ba-255f-4933-af7f-b87675bf3057.png)

(A bit hard to see because the port color pickers have broken styling, but InHDR does bring up an HDR color picker.)

There is a usage example, `TestColorHDRNode`, in `TestUINodes.cs`. This node uses the value of InHDR as its output. (To be able to add it to the graph, remove "Test" from the disabled categories list around line 728 of ShaderGraphModel.cs. The test nodes are still hidden from SME testing.)

---
### Testing status

- Added test node: Test UI Color HDR
- Verified that HDR color pickers show when useColor is true and isHdr is true
- Verified that HDR value is piped through to node by changing the intensity of the InHDR inline editor and observing the preview

