### PR TITLE
[SG2] Fix System.InvalidOperationException log spam

### DIFF
--- a/com.unity.sg2/Editor/GraphUI/DataModel/SGNodeModel.cs
+++ b/com.unity.sg2/Editor/GraphUI/DataModel/SGNodeModel.cs
@@ -146,18 +146,22 @@ namespace UnityEditor.ShaderGraph.GraphUI
         {
             get
             {
-                try
+                var latest = 0;
+
+                foreach (var key in graphHandler.registry.BrowseRegistryKeys())
                 {
-                    return graphHandler.registry.BrowseRegistryKeys()
-                        .Where(otherKey => otherKey.Name == registryKey.Name)
-                        .Select(otherKey => otherKey.Version)
-                        .Max();
+                    if (key.Name != registryKey.Name)
+                    {
+                        continue;
+                    }
+
+                    if (key.Version > latest)
+                    {
+                        latest = key.Version;
+                    }
                 }
-                catch (Exception e)
-                {
-                    Debug.Log(e + " thrown while trying to retrieve latestAvailableVersion");
-                    return -1;
-                }
+
+                return latest;
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR

This PR fixes the `System.InvalidOperationException` that starts appearing after pasting a node and then moving it.

Before:

https://user-images.githubusercontent.com/10332426/208508831-0f61d511-784c-47b6-9b72-ef258af36866.mp4

After:

https://user-images.githubusercontent.com/10332426/208508850-c62c1250-5877-49f4-9210-e961f30bbe41.mp4

---
### Testing status

- Manually tested using following steps: create node, move it, cut/paste, move again. Expect no errors, but previously the above InvalidOperationException would show (see videos above.)
- Also tested using a versioned node to ensure that upgrade behavior wasn't affected (color v0 in video above.)

