### PR TITLE
Use internal registry for com.unity.testframework.graphics in PostPro…

### DIFF
--- a/TestProjects/PostProcessing_Tests/Packages/manifest.json
+++ b/TestProjects/PostProcessing_Tests/Packages/manifest.json
@@ -1,9 +1,19 @@
 {
+  "enableLockFile": false,
+  "scopedRegistries": [
+    {
+      "name": "Unity Internal",
+      "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates",
+      "scopes": [
+        "com.unity.testframework.graphics"
+      ]
+    }
+  ],
   "dependencies": {
     "com.unity.ide.visualstudio": "2.0.25",
     "com.unity.postprocessing": "file:../../../com.unity.postprocessing",
     "com.unity.test-framework": "2.0.1-exp.2",
-    "com.unity.testframework.graphics": "9.0.0-pre.8",
+    "com.unity.testframework.graphics": "9.0.0-pre.12",
     "com.unity.external.test-protocol": "2.0.0-exp.2",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",

--- a/TestProjects/PostProcessing_Tests/ProjectSettings/PackageManagerSettings.asset
+++ b/TestProjects/PostProcessing_Tests/ProjectSettings/PackageManagerSettings.asset
@@ -20,11 +20,18 @@ MonoBehaviour:
   oneTimeWarningShown: 0
   m_Registries:
   - m_Id: main
-    m_Name: 
+    m_Name:
     m_Url: https://packages.unity.com
     m_Scopes: []
     m_IsDefault: 1
     m_Capabilities: 7
+  - m_Id: scoped:https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates
+    m_Name: Unity Internal
+    m_Url: https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates
+    m_Scopes:
+    - com.unity.testframework.graphics
+    m_IsDefault: 0
+    m_Capabilities: 0
   m_UserSelectedRegistryName: 
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:


### PR DESCRIPTION
…cessing tests

Bump com.unity.testframework.graphics to 9.0.0-pre.12 via Unity's internal artifactory registry (scoped to that package only) to pick up D3D12Validation fixes not yet available on the public UPM registry.

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

---
### Testing status
Describe what manual/automated tests were performed for this PR

---
### Comments to reviewers
Notes for the reviewers you have assigned.
