### PR TITLE
Custom AO changes for MV3

### DIFF
--- a/com.unity.postprocessing/PostProcessing/Editor/Effects/AmbientOcclusionEditor.cs
+++ b/com.unity.postprocessing/PostProcessing/Editor/Effects/AmbientOcclusionEditor.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.Rendering.PostProcessing
         SerializedParameterOverride m_Mode;
         SerializedParameterOverride m_Intensity;
         SerializedParameterOverride m_Color;
+        SerializedParameterOverride m_RenderBeforeOpaqueOnly;
         SerializedParameterOverride m_AmbientOnly;
         SerializedParameterOverride m_ThicknessModifier;
         SerializedParameterOverride m_DirectLightingStrength;
@@ -20,6 +21,7 @@ namespace UnityEditor.Rendering.PostProcessing
             m_Mode = FindParameterOverride(x => x.mode);
             m_Intensity = FindParameterOverride(x => x.intensity);
             m_Color = FindParameterOverride(x => x.color);
+            m_RenderBeforeOpaqueOnly = FindParameterOverride(x => x.renderBeforeOpaqueOnly);
             m_AmbientOnly = FindParameterOverride(x => x.ambientOnly);
             m_ThicknessModifier = FindParameterOverride(x => x.thicknessModifier);
             m_DirectLightingStrength = FindParameterOverride(x => x.directLightingStrength);
@@ -57,6 +59,7 @@ namespace UnityEditor.Rendering.PostProcessing
             }
 
             PropertyField(m_Color);
+            PropertyField(m_RenderBeforeOpaqueOnly);
             PropertyField(m_AmbientOnly);
 
             if (m_AmbientOnly.overrideState.boolValue && m_AmbientOnly.value.boolValue && !RuntimeUtilities.scriptableRenderPipelineActive)

--- a/com.unity.postprocessing/PostProcessing/Runtime/Effects/AmbientOcclusion.cs
+++ b/com.unity.postprocessing/PostProcessing/Runtime/Effects/AmbientOcclusion.cs
@@ -202,6 +202,7 @@ namespace UnityEngine.Rendering.PostProcessing
     internal interface IAmbientOcclusionMethod
     {
         DepthTextureMode GetCameraFlags();
+        RenderTexture GetResultTexture();
         void RenderAfterOpaque(PostProcessRenderContext context);
         void RenderAmbientOnly(PostProcessRenderContext context);
         void CompositeAmbientOnly(PostProcessRenderContext context);

--- a/com.unity.postprocessing/PostProcessing/Runtime/Effects/AmbientOcclusion.cs
+++ b/com.unity.postprocessing/PostProcessing/Runtime/Effects/AmbientOcclusion.cs
@@ -93,6 +93,14 @@ namespace UnityEngine.Rendering.PostProcessing
         public ColorParameter color = new ColorParameter { value = Color.black };
 
         /// <summary>
+        /// Ambient occlusion is rendered before the forward opaque pass. This allows for shaders in forward rendering to
+        /// sample ambient occlusion and decide how it interacts with fog and other custom effects.
+        /// Compositing is bypassed, each shader needs to explicitly sample the global ambient occlusion texture (_AmbientOcclusionTexture).
+        /// </summary>
+        [Tooltip("Check this box to render ambient occlusion before the forward opaque pass.\n\nThis allows for shaders in forward rendering to sample ambient occlusion and decide how it interacts with fog and other custom effects.\n\nCompositing is bypassed, each shader needs to explicitly sample the ambient occlusion texture (_AmbientOcclusionTexture).")]
+        public BoolParameter renderBeforeOpaqueOnly = new BoolParameter { value = false };
+
+        /// <summary>
         /// Only affects ambient lighting. This mode is only available with the Deferred rendering
         /// path and HDR rendering. Objects rendered with the Forward rendering path won't get any
         /// ambient occlusion.
@@ -224,6 +232,13 @@ namespace UnityEngine.Rendering.PostProcessing
                     new MultiScaleVO(settings),
                 };
             }
+        }
+
+        public bool IsRenderBeforeForwardOpaqueOnly(PostProcessRenderContext context)
+        {
+            var camera = context.camera;
+            return settings.renderBeforeOpaqueOnly.value
+                   && camera.actualRenderingPath == RenderingPath.Forward;
         }
 
         public bool IsAmbientOnly(PostProcessRenderContext context)

