### PR TITLE
[SG2] Add description field for nodes

### DIFF
--- a/com.unity.sg2/Editor/GraphDeltaRegistry/FunctionDefinitions/NodeUIDescriptor.cs
+++ b/com.unity.sg2/Editor/GraphDeltaRegistry/FunctionDefinitions/NodeUIDescriptor.cs
@@ -21,6 +21,7 @@ namespace UnityEditor.ShaderGraph.Defs
         public IReadOnlyCollection<string> Synonyms { get; }
         public string Category { get; }
         public string FunctionSelectorLabel { get; }
+        public string Description { get; }
 
         public NodeUIDescriptor(
             int version,
@@ -32,7 +33,8 @@ namespace UnityEditor.ShaderGraph.Defs
             bool hasPreview = true, // By default we assume all nodes should have previews,
             Dictionary<string, string> selectableFunctions = null,
             ParameterUIDescriptor[] parameters = null,
-            string functionSelectorLabel = ""
+            string functionSelectorLabel = "",
+            string description = null
         )
         {
             Version = version;
@@ -47,6 +49,7 @@ namespace UnityEditor.ShaderGraph.Defs
             var parametersList = parameters ?? new ParameterUIDescriptor[0];
             Parameters = parametersList.ToList().AsReadOnly();
             FunctionSelectorLabel = functionSelectorLabel;
+            Description = description;
         }
 
         public ParameterUIDescriptor GetParameterInfo(string parameterName)

--- a/com.unity.sg2/Editor/GraphDeltaRegistry/FunctionDefinitions/StandardDefinitions/TestUINodes.cs
+++ b/com.unity.sg2/Editor/GraphDeltaRegistry/FunctionDefinitions/StandardDefinitions/TestUINodes.cs
@@ -460,7 +460,8 @@ namespace UnityEditor.ShaderGraph.Defs
             tooltip: String.Empty,
             category: "Test",
             synonyms: Array.Empty<string>(),
-            hasPreview: true
+            hasPreview: true,
+            description: "Demonstrates the Float input on a node."
         );
     }
 

--- a/com.unity.sg2/Editor/GraphUI/DataModel/Searcher/ShaderGraphSearcherDatabaseProvider.cs
+++ b/com.unity.sg2/Editor/GraphUI/DataModel/Searcher/ShaderGraphSearcherDatabaseProvider.cs
@@ -91,7 +91,8 @@ namespace UnityEditor.ShaderGraph.GraphUI
                         )
                         {
                             CategoryPath = uiInfo.Category,
-                            Synonyms = uiInfo.Synonyms.ToArray()
+                            Synonyms = uiInfo.Synonyms.ToArray(),
+                            Help = uiInfo.Description,
                         };
                         namesAddedToSearcher.Add(searcherItemName);
                         searcherItems.Add(searcherItem);

--- a/com.unity.sg2/Editor/GraphUI/DataModel/ShaderGraphModel.cs
+++ b/com.unity.sg2/Editor/GraphUI/DataModel/ShaderGraphModel.cs
@@ -130,7 +130,7 @@ namespace UnityEditor.ShaderGraph.GraphUI
         internal string DefaultContextName => Registry.ResolveKey<ShaderGraphContext>().Name;
 
         [NonSerialized]
-        Dictionary<RegistryKey, SGNodeUIData> m_NodeUIData;
+        Dictionary<RegistryKey, SGNodeUIData> m_NodeUIData = new();
 
         [NonSerialized]
         GraphDataContextNodeModel m_DefaultContextNode;


### PR DESCRIPTION
### Purpose of this PR

This PR allows Item Library descriptions for nodes to be set through node UI descriptors. There's no tie-in with docs here, so this is really just enabling us to show descriptions.

![Unity_vv5tKckfXg](https://user-images.githubusercontent.com/10332426/197890137-edbf4e41-1245-4ebc-8912-339c4d08d6f3.png)

---
### Testing status

- Ensured that when a node has a description, the description is shown in the searcher (can use Test UI Float for this).
- Ensured that when a node doesn't have a description, no description is shown and there are no errors.

---
### Comments to reviewers

To enable test nodes, comment out "Test" and "Tests" around line 726 of ShaderGraphModel.cs.
