### PR TITLE
[2022.3] Fix MSAA CameraDepthTexture scaling issues by replacing UV s…

### DIFF
--- a/Packages/com.unity.render-pipelines.universal/Shaders/Utils/CopyDepthPass.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/Utils/CopyDepthPass.hlsl
@@ -17,21 +17,19 @@
 #if defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)
 #define DEPTH_TEXTURE_MS(name, samples) Texture2DMSArray<float, samples> name
 #define DEPTH_TEXTURE(name) TEXTURE2D_ARRAY_FLOAT(name)
-#define LOAD(uv, sampleIndex) LOAD_TEXTURE2D_ARRAY_MSAA(_CameraDepthAttachment, uv, unity_StereoEyeIndex, sampleIndex)
-#define SAMPLE(uv) SAMPLE_TEXTURE2D_ARRAY(_CameraDepthAttachment, sampler_CameraDepthAttachment, uv, unity_StereoEyeIndex).r
+#define LOAD_MSAA(coord, sampleIndex) LOAD_TEXTURE2D_ARRAY_MSAA(_CameraDepthAttachment, coord, unity_StereoEyeIndex, sampleIndex) 
+#define LOAD(coord) LOAD_TEXTURE2D_ARRAY(_CameraDepthAttachment, coord, unity_StereoEyeIndex) 
 #else
 #define DEPTH_TEXTURE_MS(name, samples) Texture2DMS<float, samples> name
 #define DEPTH_TEXTURE(name) TEXTURE2D_FLOAT(name)
-#define LOAD(uv, sampleIndex) LOAD_TEXTURE2D_MSAA(_CameraDepthAttachment, uv, sampleIndex)
-#define SAMPLE(uv) SAMPLE_DEPTH_TEXTURE(_CameraDepthAttachment, sampler_CameraDepthAttachment, uv)
+#define LOAD_MSAA(coord, sampleIndex) LOAD_TEXTURE2D_MSAA(_CameraDepthAttachment, coord, sampleIndex) 
+#define LOAD(coord) LOAD_TEXTURE2D(_CameraDepthAttachment, coord) 
 #endif
 
 #if MSAA_SAMPLES == 1
     DEPTH_TEXTURE(_CameraDepthAttachment);
-    SAMPLER(sampler_CameraDepthAttachment);
 #else
     DEPTH_TEXTURE_MS(_CameraDepthAttachment, MSAA_SAMPLES);
-    float4 _CameraDepthAttachment_TexelSize;
 #endif
 
 #if UNITY_REVERSED_Z
@@ -42,17 +40,17 @@
     #define DEPTH_OP max
 #endif
 
-float SampleDepth(float2 uv)
+float SampleDepth(float2 pixelCoords) 
 {
+    int2 coord = int2(pixelCoords); 
 #if MSAA_SAMPLES == 1
-    return SAMPLE(uv);
+    return LOAD(coord).r;
 #else
-    int2 coord = int2(uv * _CameraDepthAttachment_TexelSize.zw);
     float outDepth = DEPTH_DEFAULT_VALUE;
 
     UNITY_UNROLL
     for (int i = 0; i < MSAA_SAMPLES; ++i)
-        outDepth = DEPTH_OP(LOAD(coord, i), outDepth);
+        outDepth = DEPTH_OP(LOAD_MSAA(coord, i), outDepth); 
     return outDepth;
 #endif
 }
@@ -64,7 +62,7 @@ float frag(Varyings input) : SV_Target
 #endif
 {
     UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
-    return SampleDepth(input.texcoord);
+    return SampleDepth(input.positionCS.xy);
 }
 
 #endif


### PR DESCRIPTION
…ampling with screen-space texture loading and Shader truncation warning in CopyDepthPass

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

---
### Testing status
Describe what manual/automated tests were performed for this PR

---
### Comments to reviewers
Notes for the reviewers you have assigned.