--- a/com.unity.postprocessing/PostProcessing/Runtime/Effects/MultiScaleVO.cs
+++ b/com.unity.postprocessing/PostProcessing/Runtime/Effects/MultiScaleVO.cs
@@ -64,6 +64,11 @@ namespace UnityEngine.Rendering.PostProcessing
             m_Settings = settings;
         }
 
+        public RenderTexture GetResultTexture()
+        {
+            return m_AmbientOnlyAO;
+        }
+
         public DepthTextureMode GetCameraFlags()
         {
             return DepthTextureMode.Depth;

--- a/com.unity.postprocessing/PostProcessing/Runtime/Effects/MultiScaleVO.cs
+++ b/com.unity.postprocessing/PostProcessing/Runtime/Effects/MultiScaleVO.cs
@@ -215,10 +215,11 @@ namespace UnityEngine.Rendering.PostProcessing
             PushDownsampleCommands(cmd, camera, depthMap, isMSAA);
 
             float tanHalfFovH = CalculateTanHalfFovHeight(camera);
-            PushRenderCommands(cmd, ShaderIDs.TiledDepth1, ShaderIDs.Occlusion1, GetSizeArray(MipLevel.L3), tanHalfFovH, isMSAA);
-            PushRenderCommands(cmd, ShaderIDs.TiledDepth2, ShaderIDs.Occlusion2, GetSizeArray(MipLevel.L4), tanHalfFovH, isMSAA);
-            PushRenderCommands(cmd, ShaderIDs.TiledDepth3, ShaderIDs.Occlusion3, GetSizeArray(MipLevel.L5), tanHalfFovH, isMSAA);
-            PushRenderCommands(cmd, ShaderIDs.TiledDepth4, ShaderIDs.Occlusion4, GetSizeArray(MipLevel.L6), tanHalfFovH, isMSAA);
+            bool isOrtho = camera.orthographic;
+            PushRenderCommands(cmd, ShaderIDs.TiledDepth1, ShaderIDs.Occlusion1, GetSizeArray(MipLevel.L3), tanHalfFovH, isMSAA, isOrtho);
+            PushRenderCommands(cmd, ShaderIDs.TiledDepth2, ShaderIDs.Occlusion2, GetSizeArray(MipLevel.L4), tanHalfFovH, isMSAA, isOrtho);
+            PushRenderCommands(cmd, ShaderIDs.TiledDepth3, ShaderIDs.Occlusion3, GetSizeArray(MipLevel.L5), tanHalfFovH, isMSAA, isOrtho);
+            PushRenderCommands(cmd, ShaderIDs.TiledDepth4, ShaderIDs.Occlusion4, GetSizeArray(MipLevel.L6), tanHalfFovH, isMSAA, isOrtho);
 
             PushUpsampleCommands(cmd, ShaderIDs.LowDepth4, ShaderIDs.Occlusion4, ShaderIDs.LowDepth3, ShaderIDs.Occlusion3, ShaderIDs.Combined3, GetSize(MipLevel.L4), GetSize(MipLevel.L3), isMSAA);
             PushUpsampleCommands(cmd, ShaderIDs.LowDepth3, ShaderIDs.Combined3, ShaderIDs.LowDepth2, ShaderIDs.Occlusion2, ShaderIDs.Combined2, GetSize(MipLevel.L3), GetSize(MipLevel.L2), isMSAA);
@@ -337,7 +338,7 @@ namespace UnityEngine.Rendering.PostProcessing
             cmd.DispatchCompute(cs, kernel, m_ScaledWidths[(int)MipLevel.L6], m_ScaledHeights[(int)MipLevel.L6], 1);
         }
 
