### PR TITLE
[SG2] Make multiply "B" input default to 2

### DIFF
--- a/com.unity.sg2/Editor/GraphDeltaRegistry/Registry/MultiplyNode.cs
+++ b/com.unity.sg2/Editor/GraphDeltaRegistry/Registry/MultiplyNode.cs
@@ -47,7 +47,7 @@ namespace UnityEditor.ShaderGraph.GraphDelta
         void INodeDefinitionBuilder.BuildNode(NodeHandler node, Registry registry)
         {
             node.AddPort<GraphType>(kInputA, true, registry);
-            node.AddPort<GraphType>(kInputB, true, registry);
+            var inputB = node.AddPort<GraphType>(kInputB, true, registry);
             node.AddPort<GraphType>(kOutput, false, registry);
 
             // initialize all of our ports to be fully dynamic, so they can get resolved by their input connections.
@@ -62,6 +62,7 @@ namespace UnityEditor.ShaderGraph.GraphDelta
                     precisionDynamic: true);
             }
 
+            GraphTypeHelpers.SetComponents(inputB.GetTypeField(), 0, 2.0f, 2.0f, 2.0f, 2.0f);
             GraphTypeHelpers.ResolveDynamicPorts(node);
         }
 


### PR DESCRIPTION
### Purpose of this PR

This PR changes the default "B" value of the multiply node to 2 for every component, as in SG1.

![image](https://user-images.githubusercontent.com/10332426/210647341-e8922f2e-762f-4667-af34-ebc97094de2f.png)

---
### Testing status

- Manual, see screenshot for tested cases.