-        void PushRenderCommands(CommandBuffer cmd, int source, int destination, Vector3 sourceSize, float tanHalfFovH, bool isMSAA)
+        void PushRenderCommands(CommandBuffer cmd, int source, int destination, Vector3 sourceSize, float tanHalfFovH, bool isMSAA, bool isOrtho)
         {
             // Here we compute multipliers that convert the center depth value into (the reciprocal
             // of) sphere thicknesses at each sample location. This assumes a maximum sample radius
@@ -355,7 +356,9 @@ namespace UnityEngine.Rendering.PostProcessing
             // TanHalfFovH: Radius of sphere in depth units if its center lies at Z = 1
             // ScreenspaceDiameter: Diameter of sample sphere in pixel units
             // ScreenspaceDiameter / BufferWidth: Ratio of the screen width that the sphere actually covers
-            float thicknessMultiplier = 2f * tanHalfFovH * kScreenspaceDiameter / sourceSize.x;
+            float thicknessMultiplier = isOrtho
+                ? kScreenspaceDiameter / sourceSize.x
+                : 2f * tanHalfFovH * kScreenspaceDiameter / sourceSize.x;
             if (RuntimeUtilities.isSinglePassStereoEnabled)
                 thicknessMultiplier *= 2f;
 

--- a/com.unity.postprocessing/PostProcessing/Runtime/Effects/ScalableAO.cs
+++ b/com.unity.postprocessing/PostProcessing/Runtime/Effects/ScalableAO.cs
@@ -36,6 +36,11 @@ namespace UnityEngine.Rendering.PostProcessing
             m_Settings = settings;
         }
 
+        public RenderTexture GetResultTexture()
+        {
+            return m_Result;
+        }
+
         public DepthTextureMode GetCameraFlags()
         {
             return DepthTextureMode.Depth | DepthTextureMode.DepthNormals;

--- a/com.unity.postprocessing/PostProcessing/Runtime/Utils/ShaderIDs.cs
+++ b/com.unity.postprocessing/PostProcessing/Runtime/Utils/ShaderIDs.cs
@@ -17,6 +17,7 @@ namespace UnityEngine.Rendering.PostProcessing
 
         internal static readonly int AOParams = Shader.PropertyToID("_AOParams");
         internal static readonly int AOColor = Shader.PropertyToID("_AOColor");
+        internal static readonly int AmbientOcclusionTexture = Shader.PropertyToID("_AmbientOcclusionTexture");
         internal static readonly int OcclusionTexture1 = Shader.PropertyToID("_OcclusionTexture1");
         internal static readonly int OcclusionTexture2 = Shader.PropertyToID("_OcclusionTexture2");
         internal static readonly int SAOcclusionTexture = Shader.PropertyToID("_SAOcclusionTexture");

--- a/com.unity.postprocessing/PostProcessing/Shaders/Builtins/MultiScaleVODownsample1.compute
+++ b/com.unity.postprocessing/PostProcessing/Shaders/Builtins/MultiScaleVODownsample1.compute
@@ -56,8 +56,18 @@ groupshared float g_CacheW[256];
 #endif
 
 CBUFFER_START(CB0)
-    float4 ZBufferParams;
+    float4 ProjectionParams;    // x: 1 (-1 flipped), y: near,     z: far,       w: 1/far
+    float4 OrthoParams;         // x: width,          y: height,   z: unused,    w: ortho ? 1 : 0
+    float4 ZBufferParams;       // x: 1-far/near,     y: far/near, z: x/far,     w: y/far
 CBUFFER_END
+
+float Linear01DepthFromCamera(float depth)
+{
+    float isOrtho = OrthoParams.w;
+    float linear01FromCameraPersp = 1.0 / (ZBufferParams.x * depth + ZBufferParams.y);
+    float linear01FromCameraOrtho = ((ProjectionParams.z - ProjectionParams.y) * (1.0 - depth) + ProjectionParams.y) / ProjectionParams.z;
+    return lerp(linear01FromCameraPersp, linear01FromCameraOrtho, isOrtho);
+}
 
 #ifdef MSAA
 float2 Linearize(uint2 st)
@@ -81,7 +91,8 @@ float2 Linearize(uint2 st)
 float Linearize(uint2 st)
 {
     float depth = Depth[st];
-    float dist = 1.0 / (ZBufferParams.x * depth + ZBufferParams.y);
+
+    float dist = Linear01DepthFromCamera(depth);
 #ifdef UNITY_REVERSED_Z
     if (depth == 0) dist = 1e5;
 #else


### PR DESCRIPTION
Custom modifications:
- make the Multi-Scale Volumetric Obscurance technique work with an orthographic camera
- make it possible for AO to be rendered before the rest of the frame which allows for: